### PR TITLE
#275 replace "credit_weight" with "credit_vote", "debtit_weight" with…

### DIFF
--- a/src/bud/acct.py
+++ b/src/bud/acct.py
@@ -148,10 +148,10 @@ class AcctUnit(AcctCore):
     def add_membership(
         self,
         group_id: GroupID,
-        credit_weight: float = None,
-        debtit_weight: float = None,
+        credit_vote: float = None,
+        debtit_vote: float = None,
     ):
-        x_membership = membership_shop(group_id, credit_weight, debtit_weight)
+        x_membership = membership_shop(group_id, credit_vote, debtit_vote)
         self.set_membership(x_membership)
 
     def set_membership(self, x_membership: MemberShip):
@@ -183,7 +183,7 @@ class AcctUnit(AcctCore):
     def set_credor_pool(self, credor_pool: RespectNum):
         self._credor_pool = credor_pool
         ledger_dict = {
-            x_membership.group_id: x_membership.credit_weight
+            x_membership.group_id: x_membership.credit_vote
             for x_membership in self._memberships.values()
         }
         allot_dict = allot_scale(ledger_dict, self._credor_pool, self._bit)
@@ -193,7 +193,7 @@ class AcctUnit(AcctCore):
     def set_debtor_pool(self, debtor_pool: RespectNum):
         self._debtor_pool = debtor_pool
         ledger_dict = {
-            x_membership.group_id: x_membership.debtit_weight
+            x_membership.group_id: x_membership.debtit_vote
             for x_membership in self._memberships.values()
         }
         allot_dict = allot_scale(ledger_dict, self._debtor_pool, self._bit)
@@ -204,8 +204,8 @@ class AcctUnit(AcctCore):
         return {
             x_membership.group_id: {
                 "group_id": x_membership.group_id,
-                "credit_score": x_membership.credit_weight,
-                "debtit_score": x_membership.debtit_weight,
+                "credit_score": x_membership.credit_vote,
+                "debtit_score": x_membership.debtit_vote,
             }
             for x_membership in self._memberships.values()
         }

--- a/src/bud/bud.py
+++ b/src/bud/bud.py
@@ -406,8 +406,8 @@ class BudUnit:
         for x_acctunit in self._accts.values():
             x_membership = membership_shop(
                 group_id=x_group_id,
-                credit_weight=x_acctunit.credit_score,
-                debtit_weight=x_acctunit.debtit_score,
+                credit_vote=x_acctunit.credit_score,
+                debtit_vote=x_acctunit.debtit_score,
                 _acct_id=x_acctunit.acct_id,
             )
             x_groupbox.set_membership(x_membership)

--- a/src/bud/group.py
+++ b/src/bud/group.py
@@ -19,8 +19,8 @@ class GroupCore:
 
 @dataclass
 class MemberShip(GroupCore):
-    credit_weight: float = 1.0
-    debtit_weight: float = 1.0
+    credit_vote: float = 1.0
+    debtit_vote: float = 1.0
     # calculated fields
     _credor_pool: float = None
     _debtor_pool: float = None
@@ -32,19 +32,19 @@ class MemberShip(GroupCore):
     _fund_agenda_ratio_take: float = None
     _acct_id: AcctID = None
 
-    def set_credit_weight(self, x_credit_weight: float):
-        if x_credit_weight is not None:
-            self.credit_weight = x_credit_weight
+    def set_credit_vote(self, x_credit_vote: float):
+        if x_credit_vote is not None:
+            self.credit_vote = x_credit_vote
 
-    def set_debtit_weight(self, x_debtit_weight: float):
-        if x_debtit_weight is not None:
-            self.debtit_weight = x_debtit_weight
+    def set_debtit_vote(self, x_debtit_vote: float):
+        if x_debtit_vote is not None:
+            self.debtit_vote = x_debtit_vote
 
     def get_dict(self) -> dict[str, str]:
         return {
             "group_id": self.group_id,
-            "credit_weight": self.credit_weight,
-            "debtit_weight": self.debtit_weight,
+            "credit_vote": self.credit_vote,
+            "debtit_vote": self.debtit_vote,
         }
 
     def clear_fund_give_take(self):
@@ -58,14 +58,14 @@ class MemberShip(GroupCore):
 
 def membership_shop(
     group_id: GroupID,
-    credit_weight: float = None,
-    debtit_weight: float = None,
+    credit_vote: float = None,
+    debtit_vote: float = None,
     _acct_id: AcctID = None,
 ) -> MemberShip:
     return MemberShip(
         group_id=group_id,
-        credit_weight=get_1_if_None(credit_weight),
-        debtit_weight=get_1_if_None(debtit_weight),
+        credit_vote=get_1_if_None(credit_vote),
+        debtit_vote=get_1_if_None(debtit_vote),
         _credor_pool=0,
         _debtor_pool=0,
         _acct_id=_acct_id,
@@ -75,8 +75,8 @@ def membership_shop(
 def membership_get_from_dict(x_dict: dict, x_acct_id: AcctID) -> MemberShip:
     return membership_shop(
         group_id=x_dict.get("group_id"),
-        credit_weight=x_dict.get("credit_weight"),
-        debtit_weight=x_dict.get("debtit_weight"),
+        credit_vote=x_dict.get("credit_vote"),
+        debtit_vote=x_dict.get("debtit_vote"),
         _acct_id=x_acct_id,
     )
 
@@ -224,8 +224,8 @@ class GroupBox(GroupCore):
         credit_ledger = {}
         debtit_ledger = {}
         for x_acct_id, x_membership in self._memberships.items():
-            credit_ledger[x_acct_id] = x_membership.credit_weight
-            debtit_ledger[x_acct_id] = x_membership.debtit_weight
+            credit_ledger[x_acct_id] = x_membership.credit_vote
+            debtit_ledger[x_acct_id] = x_membership.debtit_vote
         fund_give_allot = allot_scale(credit_ledger, self._fund_give, self._fund_coin)
         fund_take_allot = allot_scale(debtit_ledger, self._fund_take, self._fund_coin)
         for acct_id, x_membership in self._memberships.items():

--- a/src/bud/test_acct/test__membership.py
+++ b/src/bud/test_acct/test__membership.py
@@ -41,8 +41,8 @@ def test_MemberShip_exists():
 
     # THEN
     assert swim_membership.group_id == swim_text
-    assert swim_membership.credit_weight == 1.0
-    assert swim_membership.debtit_weight == 1.0
+    assert swim_membership.credit_vote == 1.0
+    assert swim_membership.debtit_vote == 1.0
     assert swim_membership._credor_pool is None
     assert swim_membership._debtor_pool is None
     assert swim_membership._fund_give is None
@@ -57,19 +57,19 @@ def test_MemberShip_exists():
 def test_membership_shop_ReturnsCorrectObj():
     # ESTABLISH
     swim_text = ",swim"
-    swim_credit_weight = 3.0
-    swim_debtit_weight = 5.0
+    swim_credit_vote = 3.0
+    swim_debtit_vote = 5.0
 
     # WHEN
     swim_membership = membership_shop(
         group_id=swim_text,
-        credit_weight=swim_credit_weight,
-        debtit_weight=swim_debtit_weight,
+        credit_vote=swim_credit_vote,
+        debtit_vote=swim_debtit_vote,
     )
 
     # THEN
-    assert swim_membership.credit_weight == swim_credit_weight
-    assert swim_membership.debtit_weight == swim_debtit_weight
+    assert swim_membership.credit_vote == swim_credit_vote
+    assert swim_membership.debtit_vote == swim_debtit_vote
     assert swim_membership._credor_pool == 0
     assert swim_membership._debtor_pool == 0
     assert swim_membership._fund_give is None
@@ -110,85 +110,85 @@ def test_membership_shop_ReturnsCorrectObjAttr_acct_id():
 #     )
 
 
-def test_MemberShip_set_credit_weight_SetsAttr():
+def test_MemberShip_set_credit_vote_SetsAttr():
     # ESTABLISH
     swim_text = ",swim"
-    old_credit_weight = 3.0
-    swim_debtit_weight = 5.0
-    swim_membership = membership_shop(swim_text, old_credit_weight, swim_debtit_weight)
-    assert swim_membership.credit_weight == old_credit_weight
-    assert swim_membership.debtit_weight == swim_debtit_weight
+    old_credit_vote = 3.0
+    swim_debtit_vote = 5.0
+    swim_membership = membership_shop(swim_text, old_credit_vote, swim_debtit_vote)
+    assert swim_membership.credit_vote == old_credit_vote
+    assert swim_membership.debtit_vote == swim_debtit_vote
 
     # WHEN
-    new_swim_credit_weight = 44
-    swim_membership.set_credit_weight(new_swim_credit_weight)
+    new_swim_credit_vote = 44
+    swim_membership.set_credit_vote(new_swim_credit_vote)
 
     # THEN
-    assert swim_membership.credit_weight == new_swim_credit_weight
-    assert swim_membership.debtit_weight == swim_debtit_weight
+    assert swim_membership.credit_vote == new_swim_credit_vote
+    assert swim_membership.debtit_vote == swim_debtit_vote
 
 
-def test_MemberShip_set_credit_weight_HandlesNoneParameter():
+def test_MemberShip_set_credit_vote_HandlesNoneParameter():
     # ESTABLISH
     swim_text = ",swim"
-    old_credit_weight = 3.0
-    swim_debtit_weight = 5.0
-    swim_membership = membership_shop(swim_text, old_credit_weight, swim_debtit_weight)
-    assert swim_membership.credit_weight == old_credit_weight
-    assert swim_membership.debtit_weight == swim_debtit_weight
+    old_credit_vote = 3.0
+    swim_debtit_vote = 5.0
+    swim_membership = membership_shop(swim_text, old_credit_vote, swim_debtit_vote)
+    assert swim_membership.credit_vote == old_credit_vote
+    assert swim_membership.debtit_vote == swim_debtit_vote
 
     # WHEN
-    swim_membership.set_credit_weight(None)
+    swim_membership.set_credit_vote(None)
 
     # THEN
-    assert swim_membership.credit_weight == old_credit_weight
-    assert swim_membership.debtit_weight == swim_debtit_weight
+    assert swim_membership.credit_vote == old_credit_vote
+    assert swim_membership.debtit_vote == swim_debtit_vote
 
 
-def test_MemberShip_set_debtit_weight_SetsAttr():
+def test_MemberShip_set_debtit_vote_SetsAttr():
     # ESTABLISH
     swim_text = ",swim"
-    swim_credit_weight = 3.0
-    old_debtit_weight = 5.0
-    swim_membership = membership_shop(swim_text, swim_credit_weight, old_debtit_weight)
-    assert swim_membership.credit_weight == swim_credit_weight
-    assert swim_membership.debtit_weight == old_debtit_weight
+    swim_credit_vote = 3.0
+    old_debtit_vote = 5.0
+    swim_membership = membership_shop(swim_text, swim_credit_vote, old_debtit_vote)
+    assert swim_membership.credit_vote == swim_credit_vote
+    assert swim_membership.debtit_vote == old_debtit_vote
 
     # WHEN
-    new_debtit_weight = 55
-    swim_membership.set_debtit_weight(new_debtit_weight)
+    new_debtit_vote = 55
+    swim_membership.set_debtit_vote(new_debtit_vote)
 
     # THEN
-    assert swim_membership.credit_weight == swim_credit_weight
-    assert swim_membership.debtit_weight == new_debtit_weight
+    assert swim_membership.credit_vote == swim_credit_vote
+    assert swim_membership.debtit_vote == new_debtit_vote
 
 
-def test_MemberShip_set_debtit_weight_SetsAttr():
+def test_MemberShip_set_debtit_vote_SetsAttr():
     # ESTABLISH
     swim_text = ",swim"
-    swim_credit_weight = 3.0
-    old_debtit_weight = 5.0
-    swim_membership = membership_shop(swim_text, swim_credit_weight, old_debtit_weight)
-    assert swim_membership.credit_weight == swim_credit_weight
-    assert swim_membership.debtit_weight == old_debtit_weight
+    swim_credit_vote = 3.0
+    old_debtit_vote = 5.0
+    swim_membership = membership_shop(swim_text, swim_credit_vote, old_debtit_vote)
+    assert swim_membership.credit_vote == swim_credit_vote
+    assert swim_membership.debtit_vote == old_debtit_vote
 
     # WHEN
-    swim_membership.set_debtit_weight(None)
+    swim_membership.set_debtit_vote(None)
 
     # THEN
-    assert swim_membership.credit_weight == swim_credit_weight
-    assert swim_membership.debtit_weight == old_debtit_weight
+    assert swim_membership.credit_vote == swim_credit_vote
+    assert swim_membership.debtit_vote == old_debtit_vote
 
 
 def test_MemberShip_get_dict_ReturnsDictWithNecessaryDataForJSON():
     # ESTABLISH
     swim_text = ",swim"
-    swim_credit_weight = 3.0
-    swim_debtit_weight = 5.0
+    swim_credit_vote = 3.0
+    swim_debtit_vote = 5.0
     swim_membership = membership_shop(
         group_id=swim_text,
-        credit_weight=swim_credit_weight,
-        debtit_weight=swim_debtit_weight,
+        credit_vote=swim_credit_vote,
+        debtit_vote=swim_debtit_vote,
     )
 
     print(f"{swim_membership}")
@@ -200,21 +200,21 @@ def test_MemberShip_get_dict_ReturnsDictWithNecessaryDataForJSON():
     assert swim_dict is not None
     assert swim_dict == {
         "group_id": swim_membership.group_id,
-        "credit_weight": swim_membership.credit_weight,
-        "debtit_weight": swim_membership.debtit_weight,
+        "credit_vote": swim_membership.credit_vote,
+        "debtit_vote": swim_membership.debtit_vote,
     }
 
 
 def test_membership_get_from_dict_ReturnsObj():
     # ESTABLISH
     swim_text = ",swim"
-    swim_credit_weight = 3.0
-    swim_debtit_weight = 5.0
+    swim_credit_vote = 3.0
+    swim_debtit_vote = 5.0
     yao_text = "Yao"
     before_swim_membership = membership_shop(
         group_id=swim_text,
-        credit_weight=swim_credit_weight,
-        debtit_weight=swim_debtit_weight,
+        credit_vote=swim_credit_vote,
+        debtit_vote=swim_debtit_vote,
         _acct_id=yao_text,
     )
     swim_membership_dict = before_swim_membership.get_dict()
@@ -230,13 +230,13 @@ def test_membership_get_from_dict_ReturnsObj():
 def test_memberships_get_from_dict_ReturnsObj():
     # ESTABLISH
     swim_text = ",swim"
-    swim_credit_weight = 3.0
-    swim_debtit_weight = 5.0
+    swim_credit_vote = 3.0
+    swim_debtit_vote = 5.0
     yao_text = "Yao"
     before_swim_membership = membership_shop(
         group_id=swim_text,
-        credit_weight=swim_credit_weight,
-        debtit_weight=swim_debtit_weight,
+        credit_vote=swim_credit_vote,
+        debtit_vote=swim_debtit_vote,
         _acct_id=yao_text,
     )
     before_swim_memberships_objs = {swim_text: before_swim_membership}

--- a/src/bud/test_acct/test_acct_membership.py
+++ b/src/bud/test_acct/test_acct_membership.py
@@ -7,22 +7,22 @@ def test_AcctUnit_set_membership_SetsAttr_memberships():
     # ESTABLISH
     run_text = ",run"
     yao_text = "Yao"
-    run_credit_weight = 66
-    run_debtit_weight = 85
+    run_credit_vote = 66
+    run_debtit_vote = 85
     yao_acctunit = acctunit_shop(yao_text)
     assert yao_acctunit._memberships == {}
 
     # WHEN
     yao_acctunit.set_membership(
-        membership_shop(run_text, run_credit_weight, run_debtit_weight)
+        membership_shop(run_text, run_credit_vote, run_debtit_vote)
     )
 
     # THEN
     assert len(yao_acctunit._memberships) == 1
     run_membership = yao_acctunit._memberships.get(run_text)
     assert run_membership.group_id == run_text
-    assert run_membership.credit_weight == run_credit_weight
-    assert run_membership.debtit_weight == run_debtit_weight
+    assert run_membership.credit_vote == run_credit_vote
+    assert run_membership.debtit_vote == run_debtit_vote
     assert run_membership._acct_id == yao_text
 
 
@@ -30,8 +30,8 @@ def test_AcctUnit_set_membership_SetsMultipleAttr():
     # ESTABLISH
     run_text = ",run"
     fly_text = ",fly"
-    run_membership = membership_shop(run_text, credit_weight=13, debtit_weight=7)
-    fly_membership = membership_shop(fly_text, credit_weight=23, debtit_weight=5)
+    run_membership = membership_shop(run_text, credit_vote=13, debtit_vote=7)
+    fly_membership = membership_shop(fly_text, credit_vote=23, debtit_vote=5)
     yao_acctunit = acctunit_shop("Yao")
     assert yao_acctunit._memberships == {}
 
@@ -171,19 +171,19 @@ def test_AcctUnit_clear_memberships_SetsAttrCorrectly():
 def test_AcctUnit_add_membership_SetsAttrCorrectly():
     # ESTABLISH
     run_text = ",run"
-    run_credit_weight = 78
-    run_debtit_weight = 99
+    run_credit_vote = 78
+    run_debtit_vote = 99
     yao_acctunit = acctunit_shop("Yao")
     assert yao_acctunit.get_membership(run_text) is None
 
     # WHEN
-    yao_acctunit.add_membership(run_text, run_credit_weight, run_debtit_weight)
+    yao_acctunit.add_membership(run_text, run_credit_vote, run_debtit_vote)
 
     # THEN
     assert yao_acctunit.get_membership(run_text) is not None
     run_membership = yao_acctunit.get_membership(run_text)
-    assert run_membership.credit_weight == run_credit_weight
-    assert run_membership.debtit_weight == run_debtit_weight
+    assert run_membership.credit_vote == run_credit_vote
+    assert run_membership.debtit_vote == run_debtit_vote
 
 
 def test_AcctUnit_set_credor_pool_SetAttr():
@@ -216,11 +216,11 @@ def test_AcctUnit_set_credor_pool_Sets_memberships():
     # ESTABLISH
     ohio_text = ",Ohio"
     iowa_text = ",Iowa"
-    sue_credit_weight = 1
-    yao_credit_weight = 4
+    sue_credit_vote = 1
+    yao_credit_vote = 4
     bob_acctunit = acctunit_shop("Bob")
-    bob_acctunit.add_membership(ohio_text, sue_credit_weight)
-    bob_acctunit.add_membership(iowa_text, yao_credit_weight)
+    bob_acctunit.add_membership(ohio_text, sue_credit_vote)
+    bob_acctunit.add_membership(iowa_text, yao_credit_vote)
     assert bob_acctunit._credor_pool == 0
     sue_membership = bob_acctunit.get_membership(ohio_text)
     yao_membership = bob_acctunit.get_membership(iowa_text)
@@ -241,11 +241,11 @@ def test_AcctUnit_set_debtor_pool_Sets_memberships():
     # ESTABLISH
     ohio_text = ",Ohio"
     iowa_text = ",Iowa"
-    sue_debtit_weight = 1
-    yao_debtit_weight = 4
+    sue_debtit_vote = 1
+    yao_debtit_vote = 4
     bob_acctunit = acctunit_shop("Bob")
-    bob_acctunit.add_membership(ohio_text, 2, sue_debtit_weight)
-    bob_acctunit.add_membership(iowa_text, 2, yao_debtit_weight)
+    bob_acctunit.add_membership(ohio_text, 2, sue_debtit_vote)
+    bob_acctunit.add_membership(iowa_text, 2, yao_debtit_vote)
     assert bob_acctunit._debtor_pool == 0
     sue_membership = bob_acctunit.get_membership(ohio_text)
     yao_membership = bob_acctunit.get_membership(iowa_text)

--- a/src/bud/test_bud/test_bud_accts_.py
+++ b/src/bud/test_bud/test_bud_accts_.py
@@ -49,8 +49,8 @@ def test_BudUnit_set_acct_DoesSet_acct_id_membership():
     # THEN
     zia_zia_membership = yao_bud.get_acct(zia_text).get_membership(zia_text)
     assert zia_zia_membership is not None
-    assert zia_zia_membership.credit_weight == 1
-    assert zia_zia_membership.debtit_weight == 1
+    assert zia_zia_membership.credit_vote == 1
+    assert zia_zia_membership.debtit_vote == 1
 
 
 def test_BudUnit_set_acct_DoesNotOverRide_acct_id_membership():
@@ -70,8 +70,8 @@ def test_BudUnit_set_acct_DoesNotOverRide_acct_id_membership():
     # THEN
     zia_ohio_membership = yao_bud.get_acct(zia_text).get_membership(ohio_text)
     assert zia_ohio_membership is not None
-    assert zia_ohio_membership.credit_weight == zia_ohio_credit_w
-    assert zia_ohio_membership.debtit_weight == zia_ohio_debtit_w
+    assert zia_ohio_membership.credit_vote == zia_ohio_credit_w
+    assert zia_ohio_membership.debtit_vote == zia_ohio_debtit_w
     zia_zia_membership = yao_bud.get_acct(zia_text).get_membership(zia_text)
     assert zia_zia_membership is None
 
@@ -121,10 +121,10 @@ def test_BudUnit_set_acct_Creates_membership():
     yao_bud.add_acctunit(zia_text, before_zia_credit, before_zia_debtit)
     zia_acctunit = yao_bud.get_acct(zia_text)
     zia_membership = zia_acctunit.get_membership(zia_text)
-    assert zia_membership.credit_weight != before_zia_credit
-    assert zia_membership.debtit_weight != before_zia_debtit
-    assert zia_membership.credit_weight == 1
-    assert zia_membership.debtit_weight == 1
+    assert zia_membership.credit_vote != before_zia_credit
+    assert zia_membership.debtit_vote != before_zia_debtit
+    assert zia_membership.credit_vote == 1
+    assert zia_membership.debtit_vote == 1
 
     # WHEN
     after_zia_credit = 11
@@ -132,10 +132,10 @@ def test_BudUnit_set_acct_Creates_membership():
     yao_bud.set_acctunit(acctunit_shop(zia_text, after_zia_credit, after_zia_debtit))
 
     # THEN
-    assert zia_membership.credit_weight != after_zia_credit
-    assert zia_membership.debtit_weight != after_zia_debtit
-    assert zia_membership.credit_weight == 1
-    assert zia_membership.debtit_weight == 1
+    assert zia_membership.credit_vote != after_zia_credit
+    assert zia_membership.debtit_vote != after_zia_debtit
+    assert zia_membership.credit_vote == 1
+    assert zia_membership.debtit_vote == 1
 
 
 def test_BudUnit_edit_acct_RaiseExceptionWhenAcctDoesNotExist():

--- a/src/bud/test_bud/test_bud_accts_group.py
+++ b/src/bud/test_bud/test_bud_accts_group.py
@@ -91,12 +91,12 @@ def test_BudUnit_create_symmetry_groupbox_ReturnsObj():
     yao_text = "Yao"
     yao_bud = budunit_shop(yao_text)
     zia_text = "Zia"
-    yao_credit_weight = 3
-    yao_debtit_weight = 2
-    zia_credit_weight = 4
-    zia_debtit_weight = 5
-    yao_bud.add_acctunit(yao_text, yao_credit_weight, yao_debtit_weight)
-    yao_bud.add_acctunit(zia_text, zia_credit_weight, zia_debtit_weight)
+    yao_credit_vote = 3
+    yao_debtit_vote = 2
+    zia_credit_vote = 4
+    zia_debtit_vote = 5
+    yao_bud.add_acctunit(yao_text, yao_credit_vote, yao_debtit_vote)
+    yao_bud.add_acctunit(zia_text, zia_credit_vote, zia_debtit_vote)
 
     # WHEN
     xio_text = "Xio"
@@ -109,7 +109,7 @@ def test_BudUnit_create_symmetry_groupbox_ReturnsObj():
     assert len(xio_groupbox._memberships) == 2
     yao_groupbox = xio_groupbox.get_membership(yao_text)
     zia_groupbox = xio_groupbox.get_membership(zia_text)
-    assert yao_groupbox.credit_weight == yao_credit_weight
-    assert zia_groupbox.credit_weight == zia_credit_weight
-    assert yao_groupbox.debtit_weight == yao_debtit_weight
-    assert zia_groupbox.debtit_weight == zia_debtit_weight
+    assert yao_groupbox.credit_vote == yao_credit_vote
+    assert zia_groupbox.credit_vote == zia_credit_vote
+    assert yao_groupbox.debtit_vote == yao_debtit_vote
+    assert zia_groupbox.debtit_vote == zia_debtit_vote

--- a/src/bud/test_bud_settle/test_tree_traverse_base.py
+++ b/src/bud/test_bud_settle/test_tree_traverse_base.py
@@ -480,10 +480,10 @@ def test_BudUnit_settle_bud_CreatesNewGroupBoxsWhenNeeded_Scenario0():
     assert not xio_groupbox.membership_exists(xio_text)
     yao_membership = xio_groupbox.get_membership(yao_text)
     zia_membership = xio_groupbox.get_membership(zia_text)
-    assert yao_membership.credit_weight == yao_credit_score
-    assert zia_membership.credit_weight == zia_credit_score
-    assert yao_membership.debtit_weight == yao_debtit_score
-    assert zia_membership.debtit_weight == zia_debtit_score
+    assert yao_membership.credit_vote == yao_credit_score
+    assert zia_membership.credit_vote == zia_credit_score
+    assert yao_membership.debtit_vote == yao_debtit_score
+    assert zia_membership.debtit_vote == zia_debtit_score
 
 
 def test_BudUnit_settle_bud_CreatesNewGroupBoxsWhenNeeded_Scenario1():

--- a/src/gift/atom.py
+++ b/src/gift/atom.py
@@ -192,19 +192,19 @@ def _modify_bud_acct_membership_update(x_bud: BudUnit, x_atom: AtomUnit):
     x_group_id = x_atom.get_value("group_id")
     x_acctunit = x_bud.get_acct(x_acct_id)
     x_membership = x_acctunit.get_membership(x_group_id)
-    x_credit_weight = x_atom.get_value("credit_weight")
-    x_debtit_weight = x_atom.get_value("debtit_weight")
-    x_membership.set_credit_weight(x_credit_weight)
-    x_membership.set_debtit_weight(x_debtit_weight)
+    x_credit_vote = x_atom.get_value("credit_vote")
+    x_debtit_vote = x_atom.get_value("debtit_vote")
+    x_membership.set_credit_vote(x_credit_vote)
+    x_membership.set_debtit_vote(x_debtit_vote)
 
 
 def _modify_bud_acct_membership_insert(x_bud: BudUnit, x_atom: AtomUnit):
     x_acct_id = x_atom.get_value("acct_id")
     x_group_id = x_atom.get_value("group_id")
-    x_credit_weight = x_atom.get_value("credit_weight")
-    x_debtit_weight = x_atom.get_value("debtit_weight")
+    x_credit_vote = x_atom.get_value("credit_vote")
+    x_debtit_vote = x_atom.get_value("debtit_vote")
     x_acctunit = x_bud.get_acct(x_acct_id)
-    x_acctunit.add_membership(x_group_id, x_credit_weight, x_debtit_weight)
+    x_acctunit.add_membership(x_group_id, x_credit_vote, x_debtit_vote)
 
 
 def _modify_bud_ideaunit_delete(x_bud: BudUnit, x_atom: AtomUnit):
@@ -507,8 +507,8 @@ def optional_args_different(category: str, x_obj: any, y_obj: any) -> bool:
             or x_obj._fund_coin != y_obj._fund_coin
         )
     elif category in {"bud_acct_membership"}:
-        return (x_obj.credit_weight != y_obj.credit_weight) or (
-            x_obj.debtit_weight != y_obj.debtit_weight
+        return (x_obj.credit_vote != y_obj.credit_vote) or (
+            x_obj.debtit_vote != y_obj.debtit_vote
         )
     elif category in {"bud_idea_awardlink"}:
         return (x_obj.give_force != y_obj.give_force) or (

--- a/src/gift/atom_config.json
+++ b/src/gift/atom_config.json
@@ -11,11 +11,11 @@
             "normal_table_name": "membership"
         },
         "optional_args": {
-            "credit_weight": {
+            "credit_vote": {
                 "python_type": "int",
                 "sqlite_datatype": "INTEGER"
             },
-            "debtit_weight": {
+            "debtit_vote": {
                 "python_type": "int",
                 "sqlite_datatype": "INTEGER"
             }

--- a/src/gift/change.py
+++ b/src/gift/change.py
@@ -286,14 +286,10 @@ class ChangeUnit:
             x_atomunit = atomunit_shop("bud_acct_membership", atom_insert())
             x_atomunit.set_required_arg("acct_id", after_acct_id)
             x_atomunit.set_required_arg("group_id", after_membership.group_id)
-            if after_membership.credit_weight is not None:
-                x_atomunit.set_optional_arg(
-                    "credit_weight", after_membership.credit_weight
-                )
-            if after_membership.debtit_weight is not None:
-                x_atomunit.set_optional_arg(
-                    "debtit_weight", after_membership.debtit_weight
-                )
+            if after_membership.credit_vote is not None:
+                x_atomunit.set_optional_arg("credit_vote", after_membership.credit_vote)
+            if after_membership.debtit_vote is not None:
+                x_atomunit.set_optional_arg("debtit_vote", after_membership.debtit_vote)
             self.set_atomunit(x_atomunit)
 
     def add_atomunit_membership_update(
@@ -305,10 +301,10 @@ class ChangeUnit:
         x_atomunit = atomunit_shop("bud_acct_membership", atom_update())
         x_atomunit.set_required_arg("acct_id", acct_id)
         x_atomunit.set_required_arg("group_id", after_membership.group_id)
-        if after_membership.credit_weight != before_membership.credit_weight:
-            x_atomunit.set_optional_arg("credit_weight", after_membership.credit_weight)
-        if after_membership.debtit_weight != before_membership.debtit_weight:
-            x_atomunit.set_optional_arg("debtit_weight", after_membership.debtit_weight)
+        if after_membership.credit_vote != before_membership.credit_vote:
+            x_atomunit.set_optional_arg("credit_vote", after_membership.credit_vote)
+        if after_membership.debtit_vote != before_membership.debtit_vote:
+            x_atomunit.set_optional_arg("debtit_vote", after_membership.debtit_vote)
         self.set_atomunit(x_atomunit)
 
     def add_atomunit_memberships_delete(

--- a/src/gift/legible.py
+++ b/src/gift/legible.py
@@ -276,9 +276,9 @@ def add_bud_acct_membership_insert_to_legible_list(
         for acct_membership_atom in acct_membership_dict.values():
             group_id = acct_membership_atom.get_value("group_id")
             acct_id = acct_membership_atom.get_value("acct_id")
-            credit_weight_value = acct_membership_atom.get_value("credit_weight")
-            debtit_weight_value = acct_membership_atom.get_value("debtit_weight")
-            x_str = f"Group '{group_id}' has new membership {acct_id} with credit_weight_value{credit_weight_value} and debtit_weight_value={debtit_weight_value}."
+            credit_vote_value = acct_membership_atom.get_value("credit_vote")
+            debtit_vote_value = acct_membership_atom.get_value("debtit_vote")
+            x_str = f"Group '{group_id}' has new membership {acct_id} with credit_vote_value{credit_vote_value} and debtit_vote_value={debtit_vote_value}."
             legible_list.append(x_str)
 
 
@@ -289,14 +289,14 @@ def add_bud_acct_membership_update_to_legible_list(
         for acct_membership_atom in acct_membership_dict.values():
             group_id = acct_membership_atom.get_value("group_id")
             acct_id = acct_membership_atom.get_value("acct_id")
-            credit_weight_value = acct_membership_atom.get_value("credit_weight")
-            debtit_weight_value = acct_membership_atom.get_value("debtit_weight")
-            if credit_weight_value is not None and debtit_weight_value is not None:
-                x_str = f"Group '{group_id}' membership {acct_id} has new credit_weight_value{credit_weight_value} and debtit_weight_value={debtit_weight_value}."
-            elif credit_weight_value is not None and debtit_weight_value is None:
-                x_str = f"Group '{group_id}' membership {acct_id} has new credit_weight_value{credit_weight_value}."
-            elif credit_weight_value is None and debtit_weight_value is not None:
-                x_str = f"Group '{group_id}' membership {acct_id} has new debtit_weight_value={debtit_weight_value}."
+            credit_vote_value = acct_membership_atom.get_value("credit_vote")
+            debtit_vote_value = acct_membership_atom.get_value("debtit_vote")
+            if credit_vote_value is not None and debtit_vote_value is not None:
+                x_str = f"Group '{group_id}' membership {acct_id} has new credit_vote_value{credit_vote_value} and debtit_vote_value={debtit_vote_value}."
+            elif credit_vote_value is not None and debtit_vote_value is None:
+                x_str = f"Group '{group_id}' membership {acct_id} has new credit_vote_value{credit_vote_value}."
+            elif credit_vote_value is None and debtit_vote_value is not None:
+                x_str = f"Group '{group_id}' membership {acct_id} has new debtit_vote_value={debtit_vote_value}."
             legible_list.append(x_str)
 
 

--- a/src/gift/span.py
+++ b/src/gift/span.py
@@ -49,12 +49,12 @@ def credit_score_str() -> str:
     return "credit_score"
 
 
-def debtit_weight_str() -> str:
-    return "debtit_weight"
+def debtit_vote_str() -> str:
+    return "debtit_vote"
 
 
-def credit_weight_str() -> str:
-    return "credit_weight"
+def credit_vote_str() -> str:
+    return "credit_vote"
 
 
 def parent_road_str() -> str:
@@ -222,8 +222,8 @@ def create_span(x_budunit: BudUnit, span_name: str) -> DataFrame:
                 x_budunit._owner_id,
                 x_atomunit.get_value(acct_id_str()),
                 x_atomunit.get_value(group_id_str()),
-                x_atomunit.get_value(credit_weight_str()),
-                x_atomunit.get_value(debtit_weight_str()),
+                x_atomunit.get_value(credit_vote_str()),
+                x_atomunit.get_value(debtit_vote_str()),
             ]
             for x_atomunit in sorted_atomunits
         ]

--- a/src/gift/span_formats/jaar_format_00002_membership_v0_0_0.json
+++ b/src/gift/span_formats/jaar_format_00002_membership_v0_0_0.json
@@ -5,10 +5,10 @@
             "column_order": 2,
             "sort_order": 0
         },
-        "credit_weight": {
+        "credit_vote": {
             "column_order": 4
         },
-        "debtit_weight": {
+        "debtit_vote": {
             "column_order": 5
         },
         "group_id": {

--- a/src/gift/test_change/test_change_after_bud.py
+++ b/src/gift/test_change/test_change_after_bud.py
@@ -234,8 +234,8 @@ def test_ChangeUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_insert_membership()
     yao_atomunit = atomunit_shop("bud_acct_membership", atom_insert())
     yao_atomunit.set_required_arg("group_id", run_text)
     yao_atomunit.set_required_arg("acct_id", yao_text)
-    yao_run_credit_weight = 17
-    yao_atomunit.set_optional_arg("credit_weight", yao_run_credit_weight)
+    yao_run_credit_vote = 17
+    yao_atomunit.set_optional_arg("credit_vote", yao_run_credit_vote)
     print(f"{yao_atomunit=}")
     sue_changeunit = changeunit_shop()
     sue_changeunit.set_atomunit(yao_atomunit)
@@ -247,7 +247,7 @@ def test_ChangeUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_insert_membership()
     after_yao_acctunit = after_sue_budunit.get_acct(yao_text)
     after_yao_run_membership = after_yao_acctunit.get_membership(run_text)
     assert after_yao_run_membership is not None
-    assert after_yao_run_membership.credit_weight == yao_run_credit_weight
+    assert after_yao_run_membership.credit_vote == yao_run_credit_vote
 
 
 def test_ChangeUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_update_membership():
@@ -258,20 +258,20 @@ def test_ChangeUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_update_membership()
     before_sue_budunit.add_acctunit(yao_text)
     before_yao_acctunit = before_sue_budunit.get_acct(yao_text)
     run_text = ",runners"
-    old_yao_run_credit_weight = 3
-    before_yao_acctunit.add_membership(run_text, old_yao_run_credit_weight)
+    old_yao_run_credit_vote = 3
+    before_yao_acctunit.add_membership(run_text, old_yao_run_credit_vote)
     yao_run_membership = before_yao_acctunit.get_membership(run_text)
-    assert yao_run_membership.credit_weight == old_yao_run_credit_weight
-    assert yao_run_membership.debtit_weight == 1
+    assert yao_run_membership.credit_vote == old_yao_run_credit_vote
+    assert yao_run_membership.debtit_vote == 1
 
     # WHEN
     yao_atomunit = atomunit_shop("bud_acct_membership", atom_update())
     yao_atomunit.set_required_arg("group_id", run_text)
     yao_atomunit.set_required_arg("acct_id", yao_text)
-    new_yao_run_credit_weight = 7
-    new_yao_run_debtit_weight = 11
-    yao_atomunit.set_optional_arg("credit_weight", new_yao_run_credit_weight)
-    yao_atomunit.set_optional_arg("debtit_weight", new_yao_run_debtit_weight)
+    new_yao_run_credit_vote = 7
+    new_yao_run_debtit_vote = 11
+    yao_atomunit.set_optional_arg("credit_vote", new_yao_run_credit_vote)
+    yao_atomunit.set_optional_arg("debtit_vote", new_yao_run_debtit_vote)
     sue_changeunit = changeunit_shop()
     sue_changeunit.set_atomunit(yao_atomunit)
     after_sue_budunit = sue_changeunit.get_edited_bud(before_sue_budunit)
@@ -279,8 +279,8 @@ def test_ChangeUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_update_membership()
     # THEN
     after_yao_acctunit = after_sue_budunit.get_acct(yao_text)
     after_yao_run_membership = after_yao_acctunit.get_membership(run_text)
-    assert after_yao_run_membership.credit_weight == new_yao_run_credit_weight
-    assert after_yao_run_membership.debtit_weight == new_yao_run_debtit_weight
+    assert after_yao_run_membership.credit_vote == new_yao_run_credit_vote
+    assert after_yao_run_membership.debtit_vote == new_yao_run_debtit_vote
 
 
 def test_ChangeUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_delete_ideaunit():

--- a/src/gift/test_change/test_change_get_bud_difference.py
+++ b/src/gift/test_change/test_change_get_bud_difference.py
@@ -225,8 +225,8 @@ def test_ChangeUnit_add_all_different_atomunits_Creates_AtomUnit_acct_membership
     run_atomunit = get_nested_value(sue_changeunit.atomunits, x_keylist)
     assert run_atomunit.get_value("acct_id") == zia_text
     assert run_atomunit.get_value("group_id") == run_text
-    assert run_atomunit.get_value("credit_weight") == zia_run_credit_w
-    assert run_atomunit.get_value("debtit_weight") == zia_run_debtit_w
+    assert run_atomunit.get_value("credit_vote") == zia_run_credit_w
+    assert run_atomunit.get_value("debtit_vote") == zia_run_debtit_w
 
     print_atomunit_keys(sue_changeunit)
     print(f"{get_atomunit_total_count(sue_changeunit)=}")
@@ -270,8 +270,8 @@ def test_ChangeUnit_add_all_different_atomunits_Creates_AtomUnit_acct_membership
     xio_atomunit = get_nested_value(sue_changeunit.atomunits, x_keylist)
     assert xio_atomunit.get_value("acct_id") == xio_text
     assert xio_atomunit.get_value("group_id") == run_text
-    assert xio_atomunit.get_value("credit_weight") == after_xio_credit_w
-    assert xio_atomunit.get_value("debtit_weight") == after_xio_debtit_w
+    assert xio_atomunit.get_value("credit_vote") == after_xio_credit_w
+    assert xio_atomunit.get_value("debtit_vote") == after_xio_debtit_w
 
     print(f"{get_atomunit_total_count(sue_changeunit)=}")
     assert get_atomunit_total_count(sue_changeunit) == 1

--- a/src/gift/test_change/test_change_legible_acct_membership.py
+++ b/src/gift/test_change/test_change_legible_acct_membership.py
@@ -10,17 +10,17 @@ def test_create_legible_list_ReturnsObj_acct_membership_INSERT():
     category = "bud_acct_membership"
     group_id_text = "group_id"
     acct_id_text = "acct_id"
-    credit_weight_text = "credit_weight"
-    debtit_weight_text = "debtit_weight"
+    credit_vote_text = "credit_vote"
+    debtit_vote_text = "debtit_vote"
     swim_text = f"{sue_bud._road_delimiter}Swimmers"
     yao_text = "Yao"
-    credit_weight_value = 81
-    debtit_weight_value = 43
+    credit_vote_value = 81
+    debtit_vote_value = 43
     yao_atomunit = atomunit_shop(category, atom_insert())
     yao_atomunit.set_arg(group_id_text, swim_text)
     yao_atomunit.set_arg(acct_id_text, yao_text)
-    yao_atomunit.set_arg(credit_weight_text, credit_weight_value)
-    yao_atomunit.set_arg(debtit_weight_text, debtit_weight_value)
+    yao_atomunit.set_arg(credit_vote_text, credit_vote_value)
+    yao_atomunit.set_arg(debtit_vote_text, debtit_vote_value)
     # print(f"{yao_atomunit=}")
     x_changeunit = changeunit_shop()
     x_changeunit.set_atomunit(yao_atomunit)
@@ -29,28 +29,28 @@ def test_create_legible_list_ReturnsObj_acct_membership_INSERT():
     legible_list = create_legible_list(x_changeunit, sue_bud)
 
     # THEN
-    x_str = f"Group '{swim_text}' has new membership {yao_text} with credit_weight_value{credit_weight_value} and debtit_weight_value={debtit_weight_value}."
+    x_str = f"Group '{swim_text}' has new membership {yao_text} with credit_vote_value{credit_vote_value} and debtit_vote_value={debtit_vote_value}."
     print(f"{x_str=}")
     assert legible_list[0] == x_str
 
 
-def test_create_legible_list_ReturnsObj_acct_membership_UPDATE_credit_weight_debtit_weight():
+def test_create_legible_list_ReturnsObj_acct_membership_UPDATE_credit_vote_debtit_vote():
     # ESTABLISH
     sue_bud = budunit_shop("Sue")
     category = "bud_acct_membership"
     group_id_text = "group_id"
     acct_id_text = "acct_id"
-    credit_weight_text = "credit_weight"
-    debtit_weight_text = "debtit_weight"
+    credit_vote_text = "credit_vote"
+    debtit_vote_text = "debtit_vote"
     swim_text = f"{sue_bud._road_delimiter}Swimmers"
     yao_text = "Yao"
-    credit_weight_value = 81
-    debtit_weight_value = 43
+    credit_vote_value = 81
+    debtit_vote_value = 43
     yao_atomunit = atomunit_shop(category, atom_update())
     yao_atomunit.set_arg(group_id_text, swim_text)
     yao_atomunit.set_arg(acct_id_text, yao_text)
-    yao_atomunit.set_arg(credit_weight_text, credit_weight_value)
-    yao_atomunit.set_arg(debtit_weight_text, debtit_weight_value)
+    yao_atomunit.set_arg(credit_vote_text, credit_vote_value)
+    yao_atomunit.set_arg(debtit_vote_text, debtit_vote_value)
     # print(f"{yao_atomunit=}")
     x_changeunit = changeunit_shop()
     x_changeunit.set_atomunit(yao_atomunit)
@@ -59,25 +59,25 @@ def test_create_legible_list_ReturnsObj_acct_membership_UPDATE_credit_weight_deb
     legible_list = create_legible_list(x_changeunit, sue_bud)
 
     # THEN
-    x_str = f"Group '{swim_text}' membership {yao_text} has new credit_weight_value{credit_weight_value} and debtit_weight_value={debtit_weight_value}."
+    x_str = f"Group '{swim_text}' membership {yao_text} has new credit_vote_value{credit_vote_value} and debtit_vote_value={debtit_vote_value}."
     print(f"{x_str=}")
     assert legible_list[0] == x_str
 
 
-def test_create_legible_list_ReturnsObj_acct_membership_UPDATE_credit_weight():
+def test_create_legible_list_ReturnsObj_acct_membership_UPDATE_credit_vote():
     # ESTABLISH
     sue_bud = budunit_shop("Sue")
     category = "bud_acct_membership"
     group_id_text = "group_id"
     acct_id_text = "acct_id"
-    credit_weight_text = "credit_weight"
+    credit_vote_text = "credit_vote"
     swim_text = f"{sue_bud._road_delimiter}Swimmers"
     yao_text = "Yao"
-    credit_weight_value = 81
+    credit_vote_value = 81
     yao_atomunit = atomunit_shop(category, atom_update())
     yao_atomunit.set_arg(group_id_text, swim_text)
     yao_atomunit.set_arg(acct_id_text, yao_text)
-    yao_atomunit.set_arg(credit_weight_text, credit_weight_value)
+    yao_atomunit.set_arg(credit_vote_text, credit_vote_value)
     # print(f"{yao_atomunit=}")
     x_changeunit = changeunit_shop()
     x_changeunit.set_atomunit(yao_atomunit)
@@ -86,25 +86,25 @@ def test_create_legible_list_ReturnsObj_acct_membership_UPDATE_credit_weight():
     legible_list = create_legible_list(x_changeunit, sue_bud)
 
     # THEN
-    x_str = f"Group '{swim_text}' membership {yao_text} has new credit_weight_value{credit_weight_value}."
+    x_str = f"Group '{swim_text}' membership {yao_text} has new credit_vote_value{credit_vote_value}."
     print(f"{x_str=}")
     assert legible_list[0] == x_str
 
 
-def test_create_legible_list_ReturnsObj_acct_membership_UPDATE_debtit_weight():
+def test_create_legible_list_ReturnsObj_acct_membership_UPDATE_debtit_vote():
     # ESTABLISH
     sue_bud = budunit_shop("Sue")
     category = "bud_acct_membership"
     group_id_text = "group_id"
     acct_id_text = "acct_id"
-    debtit_weight_text = "debtit_weight"
+    debtit_vote_text = "debtit_vote"
     swim_text = f"{sue_bud._road_delimiter}Swimmers"
     yao_text = "Yao"
-    debtit_weight_value = 43
+    debtit_vote_value = 43
     yao_atomunit = atomunit_shop(category, atom_update())
     yao_atomunit.set_arg(group_id_text, swim_text)
     yao_atomunit.set_arg(acct_id_text, yao_text)
-    yao_atomunit.set_arg(debtit_weight_text, debtit_weight_value)
+    yao_atomunit.set_arg(debtit_vote_text, debtit_vote_value)
     # print(f"{yao_atomunit=}")
     x_changeunit = changeunit_shop()
     x_changeunit.set_atomunit(yao_atomunit)
@@ -113,7 +113,7 @@ def test_create_legible_list_ReturnsObj_acct_membership_UPDATE_debtit_weight():
     legible_list = create_legible_list(x_changeunit, sue_bud)
 
     # THEN
-    x_str = f"Group '{swim_text}' membership {yao_text} has new debtit_weight_value={debtit_weight_value}."
+    x_str = f"Group '{swim_text}' membership {yao_text} has new debtit_vote_value={debtit_vote_value}."
     print(f"{x_str=}")
     assert legible_list[0] == x_str
 

--- a/src/gift/test_span/test_span_format_config.py
+++ b/src/gift/test_span/test_span_format_config.py
@@ -12,8 +12,8 @@ from src.gift.span import (
     acct_pool_str,
     debtit_score_str,
     credit_score_str,
-    debtit_weight_str,
-    credit_weight_str,
+    debtit_vote_str,
+    credit_vote_str,
     column_order_str,
     # must_be_str,
     # must_be_roadnode_str,
@@ -39,8 +39,8 @@ def test_config_str_functions_ReturnObjs():
     assert acct_pool_str() == "acct_pool"
     assert debtit_score_str() == "debtit_score"
     assert credit_score_str() == "credit_score"
-    assert debtit_weight_str() == "debtit_weight"
-    assert credit_weight_str() == "credit_weight"
+    assert debtit_vote_str() == "debtit_vote"
+    assert credit_vote_str() == "credit_vote"
     assert jaar_format_00001_acct_v0_0_0() == "jaar_format_00001_acct_v0_0_0"
     x0002_span = "jaar_format_00002_membership_v0_0_0"
     assert jaar_format_00002_membership_v0_0_0() == x0002_span
@@ -168,16 +168,16 @@ def test_get_spanref_HasCorrectAttrs_jaar_format_00002_membership_v0_0_0():
     owner_id_spancolumn = format_00002_spanref.get_spancolumn(owner_id_str())
     acct_id_spancolumn = format_00002_spanref.get_spancolumn(acct_id_str())
     group_id_spancolumn = format_00002_spanref.get_spancolumn(group_id_str())
-    credit_weight_spancolumn = format_00002_spanref.get_spancolumn(credit_weight_str())
-    debtit_weight_spancolumn = format_00002_spanref.get_spancolumn(debtit_weight_str())
+    credit_vote_spancolumn = format_00002_spanref.get_spancolumn(credit_vote_str())
+    debtit_vote_spancolumn = format_00002_spanref.get_spancolumn(debtit_vote_str())
     assert len(format_00002_spanref._spancolumns) == 6
 
     assert real_id_spancolumn.column_order == 0
     assert owner_id_spancolumn.column_order == 1
     assert acct_id_spancolumn.column_order == 2
     assert group_id_spancolumn.column_order == 3
-    assert debtit_weight_spancolumn.column_order == 5
-    assert credit_weight_spancolumn.column_order == 4
+    assert debtit_vote_spancolumn.column_order == 5
+    assert credit_vote_spancolumn.column_order == 4
 
 
 def test_get_spanref_HasCorrectAttrs_jaar_format_00003_ideaunit_v0_0_0():

--- a/src/gift/test_span/test_span_format_create.py
+++ b/src/gift/test_span/test_span_format_create.py
@@ -16,8 +16,8 @@ from src.gift.span import (
     pledge_str,
     debtit_score_str,
     credit_score_str,
-    debtit_weight_str,
-    credit_weight_str,
+    debtit_vote_str,
+    credit_vote_str,
     get_spanref,
 )
 from src.bud.examples.example_buds import budunit_v001
@@ -110,29 +110,29 @@ def test_create_span_Arg_jaar_format_00002_membership_v0_0_0():
     assert membership_dataframe.loc[0, owner_id_str()] == sue_budunit._owner_id
     assert membership_dataframe.loc[0, acct_id_str()] == bob_text
     assert membership_dataframe.loc[0, group_id_str()] == iowa_text
-    assert membership_dataframe.loc[0, credit_weight_str()] == bob_iowa_credit_w
-    assert membership_dataframe.loc[0, debtit_weight_str()] == bob_iowa_debtit_w
+    assert membership_dataframe.loc[0, credit_vote_str()] == bob_iowa_credit_w
+    assert membership_dataframe.loc[0, debtit_vote_str()] == bob_iowa_debtit_w
 
     assert membership_dataframe.loc[2, real_id_str()] == music_real_id
     assert membership_dataframe.loc[2, owner_id_str()] == sue_budunit._owner_id
     assert membership_dataframe.loc[2, acct_id_str()] == sue_text
     assert membership_dataframe.loc[2, group_id_str()] == iowa_text
-    assert membership_dataframe.loc[2, credit_weight_str()] == sue_iowa_credit_w
-    assert membership_dataframe.loc[2, debtit_weight_str()] == sue_iowa_debtit_w
+    assert membership_dataframe.loc[2, credit_vote_str()] == sue_iowa_credit_w
+    assert membership_dataframe.loc[2, debtit_vote_str()] == sue_iowa_debtit_w
 
     assert membership_dataframe.loc[4, real_id_str()] == music_real_id
     assert membership_dataframe.loc[4, owner_id_str()] == sue_budunit._owner_id
     assert membership_dataframe.loc[4, acct_id_str()] == yao_text
     assert membership_dataframe.loc[4, group_id_str()] == iowa_text
-    assert membership_dataframe.loc[4, credit_weight_str()] == yao_iowa_credit_w
-    assert membership_dataframe.loc[4, debtit_weight_str()] == yao_iowa_debtit_w
+    assert membership_dataframe.loc[4, credit_vote_str()] == yao_iowa_credit_w
+    assert membership_dataframe.loc[4, debtit_vote_str()] == yao_iowa_debtit_w
 
     assert membership_dataframe.loc[5, real_id_str()] == music_real_id
     assert membership_dataframe.loc[5, owner_id_str()] == sue_budunit._owner_id
     assert membership_dataframe.loc[5, acct_id_str()] == yao_text
     assert membership_dataframe.loc[5, group_id_str()] == ohio_text
-    assert membership_dataframe.loc[5, credit_weight_str()] == yao_ohio_credit_w
-    assert membership_dataframe.loc[5, debtit_weight_str()] == yao_ohio_debtit_w
+    assert membership_dataframe.loc[5, credit_vote_str()] == yao_ohio_credit_w
+    assert membership_dataframe.loc[5, debtit_vote_str()] == yao_ohio_debtit_w
     assert len(membership_dataframe) == 7
 
 

--- a/src/gift/test_span/test_span_format_import.py
+++ b/src/gift/test_span/test_span_format_import.py
@@ -16,8 +16,8 @@ from src.gift.span import (
     pledge_str,
     debtit_score_str,
     credit_score_str,
-    debtit_weight_str,
-    credit_weight_str,
+    debtit_vote_str,
+    credit_vote_str,
     get_spanref,
 )
 from src.bud.examples.example_buds import budunit_v001
@@ -110,29 +110,29 @@ from src.bud.examples.example_buds import budunit_v001
 #     assert membership_dataframe.loc[0, owner_id_str()] == sue_budunit._owner_id
 #     assert membership_dataframe.loc[0, acct_id_str()] == bob_text
 #     assert membership_dataframe.loc[0, group_id_str()] == iowa_text
-#     assert membership_dataframe.loc[0, credit_weight_str()] == bob_iowa_credit_w
-#     assert membership_dataframe.loc[0, debtit_weight_str()] == bob_iowa_debtit_w
+#     assert membership_dataframe.loc[0, credit_vote_str()] == bob_iowa_credit_w
+#     assert membership_dataframe.loc[0, debtit_vote_str()] == bob_iowa_debtit_w
 
 #     assert membership_dataframe.loc[2, real_id_str()] == music_real_id
 #     assert membership_dataframe.loc[2, owner_id_str()] == sue_budunit._owner_id
 #     assert membership_dataframe.loc[2, acct_id_str()] == sue_text
 #     assert membership_dataframe.loc[2, group_id_str()] == iowa_text
-#     assert membership_dataframe.loc[2, credit_weight_str()] == sue_iowa_credit_w
-#     assert membership_dataframe.loc[2, debtit_weight_str()] == sue_iowa_debtit_w
+#     assert membership_dataframe.loc[2, credit_vote_str()] == sue_iowa_credit_w
+#     assert membership_dataframe.loc[2, debtit_vote_str()] == sue_iowa_debtit_w
 
 #     assert membership_dataframe.loc[4, real_id_str()] == music_real_id
 #     assert membership_dataframe.loc[4, owner_id_str()] == sue_budunit._owner_id
 #     assert membership_dataframe.loc[4, acct_id_str()] == yao_text
 #     assert membership_dataframe.loc[4, group_id_str()] == iowa_text
-#     assert membership_dataframe.loc[4, credit_weight_str()] == yao_iowa_credit_w
-#     assert membership_dataframe.loc[4, debtit_weight_str()] == yao_iowa_debtit_w
+#     assert membership_dataframe.loc[4, credit_vote_str()] == yao_iowa_credit_w
+#     assert membership_dataframe.loc[4, debtit_vote_str()] == yao_iowa_debtit_w
 
 #     assert membership_dataframe.loc[5, real_id_str()] == music_real_id
 #     assert membership_dataframe.loc[5, owner_id_str()] == sue_budunit._owner_id
 #     assert membership_dataframe.loc[5, acct_id_str()] == yao_text
 #     assert membership_dataframe.loc[5, group_id_str()] == ohio_text
-#     assert membership_dataframe.loc[5, credit_weight_str()] == yao_ohio_credit_w
-#     assert membership_dataframe.loc[5, debtit_weight_str()] == yao_ohio_debtit_w
+#     assert membership_dataframe.loc[5, credit_vote_str()] == yao_ohio_credit_w
+#     assert membership_dataframe.loc[5, debtit_vote_str()] == yao_ohio_debtit_w
 #     assert len(membership_dataframe) == 7
 
 

--- a/src/normal_db/normal_models.py
+++ b/src/normal_db/normal_models.py
@@ -42,8 +42,8 @@ class MemberShipTable(Base):
     uid = Column(Integer, primary_key=True)
     group_id = Column(String)
     acct_id = Column(String)
-    credit_weight = Column(Integer)
-    debtit_weight = Column(Integer)
+    credit_vote = Column(Integer)
+    debtit_vote = Column(Integer)
 
 
 class IdeaTable(Base):

--- a/src/real/test_real_/test_journal_sqlstr_.py
+++ b/src/real/test_real_/test_journal_sqlstr_.py
@@ -166,7 +166,7 @@ CREATE TABLE IF NOT EXISTS atom_hx (
         "idea_reasonunit_UPDATE_base_idea_active_requisite INTEGER NULL"
     )
     assert generated_sqlstr.find(example_idea_reasonunit_text) > 0
-    assert generated_sqlstr.find(example_idea_reasonunit_text) == 3621
+    assert generated_sqlstr.find(example_idea_reasonunit_text) == 3613
 
 
 def test_get_atom_hx_table_insert_sqlstr_ReturnsCorrectStr():
@@ -218,12 +218,12 @@ CREATE TABLE IF NOT EXISTS atom_mstr (
 ;"""
     assert generated_sqlstr.find(begin_sqlstr) == 0
     assert generated_sqlstr.find(end_sqlstr) > 0
-    assert generated_sqlstr.find(end_sqlstr) == 5460
+    assert generated_sqlstr.find(end_sqlstr) == 5452
     example_idea_reasonunit_text = (
         "idea_reasonunit_UPDATE_base_idea_active_requisite INTEGER NULL"
     )
     assert generated_sqlstr.find(example_idea_reasonunit_text) > 0
-    assert generated_sqlstr.find(example_idea_reasonunit_text) == 3653
+    assert generated_sqlstr.find(example_idea_reasonunit_text) == 3645
 
 
 def test_get_create_table_if_not_exist_sqlstrs_HasCorrectNumberOfNumber():


### PR DESCRIPTION
… "debtit_vote"

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request standardizes the terminology by replacing 'credit_weight' with 'credit_vote' and 'debtit_weight' with 'debtit_vote' across the codebase, including updates to the relevant test cases.

- **Enhancements**:
    - Replaced all instances of 'credit_weight' with 'credit_vote' and 'debtit_weight' with 'debtit_vote' across multiple files to standardize terminology.
- **Tests**:
    - Updated test cases to reflect the renaming of 'credit_weight' to 'credit_vote' and 'debtit_weight' to 'debtit_vote'.

<!-- Generated by sourcery-ai[bot]: end summary -->