### PR TITLE
142 functionally create and delete persons in a world unit by checking when giftunits are saved

### DIFF
--- a/src/agenda/agenda.py
+++ b/src/agenda/agenda.py
@@ -1116,7 +1116,7 @@ class AgendaUnit:
         bundling: bool = True,
         create_missing_ancestors: bool = True,
     ):
-        if RoadNode(idea_kid._label).is_node(self._road_delimiter) == False:
+        if RoadNode(idea_kid._label).is_node(self._road_delimiter) is False:
             raise InvalidAgendaException(
                 f"add_idea failed because '{idea_kid._label}' is not a RoadNode."
             )

--- a/src/listen/special_func.py
+++ b/src/listen/special_func.py
@@ -20,7 +20,7 @@ def create_pledge(
             x_agenda.add_partyunit(x_suffgroup)
 
         if reason_premise != None:
-            if x_agenda.idea_exists(reason_premise) == False:
+            if x_agenda.idea_exists(reason_premise) is False:
                 x_agenda.get_idea_obj(reason_premise, if_missing_create=True)
             reason_base = get_parent_road(reason_premise)
             x_agenda.edit_reason(pledge_road, reason_base, reason_premise)
@@ -35,6 +35,23 @@ def add_duty_pledge(
     duty_agenda = x_userhub.get_duty_agenda()
     old_duty_agenda = copy_deepcopy(duty_agenda)
     create_pledge(duty_agenda, pledge_road, x_suffgroup, reason_premise)
+    next_atomunit = x_userhub._default_atomunit()
+    next_atomunit._nucunit.add_all_different_quarkunits(old_duty_agenda, duty_agenda)
+    next_atomunit.save_files()
+    x_userhub.append_atoms_to_duty_file()
+
+
+def create_belief(x_agenda: AgendaUnit, belief_pick: RoadUnit):
+    if x_agenda.idea_exists(belief_pick) is False:
+        x_agenda.get_idea_obj(belief_pick, if_missing_create=True)
+    belief_base = get_parent_road(belief_pick)
+    x_agenda.set_belief(belief_base, belief_pick)
+
+
+def add_duty_belief(x_userhub: UserHub, belief_pick: RoadUnit):
+    duty_agenda = x_userhub.get_duty_agenda()
+    old_duty_agenda = copy_deepcopy(duty_agenda)
+    create_belief(duty_agenda, belief_pick)
     next_atomunit = x_userhub._default_atomunit()
     next_atomunit._nucunit.add_all_different_quarkunits(old_duty_agenda, duty_agenda)
     next_atomunit.save_files()

--- a/src/listen/special_func.py
+++ b/src/listen/special_func.py
@@ -1,4 +1,4 @@
-from src._road.road import RoadUnit, get_terminus_node
+from src._road.road import RoadUnit, get_terminus_node, get_parent_road
 from src.agenda.group import GroupID
 from src.agenda.agenda import AgendaUnit
 from src.listen.userhub import UserHub
@@ -6,7 +6,10 @@ from copy import deepcopy as copy_deepcopy
 
 
 def create_pledge(
-    x_agenda: AgendaUnit, pledge_road: RoadUnit, x_suffgroup: GroupID = None
+    x_agenda: AgendaUnit,
+    pledge_road: RoadUnit,
+    x_suffgroup: GroupID = None,
+    reason_premise: RoadUnit = None,
 ):
     if pledge_road is not None and get_terminus_node(pledge_road) != "":
         x_idea = x_agenda.get_idea_obj(pledge_road, if_missing_create=True)
@@ -16,13 +19,22 @@ def create_pledge(
         if x_agenda.get_groupunit(x_suffgroup) is None:
             x_agenda.add_partyunit(x_suffgroup)
 
+        if reason_premise != None:
+            if x_agenda.idea_exists(reason_premise) == False:
+                x_agenda.get_idea_obj(reason_premise, if_missing_create=True)
+            reason_base = get_parent_road(reason_premise)
+            x_agenda.edit_reason(pledge_road, reason_base, reason_premise)
+
 
 def add_duty_pledge(
-    x_userhub: UserHub, pledge_road: RoadUnit, x_suffgroup: GroupID = None
+    x_userhub: UserHub,
+    pledge_road: RoadUnit,
+    x_suffgroup: GroupID = None,
+    reason_premise: RoadUnit = None,
 ):
     duty_agenda = x_userhub.get_duty_agenda()
     old_duty_agenda = copy_deepcopy(duty_agenda)
-    create_pledge(duty_agenda, pledge_road, x_suffgroup)
+    create_pledge(duty_agenda, pledge_road, x_suffgroup, reason_premise)
     next_atomunit = x_userhub._default_atomunit()
     next_atomunit._nucunit.add_all_different_quarkunits(old_duty_agenda, duty_agenda)
     next_atomunit.save_files()

--- a/src/listen/test_special_func/test_add_pledge.py
+++ b/src/listen/test_special_func/test_add_pledge.py
@@ -50,3 +50,29 @@ def test_add_duty_pledge_SetsDutyAgendapledgeIdea_suffgroup(env_dir_setup_cleanu
     clean_idea = new_sue_duty.get_idea_obj(clean_road)
     print(f"{clean_idea._assignedunit._suffgroups=}")
     assert clean_idea._assignedunit.suffgroup_exists(bob_text)
+
+
+def test_add_duty_pledge_CanAdd_reasonunit(env_dir_setup_cleanup):
+    # GIVEN
+    sue_text = "Sue"
+    sue_userhub = userhub_shop(env_dir(), root_label(), sue_text)
+    sue_userhub.initialize_atom_duty_files()
+    old_sue_duty = sue_userhub.get_duty_agenda()
+    clean_text = "clean"
+    clean_road = old_sue_duty.make_l1_road(clean_text)
+    house_estimation_text = "house_estimation"
+    house_estimation_road = old_sue_duty.make_l1_road(house_estimation_text)
+    dirty_text = "dirty"
+    dirty_road = old_sue_duty.make_road(house_estimation_road, dirty_text)
+    assert old_sue_duty.idea_exists(clean_road) is False
+
+    # WHEN
+    add_duty_pledge(sue_userhub, clean_road, reason_premise=dirty_road)
+
+    # THEN
+    new_sue_duty = sue_userhub.get_duty_agenda()
+    clean_idea = new_sue_duty.get_idea_obj(clean_road)
+    print(f"{clean_idea._reasonunits.keys()=}")
+    assert clean_idea.get_reasonunit(house_estimation_road) != None
+    house_reasonunit = clean_idea.get_reasonunit(house_estimation_road)
+    assert house_reasonunit.get_premise(dirty_road) != None

--- a/src/listen/test_special_func/test_add_pledge.py
+++ b/src/listen/test_special_func/test_add_pledge.py
@@ -1,6 +1,6 @@
 from src._road.road import get_default_real_id_roadnode as root_label
 from src.listen.userhub import userhub_shop
-from src.listen.special_func import add_duty_pledge
+from src.listen.special_func import add_duty_pledge, add_duty_belief
 from src.listen.examples.listen_env import (
     env_dir_setup_cleanup,
     get_listen_temp_env_dir as env_dir,
@@ -64,7 +64,7 @@ def test_add_duty_pledge_CanAdd_reasonunit(env_dir_setup_cleanup):
     house_estimation_road = old_sue_duty.make_l1_road(house_estimation_text)
     dirty_text = "dirty"
     dirty_road = old_sue_duty.make_road(house_estimation_road, dirty_text)
-    assert old_sue_duty.idea_exists(clean_road) is False
+    assert old_sue_duty.idea_exists(dirty_road) is False
 
     # WHEN
     add_duty_pledge(sue_userhub, clean_road, reason_premise=dirty_road)
@@ -76,3 +76,26 @@ def test_add_duty_pledge_CanAdd_reasonunit(env_dir_setup_cleanup):
     assert clean_idea.get_reasonunit(house_estimation_road) != None
     house_reasonunit = clean_idea.get_reasonunit(house_estimation_road)
     assert house_reasonunit.get_premise(dirty_road) != None
+
+
+def test_add_duty_belief_CanAdd_beliefunit(env_dir_setup_cleanup):
+    # GIVEN
+    sue_text = "Sue"
+    sue_userhub = userhub_shop(env_dir(), root_label(), sue_text)
+    sue_userhub.initialize_atom_duty_files()
+    old_sue_duty = sue_userhub.get_duty_agenda()
+    house_estimation_text = "house_estimation"
+    house_estimation_road = old_sue_duty.make_l1_road(house_estimation_text)
+    dirty_text = "dirty"
+    dirty_road = old_sue_duty.make_road(house_estimation_road, dirty_text)
+    assert old_sue_duty.idea_exists(dirty_road) is False
+    assert old_sue_duty.get_belief(dirty_road) is None
+
+    # WHEN
+    add_duty_belief(sue_userhub, dirty_road)
+
+    # THEN
+    new_sue_duty = sue_userhub.get_duty_agenda()
+    assert new_sue_duty.idea_exists(dirty_road)
+    assert new_sue_duty.get_belief(house_estimation_road) != None
+    assert new_sue_duty.get_belief(house_estimation_road).pick == dirty_road

--- a/src/money/test_cash/test_scale_distribution.py
+++ b/src/money/test_cash/test_scale_distribution.py
@@ -42,7 +42,7 @@ def test_allot_scale_v02():
     )
 
 
-def test_allot_scale_v03_0():
+def test_allot_scale_v03():
     # Example usage:
     partys = {
         "obj1": {"creditor_weight": 1.0},
@@ -61,7 +61,7 @@ def test_allot_scale_v03_0():
     assert sum(obj["alloted_value"] for obj in partys.values()) == scale_number
 
 
-def test_allot_scale_v03_1():
+def test_allot_scale_v04():
     # Example usage:
     partys = {
         "obj1": {"creditor_weight": 1.0},
@@ -80,7 +80,7 @@ def test_allot_scale_v03_1():
     assert sum(obj["alloted_value"] for obj in partys.values()) == scale_number
 
 
-def test_allot_scale_v04():
+def test_allot_scale_v05():
     # Example usage:
     partys = {
         "obj1": {"creditor_weight": 1.0},
@@ -107,7 +107,7 @@ def test_allot_scale_v04():
     assert sum(obj["alloted_value"] for obj in partys.values()) == scale_number
 
 
-def test_allot_scale_v05():
+def test_allot_scale_v06():
     # Example usage:
     partys = {
         "obj1": {"creditor_weight": 1.0},
@@ -134,7 +134,7 @@ def test_allot_scale_v05():
     assert sum(obj["alloted_value"] for obj in partys.values()) == scale_number
 
 
-def test_allot_scale_v06():
+def test_allot_scale_v07():
     # Example usage:
     partys = {
         "obj1": {"creditor_weight": 1.0},


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces new functions for migrating belief units between agendas and enhances existing pledge and belief creation functions to support additional parameters. It also includes new tests to verify these functionalities and renames some test functions for clarity.

* **New Features**:
    - Introduced `migrate_all_beliefs` function to transfer belief units from one agenda to another.
    - Added `create_belief` and `add_duty_belief` functions to handle belief creation and addition in duty agendas.
* **Enhancements**:
    - Enhanced `create_pledge` and `add_duty_pledge` functions to support an optional `reason_premise` parameter for adding reason units.
    - Refactored `listen_to_beliefs_role_job` and `listen_to_beliefs_duty_work` functions to use the new `migrate_all_beliefs` function.
* **Tests**:
    - Added `test_migrate_all_beliefs_CorrectlyAddsIdeaUnitsAndSetsBeliefUnits` to verify the migration of belief units.
    - Added `test_add_duty_pledge_CanAdd_reasonunit` to test the addition of reason units in duty pledges.
    - Added `test_add_duty_belief_CanAdd_beliefunit` to test the addition of belief units in duty agendas.
    - Renamed several test functions in `test_cash/test_scale_distribution.py` for better versioning and clarity.

<!-- Generated by sourcery-ai[bot]: end summary -->