### PR TITLE
closes #298 stone with multiple categorys

### DIFF
--- a/src/gift/atom.py
+++ b/src/gift/atom.py
@@ -711,6 +711,8 @@ class AtomRow:
                     self.__dict__[x_arg] = int(x_value)
                 elif python_type == "float":
                     self.__dict__[x_arg] = float(x_value)
+        if self.label != None and self.parent_road != None and self.road == None:
+            self.road = create_road(self.parent_road, self.label)
 
     def get_atomunits(self) -> list[AtomUnit]:
         self._set_python_types()

--- a/src/gift/test_atom/test_atom_row.py
+++ b/src/gift/test_atom/test_atom_row.py
@@ -1,7 +1,9 @@
+from src._road.road import create_road
 from src.gift.atom_config import (
     bud_acctunit_text,
     bud_acct_membership_text,
     bud_ideaunit_text,
+    bud_idea_healerhold_text,
     atom_insert,
     atom_delete,
     acct_id_str,
@@ -115,7 +117,7 @@ def test_AtomRow_delete_atom_category_SetsAttr():
 
 def test_AtomRow_set_python_types_SetsAttr():
     # ESTABLISH
-    x_atomrow = atomrow_shop({bud_acctunit_text()}, atom_insert())
+    x_atomrow = atomrow_shop({}, atom_insert())
     x_atomrow.close = "4"
     x_parent_road = "fizz_buzz"
     x_label = "buzzziy"
@@ -132,6 +134,7 @@ def test_AtomRow_set_python_types_SetsAttr():
     assert x_atomrow.label == x_label
     assert x_atomrow.monetary_desc == x_monetary_desc
     assert x_atomrow.morph == x_morph_text
+    assert not x_atomrow.road
 
     # WHEN
     x_atomrow._set_python_types()
@@ -142,6 +145,7 @@ def test_AtomRow_set_python_types_SetsAttr():
     assert x_atomrow.label == x_label
     assert x_atomrow.monetary_desc == x_monetary_desc
     assert x_atomrow.morph == x_morph_bool
+    assert x_atomrow.road == create_road(x_parent_road, x_label)
 
 
 def test_AtomRow_get_atomunits_ReturnsObj_bud_acctunit_text_INSERT_Scenario0():
@@ -244,3 +248,28 @@ def test_AtomRow_get_atomunits_ReturnsObj_bud_ideaunit_INSERT_pledge_False():
     static_atomunit.set_arg("label", "casa")
     static_atomunit.set_arg("pledge", False)
     assert x_atomunit == static_atomunit
+
+
+def test_AtomRow_get_atomunits_ReturnsObj_bud_ideaunit_INSERT_pledge_False():
+    # ESTABLISH
+    x_categorys = {bud_ideaunit_text(), bud_idea_healerhold_text()}
+    x_atomrow = atomrow_shop(x_categorys, atom_insert())
+    x_atomrow.parent_road = "music78"
+    x_atomrow.label = "casa"
+    x_atomrow.pledge = False
+    x_atomrow.healer_id = "Bob"
+
+    # WHEN / THEN
+    x_atomunits = x_atomrow.get_atomunits()
+
+    # THEN
+    assert len(x_atomunits) == 2
+    y_idea_atomunit = atomunit_shop(bud_ideaunit_text(), atom_insert())
+    y_idea_atomunit.set_arg("parent_road", "music78")
+    y_idea_atomunit.set_arg("label", "casa")
+    y_idea_atomunit.set_arg("pledge", False)
+    assert y_idea_atomunit in x_atomunits
+    healerhold_atomunit = atomunit_shop(bud_idea_healerhold_text(), atom_insert())
+    healerhold_atomunit.set_arg("road", "music78;casa")
+    healerhold_atomunit.set_arg("healer_id", "Bob")
+    assert healerhold_atomunit in x_atomunits

--- a/src/stone/stone_config.py
+++ b/src/stone/stone_config.py
@@ -60,6 +60,10 @@ def stone_format_00019_ideaunit_v0_0_0() -> str:
     return "stone_format_00019_ideaunit_v0_0_0"
 
 
+def stone_format_00036_problem_healer_v0_0_0() -> str:
+    return "stone_format_00036_problem_healer_v0_0_0"
+
+
 # def stone_format_00020_bud_acct_membership_v0_0_0()-> str: return "stone_format_00020_bud_acct_membership_v0_0_0"
 # def stone_format_00021_bud_acctunit_v0_0_0()-> str: return "stone_format_00021_bud_acctunit_v0_0_0"
 # def stone_format_00022_bud_idea_awardlink_v0_0_0()-> str: return "stone_format_00022_bud_idea_awardlink_v0_0_0"
@@ -126,6 +130,7 @@ def get_stone_filenames() -> set[str]:
         stone_format_00027_bud_idea_reasonunit_v0_0_0(),
         stone_format_00028_bud_ideaunit_v0_0_0(),
         stone_format_00029_budunit_v0_0_0(),
+        stone_format_00036_problem_healer_v0_0_0(),
     }
 
 
@@ -145,6 +150,7 @@ def get_stone_format_headers() -> dict[str, list[str]]:
         "base,base_idea_active_requisite,owner_id,real_id,road": stone_format_00027_bud_idea_reasonunit_v0_0_0(),
         "addin,begin,close,denom,gogo_want,label,mass,morph,numor,owner_id,parent_road,pledge,problem_bool,real_id,stop_want": stone_format_00028_bud_ideaunit_v0_0_0(),
         "bit,credor_respect,debtor_respect,fund_coin,fund_pool,max_tree_traverse,monetary_desc,owner_id,penny,real_id,tally": stone_format_00029_budunit_v0_0_0(),
+        "healer_id,label,owner_id,parent_road,problem_bool,real_id": stone_format_00036_problem_healer_v0_0_0(),
     }
 
 

--- a/src/stone/stone_formats/stone_format_00036_problem_healer_v0_0_0.json
+++ b/src/stone/stone_formats/stone_format_00036_problem_healer_v0_0_0.json
@@ -1,0 +1,28 @@
+{
+    "atom_categorys": ["bud_ideaunit", "bud_idea_healerhold"],
+    "attributes": {
+        "label": {
+            "column_order": 3,
+            "sort_order": 3
+        },
+        "parent_road": {
+            "column_order": 2,
+            "sort_order": 2
+        },
+        "owner_id": {
+            "column_order": 1,
+            "sort_order": 1
+        },
+        "problem_bool": {
+            "column_order": 6
+        },
+        "real_id": {
+            "column_order": 0,
+            "sort_order": 0
+        },
+        "healer_id": {
+            "column_order": 3,
+            "sort_order": 3
+        }
+    }
+}

--- a/src/stone/test_stone/test_stone_format_config.py
+++ b/src/stone/test_stone/test_stone_format_config.py
@@ -141,10 +141,10 @@ def test_get_stone_format_headers_ReturnsObj():
 
     # THEN
     # print(f"{set(get_stone_format_headers().values())=}")
-    assert len(x_headers) == len(get_stone_filenames())
-    assert set(x_headers.values()) == get_stone_filenames()
     for x_stone_filename in get_stone_filenames():
         check_sorted_headers_exist(x_stone_filename, x_headers)
+    assert len(x_headers) == len(get_stone_filenames())
+    assert set(x_headers.values()) == get_stone_filenames()
 
 
 def test__generate_stone_dataframe_ReturnsCorrectObj():

--- a/src/stone/test_stone/test_stone_format_generate_stone.py
+++ b/src/stone/test_stone/test_stone_format_generate_stone.py
@@ -195,3 +195,41 @@ def test_create_stone_df_Arg_stone_format_00003_ideaunit_v0_0_0_Scenario_budunit
         array_headers = list(ideaunit_format.columns)
         assert array_headers == get_stoneref(x_stone_name).get_headers_list()
         assert len(ideaunit_format) == 251
+
+
+def test_create_changeunit_Arg_stone_format_00003_ideaunit_v0_0_0():
+    # ESTABLISH
+    sue_text = sue_str()
+    bob_text = bob_str()
+    music_real_id = "music56"
+    sue_budunit = budunit_shop(sue_text, music_real_id)
+    casa_text = "casa"
+    casa_road = sue_budunit.make_l1_road(casa_text)
+    casa_mass = 31
+    sue_budunit.set_l1_idea(ideaunit_shop(casa_text, _mass=casa_mass))
+    clean_text = "clean"
+    clean_road = sue_budunit.make_road(casa_road, clean_text)
+    sue_budunit.set_idea(ideaunit_shop(clean_text, pledge=True), casa_road)
+    x_stone_name = stone_format_00003_ideaunit_v0_0_0()
+    ideaunit_dataframe = create_stone_df(sue_budunit, x_stone_name)
+    ideaunit_csv = ideaunit_dataframe.to_csv(index=False)
+
+    # WHEN
+    ideaunit_changunit = create_changeunit(ideaunit_csv)
+
+    # THEN
+    casa_atomunit = atomunit_shop(bud_ideaunit_text(), atom_insert())
+    casa_atomunit.set_arg(parent_road_str(), sue_budunit._real_id)
+    casa_atomunit.set_arg(label_str(), casa_text)
+    casa_atomunit.set_arg(pledge_str(), False)
+    casa_atomunit.set_arg(mass_str(), casa_mass)
+    print(f"{casa_atomunit=}")
+    assert casa_atomunit.get_value(mass_str()) == casa_mass
+    clean_atomunit = atomunit_shop(bud_ideaunit_text(), atom_insert())
+    clean_atomunit.set_arg(parent_road_str(), casa_road)
+    clean_atomunit.set_arg(label_str(), clean_text)
+    clean_atomunit.set_arg(pledge_str(), True)
+    clean_atomunit.set_arg(mass_str(), 1)
+    assert ideaunit_changunit.atomunit_exists(casa_atomunit)
+    assert ideaunit_changunit.atomunit_exists(clean_atomunit)
+    assert len(ideaunit_changunit.get_ordered_atomunits()) == 2


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a new stone format 'stone_format_00036_problem_healer_v0_0_0' and its configuration. Enhance the '_set_python_types' method to handle road creation. Introduce new tests to verify change unit creation and atom unit retrieval with multiple categories.

New Features:
- Introduce a new stone format 'stone_format_00036_problem_healer_v0_0_0' with associated JSON configuration defining its attributes and atom categories.

Enhancements:
- Add logic in the '_set_python_types' method to automatically create a road if both label and parent_road are set but road is not.

Tests:
- Add a new test 'test_create_changeunit_Arg_stone_format_00003_ideaunit_v0_0_0' to verify the creation of change units from a CSV representation of idea units.
- Add a new test 'test_AtomRow_get_atomunits_ReturnsObj_bud_ideaunit_INSERT_pledge_False' to ensure correct retrieval of atom units with multiple categories.

<!-- Generated by sourcery-ai[bot]: end summary -->