### PR TITLE
238 reality needs atoms to build create builder that takes csv formats and turns them into changeunits

### DIFF
--- a/src/bud/test_acct/test__membership.py
+++ b/src/bud/test_acct/test__membership.py
@@ -163,7 +163,7 @@ def test_MemberShip_set_debtit_vote_SetsAttr():
     assert swim_membership.debtit_vote == new_debtit_vote
 
 
-def test_MemberShip_set_debtit_vote_SetsAttr():
+def test_MemberShip_set_debtit_vote_DoesNotSetsAttrNone():
     # ESTABLISH
     swim_text = ",swim"
     swim_credit_vote = 3.0

--- a/src/bud/test_acct/test_acct_membership.py
+++ b/src/bud/test_acct/test_acct_membership.py
@@ -97,7 +97,7 @@ def test_memberships_exist_ReturnsCorrectObj():
     run_text = ",run"
     fly_text = ",fly"
     yao_acctunit = acctunit_shop("Yao")
-    assert yao_acctunit.memberships_exist() is False
+    assert not yao_acctunit.memberships_exist()
 
     # WHEN
     yao_acctunit.set_membership(membership_shop(run_text))
@@ -117,7 +117,7 @@ def test_memberships_exist_ReturnsCorrectObj():
     # WHEN
     yao_acctunit.delete_membership(run_text)
     # THEN
-    assert yao_acctunit.memberships_exist() is False
+    assert not yao_acctunit.memberships_exist()
 
 
 def test_AcctUnit_del_membership_SetsAttrCorrectly():

--- a/src/bud/test_bud/test_bud_json.py
+++ b/src/bud/test_bud/test_bud_json.py
@@ -478,7 +478,7 @@ def test_budunit_get_from_json_ReturnsCorrectObj_road_delimiter_GroupExample():
     assert after_yao_acctunit._road_delimiter == slash_delimiter
 
 
-def test_budunit_get_from_json_ExportCorrectyExportsBudUnit_mass():
+def test_budunit_get_from_json_ExportsBudUnit_mass():
     # ESTABLISH
     x1_bud = budunit_v001()
     x1_bud._tally = 15

--- a/src/bud/test_bud/test_bud_json.py
+++ b/src/bud/test_bud/test_bud_json.py
@@ -12,7 +12,6 @@ from src.bud.bud import (
 )
 from src.bud.examples.example_buds import (
     budunit_v001,
-    budunit_v002,
     get_budunit_x1_3levels_1reason_1facts,
     get_budunit_base_time_example,
 )
@@ -301,6 +300,12 @@ def test_BudUnit_get_json_ReturnsCorrectJSON_BigExample():
     originholds_text = "_originholds"
     assert len(bud_dict[originunit_text][originholds_text])
 
+    anna_text = "Anna"
+    anna_acctunit = yao_bud.get_acct(anna_text)
+    assert anna_acctunit.get_membership(",Family").credit_vote == 6.2
+    assert yao_bud._accts is not None
+    assert len(yao_bud._accts) == 22
+
 
 def test_budunit_get_from_json_ReturnsCorrectObjSimpleExample():
     # ESTABLISH
@@ -497,16 +502,6 @@ def test_budunit_get_from_json_ExportsBudUnit_mass():
     assert x1_bud._idearoot._kids == x2_bud._idearoot._kids
 
 
-def test_budunit_get_from_json_CorrectlyLoads_membership_credit_vote():
-    # ESTABLISH / WHEN
-    x2_bud = budunit_v002()
-
-    # THEN
-    anna_text = "Anna"
-    anna_acctunit = x2_bud.get_acct(anna_text)
-    assert anna_acctunit.get_membership(",Family").credit_vote == 6.2
-
-
 def test_get_dict_of_bud_from_dict_ReturnsDictOfBudUnits():
     # ESTABLISH
     x1_bud = budunit_v001()
@@ -554,12 +549,3 @@ def test_get_dict_of_bud_from_dict_ReturnsDictOfBudUnits():
     assert ccn_philipa_acctunit._memberships == x1_philipa_acctunit._memberships
     assert ccn_bud1 == x1_bud
     assert ccn_dict_of_obj.get(x1_bud._owner_id) == x1_bud
-
-
-def test_budunit_get_from_json_CheckExampleHasCorrectAttrs_budunit_v001():
-    # ESTABLISH / WHEN
-    yao_bud = budunit_v001()
-
-    # THEN
-    assert yao_bud._accts is not None
-    assert len(yao_bud._accts) == 22

--- a/src/bud/test_graphs/test_concepts.py
+++ b/src/bud/test_graphs/test_concepts.py
@@ -13,7 +13,7 @@ from src.bud.graphic import (
 )
 
 
-def test_budunit_explanation_ShowsExplanation0BudConceptGraph():
+def test_budunit_explanation_ShowsExplanation0BudGraph():
     # ESTABLISH / WHEN
     ideatree1 = display_ideatree(get_budunit_with_4_levels())
     ideatree2 = display_ideatree(get_budunit_with_4_levels_and_2reasons(), "Task")

--- a/src/gift/legible.py
+++ b/src/gift/legible.py
@@ -293,9 +293,9 @@ def add_bud_acct_membership_update_to_legible_list(
             debtit_vote_value = acct_membership_atom.get_value("debtit_vote")
             if credit_vote_value is not None and debtit_vote_value is not None:
                 x_str = f"Group '{group_id}' membership {acct_id} has new credit_vote_value{credit_vote_value} and debtit_vote_value={debtit_vote_value}."
-            elif credit_vote_value is not None and debtit_vote_value is None:
+            elif credit_vote_value is not None:
                 x_str = f"Group '{group_id}' membership {acct_id} has new credit_vote_value{credit_vote_value}."
-            elif credit_vote_value is None and debtit_vote_value is not None:
+            elif debtit_vote_value is not None:
                 x_str = f"Group '{group_id}' membership {acct_id} has new debtit_vote_value={debtit_vote_value}."
             legible_list.append(x_str)
 

--- a/src/gift/test_span/test_span_format_create.py
+++ b/src/gift/test_span/test_span_format_create.py
@@ -174,14 +174,15 @@ def test_create_span_Arg_jaar_format_00003_ideaunit_v0_0_0():
     assert len(ideaunit_format) == 2
 
 
-def test_create_span_Arg_jaar_format_00003_ideaunit_v0_0_0_Scenario_budunit_v001():
-    # ESTABLISH / WHEN
-    x_span_name = jaar_format_00003_ideaunit_v0_0_0()
+# Commented out to reduce testing time.
+# def test_create_span_Arg_jaar_format_00003_ideaunit_v0_0_0_Scenario_budunit_v001():
+#     # ESTABLISH / WHEN
+#     x_span_name = jaar_format_00003_ideaunit_v0_0_0()
 
-    # WHEN
-    ideaunit_format = create_span(budunit_v001(), x_span_name)
+#     # WHEN
+#     ideaunit_format = create_span(budunit_v001(), x_span_name)
 
-    # THEN
-    array_headers = list(ideaunit_format.columns)
-    assert array_headers == get_spanref(x_span_name).get_headers_list()
-    assert len(ideaunit_format) == 252
+#     # THEN
+#     array_headers = list(ideaunit_format.columns)
+#     assert array_headers == get_spanref(x_span_name).get_headers_list()
+#     assert len(ideaunit_format) == 252

--- a/src/span/examples/span_env.py
+++ b/src/span/examples/span_env.py
@@ -1,0 +1,22 @@
+from src._instrument.file import delete_dir
+from pytest import fixture as pytest_fixture
+
+
+def src_span_examples_dir() -> str:
+    return "src/span/examples"
+
+
+# @pytest_fixture()
+# def env_dir_setup_cleanup():
+#     env_dir = src_span_examples_dir()
+#     delete_dir(dir=env_dir)
+#     yield env_dir
+#     delete_dir(dir=env_dir)
+
+
+def span_examples_dir() -> str:
+    return f"{src_span_examples_dir()}/span_examples"
+
+
+def span_reals_dir() -> str:
+    return f"{src_span_examples_dir()}/reals"

--- a/src/span/examples/span_examples/Sue_acct_example_00.csv
+++ b/src/span/examples/span_examples/Sue_acct_example_00.csv
@@ -1,0 +1,4 @@
+real_id,owner_id,acct_id,credit_score,debtit_score
+music56,Sue,Bob,13,29
+music56,Sue,Sue,11,23
+music56,Sue,Yao,41,37

--- a/src/span/span.py
+++ b/src/span/span.py
@@ -188,11 +188,11 @@ def _get_headers_list(span_name: str) -> list[str]:
     return get_spanref(span_name).get_headers_list()
 
 
-def create_span_dataframe(d2_list: list[list[str]], span_name: str) -> DataFrame:
+def _generate_span_dataframe(d2_list: list[list[str]], span_name: str) -> DataFrame:
     return DataFrame(d2_list, columns=_get_headers_list(span_name))
 
 
-def create_span(x_budunit: BudUnit, span_name: str) -> DataFrame:
+def create_span_df(x_budunit: BudUnit, span_name: str) -> DataFrame:
     x_changeunit = changeunit_shop()
     x_changeunit.add_all_atomunits(x_budunit)
     x_spanref = get_spanref(span_name)
@@ -244,10 +244,21 @@ def create_span(x_budunit: BudUnit, span_name: str) -> DataFrame:
                 ]
             )
 
-    x_span = create_span_dataframe(d2_list, span_name)
+    x_span = _generate_span_dataframe(d2_list, span_name)
     ascending_bools = get_ascending_bools(sorting_columns)
     x_span.sort_values(sorting_columns, ascending=ascending_bools, inplace=True)
     x_span.reset_index(inplace=True)
     x_span.drop(columns=["index"], inplace=True)
 
     return x_span
+
+
+def save_span_csv(x_spanname: str, x_budunit: BudUnit, x_dir: str, x_filename: str):
+    x_dataframe = create_span_df(x_budunit, x_spanname)
+    csv_path = f"{x_dir}/{x_filename}"
+    print(f"{csv_path=}")
+    x_dataframe.to_csv(csv_path, index=False)
+
+
+def open_span_csv():
+    pass

--- a/src/span/test_span/test_env.py
+++ b/src/span/test_span/test_env.py
@@ -1,0 +1,20 @@
+from src.span.examples.span_env import (
+    span_examples_dir,
+    src_span_examples_dir,
+    span_reals_dir,
+)
+
+
+def test_src_span_examples_dir_ReturnsObj():
+    # ESTABLISH / WHEN / THEN
+    assert src_span_examples_dir() == "src/span/examples"
+
+
+def test_span_examples_dir_ReturnsObj():
+    # ESTABLISH / WHEN / THEN
+    assert span_examples_dir() == f"{src_span_examples_dir()}/span_examples"
+
+
+def test_span_reals_dir_ReturnsObj():
+    # ESTABLISH / WHEN / THEN
+    assert span_reals_dir() == f"{src_span_examples_dir()}/reals"

--- a/src/span/test_span/test_span_column.py
+++ b/src/span/test_span/test_span_column.py
@@ -1,4 +1,4 @@
-from src.gift.span import SpanColumn, SpanRef, spanref_shop
+from src.span.span import SpanColumn, SpanRef, spanref_shop
 
 
 def test_SpanColumn_Exists():

--- a/src/span/test_span/test_span_format_config.py
+++ b/src/span/test_span/test_span_format_config.py
@@ -1,6 +1,6 @@
 from src._instrument.file import dir_files
 from src.gift.atom_config import config_file_dir, bud_acctunit_text
-from src.gift.span import (
+from src.span.span import (
     real_id_str,
     owner_id_str,
     acct_id_str,
@@ -26,7 +26,7 @@ from src.gift.span import (
     jaar_format_00002_membership_v0_0_0,
     jaar_format_00003_ideaunit_v0_0_0,
     _get_headers_list,
-    create_span_dataframe,
+    _generate_span_dataframe,
     get_spanref,
 )
 
@@ -95,30 +95,30 @@ def test_get_headers_list_ReturnsObj():
     ]
 
 
-def test_create_span_dataframe_ReturnsCorrectObj():
+def test__generate_span_dataframe_ReturnsCorrectObj():
     # ESTABLISH
     empty_d2 = []
     # WHEN
-    x_df = create_span_dataframe(empty_d2, jaar_format_00001_acct_v0_0_0())
+    x_df = _generate_span_dataframe(empty_d2, jaar_format_00001_acct_v0_0_0())
     # THEN
     assert list(x_df.columns) == _get_headers_list(jaar_format_00001_acct_v0_0_0())
 
 
-def for_all_spans_create_span_dataframe():
+def for_all_spans__generate_span_dataframe():
     # Catching broad exceptions can make debugging difficult. Consider catching more specific exceptions or at least logging the exception details.
     empty_d2 = []
     for x_filename in get_span_filenames():
         try:
-            create_span_dataframe(empty_d2, x_filename)
+            _generate_span_dataframe(empty_d2, x_filename)
         except Exception:
-            print(f"create_span_dataframe failed for {x_filename=}")
+            print(f"_generate_span_dataframe failed for {x_filename=}")
             return False
     return True
 
 
-def test_create_span_dataframe_ReturnsCorrectObjForEvery_span():
+def test__generate_span_dataframe_ReturnsCorrectObjForEvery_span():
     # ESTABLISH / WHEN / THEN
-    assert for_all_spans_create_span_dataframe()
+    assert for_all_spans__generate_span_dataframe()
 
 
 def test_span_FilesExist():

--- a/src/span/test_span/test_span_format_create.py
+++ b/src/span/test_span/test_span_format_create.py
@@ -1,11 +1,12 @@
+from src._instrument.file import delete_dir, open_file
 from src._road.jaar_refer import sue_str, bob_str, yao_str
 from src.bud.idea import ideaunit_shop
 from src.bud.bud import budunit_shop
-from src.gift.span import (
+from src.span.span import (
     jaar_format_00001_acct_v0_0_0,
     jaar_format_00002_membership_v0_0_0,
     jaar_format_00003_ideaunit_v0_0_0,
-    create_span,
+    create_span_df,
     real_id_str,
     owner_id_str,
     acct_id_str,
@@ -19,11 +20,13 @@ from src.gift.span import (
     debtit_vote_str,
     credit_vote_str,
     get_spanref,
+    save_span_csv,
 )
-from src.bud.examples.example_buds import budunit_v001
+from src.span.examples.span_env import span_examples_dir
+from os.path import exists as os_path_exists
 
 
-def test_create_span_Arg_jaar_format_00001_acct_v0_0_0():
+def test_create_span_df_Arg_jaar_format_00001_acct_v0_0_0():
     # ESTABLISH
     sue_text = sue_str()
     bob_text = bob_str()
@@ -42,7 +45,7 @@ def test_create_span_Arg_jaar_format_00001_acct_v0_0_0():
 
     # WHEN
     x_span_name = jaar_format_00001_acct_v0_0_0()
-    acct_dataframe = create_span(sue_budunit, x_span_name)
+    acct_dataframe = create_span_df(sue_budunit, x_span_name)
 
     # THEN
     array_headers = list(acct_dataframe.columns)
@@ -69,7 +72,7 @@ def test_create_span_Arg_jaar_format_00001_acct_v0_0_0():
     assert len(acct_dataframe) == 3
 
 
-def test_create_span_Arg_jaar_format_00002_membership_v0_0_0():
+def test_create_span_df_Arg_jaar_format_00002_membership_v0_0_0():
     # ESTABLISH
     sue_text = sue_str()
     bob_text = bob_str()
@@ -99,7 +102,7 @@ def test_create_span_Arg_jaar_format_00002_membership_v0_0_0():
 
     # WHEN
     x_span_name = jaar_format_00002_membership_v0_0_0()
-    membership_dataframe = create_span(sue_budunit, x_span_name)
+    membership_dataframe = create_span_df(sue_budunit, x_span_name)
 
     # THEN
     array_headers = list(membership_dataframe.columns)
@@ -136,7 +139,7 @@ def test_create_span_Arg_jaar_format_00002_membership_v0_0_0():
     assert len(membership_dataframe) == 7
 
 
-def test_create_span_Arg_jaar_format_00003_ideaunit_v0_0_0():
+def test_create_span_df_Arg_jaar_format_00003_ideaunit_v0_0_0():
     # ESTABLISH
     sue_text = sue_str()
     bob_text = bob_str()
@@ -152,7 +155,7 @@ def test_create_span_Arg_jaar_format_00003_ideaunit_v0_0_0():
 
     # WHEN
     x_span_name = jaar_format_00003_ideaunit_v0_0_0()
-    ideaunit_format = create_span(sue_budunit, x_span_name)
+    ideaunit_format = create_span_df(sue_budunit, x_span_name)
 
     # THEN
     array_headers = list(ideaunit_format.columns)
@@ -175,14 +178,50 @@ def test_create_span_Arg_jaar_format_00003_ideaunit_v0_0_0():
 
 
 # Commented out to reduce testing time.
-# def test_create_span_Arg_jaar_format_00003_ideaunit_v0_0_0_Scenario_budunit_v001():
+# def test_create_span_df_Arg_jaar_format_00003_ideaunit_v0_0_0_Scenario_budunit_v001():
 #     # ESTABLISH / WHEN
 #     x_span_name = jaar_format_00003_ideaunit_v0_0_0()
 
 #     # WHEN
-#     ideaunit_format = create_span(budunit_v001(), x_span_name)
+#     ideaunit_format = create_span_df(budunit_v001(), x_span_name)
 
 #     # THEN
 #     array_headers = list(ideaunit_format.columns)
 #     assert array_headers == get_spanref(x_span_name).get_headers_list()
 #     assert len(ideaunit_format) == 252
+
+
+def test_save_span_csv_Arg_jaar_format_00001_acct_v0_0_0_SaveToCSV():
+    # ESTABLISH
+    sue_text = sue_str()
+    bob_text = bob_str()
+    yao_text = yao_str()
+    sue_credit_score = 11
+    bob_credit_score = 13
+    yao_credit_score = 41
+    sue_debtit_score = 23
+    bob_debtit_score = 29
+    yao_debtit_score = 37
+    music_real_id = "music56"
+    sue_budunit = budunit_shop(sue_text, music_real_id)
+    sue_budunit.add_acctunit(sue_text, sue_credit_score, sue_debtit_score)
+    sue_budunit.add_acctunit(bob_text, bob_credit_score, bob_debtit_score)
+    sue_budunit.add_acctunit(yao_text, yao_credit_score, yao_debtit_score)
+    j1_spanname = jaar_format_00001_acct_v0_0_0()
+    acct_filename = f"{sue_text}_acct_example_00.csv"
+    csv_example_path = f"{span_examples_dir()}/{acct_filename}"
+    print(f"{csv_example_path}")
+    delete_dir(csv_example_path)
+    assert not os_path_exists(csv_example_path)
+
+    # WHEN
+    save_span_csv(j1_spanname, sue_budunit, span_examples_dir(), acct_filename)
+
+    # THEN
+    assert os_path_exists(csv_example_path)
+    sue_acct_example_csv = """real_id,owner_id,acct_id,credit_score,debtit_score
+music56,Sue,Bob,13,29
+music56,Sue,Sue,11,23
+music56,Sue,Yao,41,37
+"""
+    assert open_file(span_examples_dir(), acct_filename) == sue_acct_example_csv

--- a/src/span/test_span/test_span_format_import.py
+++ b/src/span/test_span/test_span_format_import.py
@@ -1,11 +1,12 @@
+from src._instrument.file import delete_dir, open_file
 from src._road.jaar_refer import sue_str, bob_str, yao_str
 from src.bud.idea import ideaunit_shop
 from src.bud.bud import budunit_shop
-from src.gift.span import (
+from src.span.span import (
     jaar_format_00001_acct_v0_0_0,
     jaar_format_00002_membership_v0_0_0,
     jaar_format_00003_ideaunit_v0_0_0,
-    create_span,
+    create_span_df,
     real_id_str,
     owner_id_str,
     acct_id_str,
@@ -19,11 +20,13 @@ from src.gift.span import (
     debtit_vote_str,
     credit_vote_str,
     get_spanref,
+    save_span_csv,
 )
-from src.bud.examples.example_buds import budunit_v001
+from src.span.examples.span_env import span_examples_dir, span_reals_dir
+from os.path import exists as os_path_exists
 
 
-# def test_create_span_Arg_jaar_format_00001_acct_v0_0_0():
+# def test_save_span_csv_Arg_jaar_format_00001_acct_v0_0_0_SaveToCSV():
 #     # ESTABLISH
 #     sue_text = sue_str()
 #     bob_text = bob_str()
@@ -39,37 +42,32 @@ from src.bud.examples.example_buds import budunit_v001
 #     sue_budunit.add_acctunit(sue_text, sue_credit_score, sue_debtit_score)
 #     sue_budunit.add_acctunit(bob_text, bob_credit_score, bob_debtit_score)
 #     sue_budunit.add_acctunit(yao_text, yao_credit_score, yao_debtit_score)
+#     j1_spanname = jaar_format_00001_acct_v0_0_0()
+#     acct_filename = f"{sue_text}_acct_example_00.csv"
+#     csv_example_path = f"{span_examples_dir()}/{acct_filename}"
+#     print(f"{csv_example_path}")
+#     delete_dir(csv_example_path)
+#     save_span_csv(j1_spanname, sue_budunit, span_examples_dir(), acct_filename)
+#     x_span_real_id = span_reals_dir()
+
+#     # acct_dataframe.to_csv(csv_example_path, index=False)
 
 #     # WHEN
-#     x_span_name = jaar_format_00001_acct_v0_0_0()
-#     acct_dataframe = create_span(sue_budunit, x_span_name)
+#     open_span_csv(, span_examples_dir(), acct_filename)
 
 #     # THEN
-#     array_headers = list(acct_dataframe.columns)
-#     acct_spanref = get_spanref(x_span_name)
-#     assert array_headers == acct_spanref.get_headers_list()
-#     assert acct_dataframe.loc[0, real_id_str()] == music_real_id
-#     assert acct_dataframe.loc[0, owner_id_str()] == sue_budunit._owner_id
-#     assert acct_dataframe.loc[0, acct_id_str()] == bob_text
-#     assert acct_dataframe.loc[0, credit_score_str()] == bob_credit_score
-#     assert acct_dataframe.loc[0, debtit_score_str()] == bob_debtit_score
+#     assert os_path_exists(csv_example_path)
+#     sue_acct_example_csv = """real_id,owner_id,acct_id,credit_score,debtit_score
+# music56,Sue,Bob,13,29
+# music56,Sue,Sue,11,23
+# music56,Sue,Yao,41,37
+# """
+#     assert open_file(span_examples_dir(), acct_filename) == sue_acct_example_csv
 
-#     assert acct_dataframe.loc[1, real_id_str()] == music_real_id
-#     assert acct_dataframe.loc[1, owner_id_str()] == sue_budunit._owner_id
-#     assert acct_dataframe.loc[1, acct_id_str()] == sue_text
-#     assert acct_dataframe.loc[1, credit_score_str()] == sue_credit_score
-#     assert acct_dataframe.loc[1, debtit_score_str()] == sue_debtit_score
-
-#     assert acct_dataframe.loc[2, real_id_str()] == music_real_id
-#     assert acct_dataframe.loc[2, owner_id_str()] == sue_budunit._owner_id
-#     assert acct_dataframe.loc[2, acct_id_str()] == yao_text
-#     assert acct_dataframe.loc[2, credit_score_str()] == yao_credit_score
-#     assert acct_dataframe.loc[2, debtit_score_str()] == yao_debtit_score
-
-#     assert len(acct_dataframe) == 3
+#     assert 1 == 2
 
 
-# def test_create_span_Arg_jaar_format_00002_membership_v0_0_0():
+# def test_create_span_df_Arg_jaar_format_00002_membership_v0_0_0():
 #     # ESTABLISH
 #     sue_text = sue_str()
 #     bob_text = bob_str()
@@ -99,7 +97,7 @@ from src.bud.examples.example_buds import budunit_v001
 
 #     # WHEN
 #     x_span_name = jaar_format_00002_membership_v0_0_0()
-#     membership_dataframe = create_span(sue_budunit, x_span_name)
+#     membership_dataframe = create_span_df(sue_budunit, x_span_name)
 
 #     # THEN
 #     array_headers = list(membership_dataframe.columns)
@@ -136,7 +134,7 @@ from src.bud.examples.example_buds import budunit_v001
 #     assert len(membership_dataframe) == 7
 
 
-# def test_create_span_Arg_jaar_format_00003_ideaunit_v0_0_0():
+# def test_create_span_df_Arg_jaar_format_00003_ideaunit_v0_0_0():
 #     # ESTABLISH
 #     sue_text = sue_str()
 #     bob_text = bob_str()
@@ -152,7 +150,7 @@ from src.bud.examples.example_buds import budunit_v001
 
 #     # WHEN
 #     x_span_name = jaar_format_00003_ideaunit_v0_0_0()
-#     ideaunit_format = create_span(sue_budunit, x_span_name)
+#     ideaunit_format = create_span_df(sue_budunit, x_span_name)
 
 #     # THEN
 #     array_headers = list(ideaunit_format.columns)
@@ -174,12 +172,12 @@ from src.bud.examples.example_buds import budunit_v001
 #     assert len(ideaunit_format) == 2
 
 
-# def test_create_span_Arg_jaar_format_00003_ideaunit_v0_0_0_Scenario_budunit_v001():
+# def test_create_span_df_Arg_jaar_format_00003_ideaunit_v0_0_0_Scenario_budunit_v001():
 #     # ESTABLISH / WHEN
 #     x_span_name = jaar_format_00003_ideaunit_v0_0_0()
 
 #     # WHEN
-#     ideaunit_format = create_span(budunit_v001(), x_span_name)
+#     ideaunit_format = create_span_df(budunit_v001(), x_span_name)
 
 #     # THEN
 #     array_headers = list(ideaunit_format.columns)


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces a new feature to save span dataframes to CSV files, enhances function names for better clarity, and updates the test suite accordingly. It also adds new utility functions for managing span example directories and paths.

- **New Features**:
    - Introduced `save_span_csv` function to save span dataframes to CSV files.
    - Added `span_env.py` to manage span example directories and paths.
    - Added `test_env.py` to test the new span environment functions.
- **Enhancements**:
    - Renamed `create_span` to `create_span_df` for better clarity.
    - Renamed `create_span_dataframe` to `_generate_span_dataframe` to indicate its internal use.
    - Updated test cases to reflect the new function names and added a new test for saving span dataframes to CSV.
- **Tests**:
    - Added tests for the new `save_span_csv` function.
    - Commented out some tests to reduce testing time.
    - Removed redundant tests and assertions in `test_bud_json.py` and `test_acct_membership.py`.

<!-- Generated by sourcery-ai[bot]: end summary -->