### PR TITLE
175 enable documentation process

### DIFF
--- a/src/f7_fiscal/examples/music23.json
+++ b/src/f7_fiscal/examples/music23.json
@@ -56,7 +56,7 @@
         "yr1_jan1_offset": 440640
     },
     "current_time": 23,
-    "bud_history": {
+    "outlaylogs": {
         "Bob": {
             "owner_id": "Bob",
             "episodes": {"702": {"timestamp": 702, "money_magnitude": 33}}

--- a/src/f7_fiscal/fiscal.py
+++ b/src/f7_fiscal/fiscal.py
@@ -51,7 +51,7 @@ class FiscalUnit:
     fiscals_dir: str
     timeline: TimeLineUnit = None
     current_time: int = None
-    bud_history: dict[OwnerID, OutlayLog] = None
+    outlaylogs: dict[OwnerID, OutlayLog] = None
     _fiscal_dir: str = None
     _owners_dir: str = None
     _journal_db: str = None
@@ -223,18 +223,18 @@ class FiscalUnit:
     def get_final_file_bud(self, owner_id: OwnerID) -> BudUnit:
         return self._get_hubunit(owner_id).get_final_bud()
 
-    # bud_history
+    # outlaylogs
     def set_outlaylog(self, x_outlaylog: OutlayLog):
-        self.bud_history[x_outlaylog.owner_id] = x_outlaylog
+        self.outlaylogs[x_outlaylog.owner_id] = x_outlaylog
 
     def outlaylog_exists(self, x_owner_id: OwnerID) -> bool:
-        return self.bud_history.get(x_owner_id) != None
+        return self.outlaylogs.get(x_owner_id) != None
 
     def get_outlaylog(self, x_owner_id: OwnerID) -> OutlayLog:
-        return self.bud_history.get(x_owner_id)
+        return self.outlaylogs.get(x_owner_id)
 
     def del_outlaylog(self, x_owner_id: OwnerID):
-        self.bud_history.pop(x_owner_id)
+        self.outlaylogs.pop(x_owner_id)
 
     def add_outlaylog(
         self, x_owner_id: OwnerID, x_timestamp: TimeLinePoint, x_money_magnitude: int
@@ -249,7 +249,7 @@ class FiscalUnit:
             "fiscal_id": self.fiscal_id,
             "timeline": self.timeline.get_dict(),
             "current_time": self.current_time,
-            "bud_history": self._get_bud_history_dict(),
+            "outlaylogs": self._get_outlaylogs_dict(),
             "road_delimiter": self._road_delimiter,
             "fund_coin": self._fund_coin,
             "respect_bit": self._respect_bit,
@@ -259,10 +259,10 @@ class FiscalUnit:
     def get_json(self) -> str:
         return get_json_from_dict(self.get_dict())
 
-    def _get_bud_history_dict(self):
+    def _get_outlaylogs_dict(self):
         return {
             x_episode.owner_id: x_episode.get_dict()
-            for x_episode in self.bud_history.values()
+            for x_episode in self.outlaylogs.values()
         }
 
 
@@ -284,7 +284,7 @@ def fiscalunit_shop(
         fiscals_dir=fiscals_dir,
         timeline=timeline,
         current_time=get_0_if_None(current_time),
-        bud_history={},
+        outlaylogs={},
         _road_delimiter=default_road_delimiter_if_none(_road_delimiter),
         _fund_coin=default_respect_bit_if_none(_fund_coin),
         _respect_bit=default_respect_bit_if_none(_respect_bit),
@@ -308,12 +308,12 @@ def get_from_dict(fiscal_dict: dict) -> FiscalUnit:
     x_fiscal._fund_coin = fiscal_dict.get("fund_coin")
     x_fiscal._respect_bit = fiscal_dict.get("respect_bit")
     x_fiscal._penny = fiscal_dict.get("penny")
-    x_fiscal.bud_history = _get_bud_history_from_dict(fiscal_dict.get("bud_history"))
+    x_fiscal.outlaylogs = _get_outlaylogs_from_dict(fiscal_dict.get("outlaylogs"))
     return x_fiscal
 
 
-def _get_bud_history_from_dict(bud_history_dict: dict) -> dict[OwnerID, OutlayLog]:
+def _get_outlaylogs_from_dict(outlaylogs_dict: dict) -> dict[OwnerID, OutlayLog]:
     return {
         x_owner_id: get_outlaylog_from_dict(outlaylog_dict)
-        for x_owner_id, outlaylog_dict in bud_history_dict.items()
+        for x_owner_id, outlaylog_dict in outlaylogs_dict.items()
     }

--- a/src/f7_fiscal/fiscal.py
+++ b/src/f7_fiscal/fiscal.py
@@ -52,14 +52,14 @@ class FiscalUnit:
     timeline: TimeLineUnit = None
     current_time: int = None
     outlaylogs: dict[OwnerID, OutlayLog] = None
+    road_delimiter: str = None
+    fund_coin: FundCoin = None
+    respect_bit: BitNum = None
+    penny: PennyNum = None
     _fiscal_dir: str = None
     _owners_dir: str = None
     _journal_db: str = None
     _gifts_dir: str = None
-    _road_delimiter: str = None
-    _fund_coin: FundCoin = None
-    _respect_bit: BitNum = None
-    _penny: PennyNum = None
 
     # directory setup
     def _set_fiscal_dirs(self, in_memory_journal: bool = None):
@@ -86,8 +86,8 @@ class FiscalUnit:
                 fiscal_id=self.fiscal_id,
                 owner_id=x_owner_id,
                 keep_road=None,
-                road_delimiter=self._road_delimiter,
-                respect_bit=self._respect_bit,
+                road_delimiter=self.road_delimiter,
+                respect_bit=self.respect_bit,
             )
             for x_owner_id in x_owner_ids
         }
@@ -133,8 +133,8 @@ class FiscalUnit:
             fiscal_id=self.fiscal_id,
             fiscals_dir=self.fiscals_dir,
             keep_road=None,
-            road_delimiter=self._road_delimiter,
-            respect_bit=self._respect_bit,
+            road_delimiter=self.road_delimiter,
+            respect_bit=self.respect_bit,
         )
 
     def init_owner_keeps(self, owner_id: OwnerID):
@@ -155,8 +155,8 @@ class FiscalUnit:
                 healer_id,
                 keep_road=None,
                 # "duty_job",
-                road_delimiter=self._road_delimiter,
-                respect_bit=self._respect_bit,
+                road_delimiter=self.road_delimiter,
+                respect_bit=self.respect_bit,
             )
             for keep_road in healer_dict.keys():
                 self._set_owner_duty(healer_hubunit, keep_road, x_voice)
@@ -184,8 +184,8 @@ class FiscalUnit:
                 owner_id=healer_id,
                 keep_road=None,
                 # "duty_job",
-                road_delimiter=self._road_delimiter,
-                respect_bit=self._respect_bit,
+                road_delimiter=self.road_delimiter,
+                respect_bit=self.respect_bit,
             )
             healer_hubunit.create_voice_treasury_db_files()
             for keep_road in healer_dict.keys():
@@ -195,8 +195,8 @@ class FiscalUnit:
                     owner_id=healer_id,
                     keep_road=keep_road,
                     # "duty_job",
-                    road_delimiter=self._road_delimiter,
-                    respect_bit=self._respect_bit,
+                    road_delimiter=self.road_delimiter,
+                    respect_bit=self.respect_bit,
                 )
                 keep_hubunit.save_duty_bud(x_voice)
                 create_job_file_from_duty_file(keep_hubunit, owner_id)
@@ -250,10 +250,10 @@ class FiscalUnit:
             "timeline": self.timeline.get_dict(),
             "current_time": self.current_time,
             "outlaylogs": self._get_outlaylogs_dict(),
-            "road_delimiter": self._road_delimiter,
-            "fund_coin": self._fund_coin,
-            "respect_bit": self._respect_bit,
-            "penny": self._penny,
+            "road_delimiter": self.road_delimiter,
+            "fund_coin": self.fund_coin,
+            "respect_bit": self.respect_bit,
+            "penny": self.penny,
         }
 
     def get_json(self) -> str:
@@ -272,10 +272,10 @@ def fiscalunit_shop(
     timeline: TimeLineUnit = None,
     current_time: int = None,
     in_memory_journal: bool = None,
-    _road_delimiter: str = None,
-    _fund_coin: float = None,
-    _respect_bit: float = None,
-    _penny: float = None,
+    road_delimiter: str = None,
+    fund_coin: float = None,
+    respect_bit: float = None,
+    penny: float = None,
 ) -> FiscalUnit:
     if timeline is None:
         timeline = timelineunit_shop()
@@ -285,10 +285,10 @@ def fiscalunit_shop(
         timeline=timeline,
         current_time=get_0_if_None(current_time),
         outlaylogs={},
-        _road_delimiter=default_road_delimiter_if_none(_road_delimiter),
-        _fund_coin=default_respect_bit_if_none(_fund_coin),
-        _respect_bit=default_respect_bit_if_none(_respect_bit),
-        _penny=default_penny_if_none(_penny),
+        road_delimiter=default_road_delimiter_if_none(road_delimiter),
+        fund_coin=default_respect_bit_if_none(fund_coin),
+        respect_bit=default_respect_bit_if_none(respect_bit),
+        penny=default_penny_if_none(penny),
     )
     if fiscal_x.fiscals_dir is not None:
         fiscal_x._set_fiscal_dirs(in_memory_journal=in_memory_journal)
@@ -304,10 +304,10 @@ def get_from_dict(fiscal_dict: dict) -> FiscalUnit:
     x_fiscal = fiscalunit_shop(x_fiscal_id, None)
     x_fiscal.timeline = timelineunit_shop(fiscal_dict.get("timeline"))
     x_fiscal.current_time = fiscal_dict.get("current_time")
-    x_fiscal._road_delimiter = fiscal_dict.get("road_delimiter")
-    x_fiscal._fund_coin = fiscal_dict.get("fund_coin")
-    x_fiscal._respect_bit = fiscal_dict.get("respect_bit")
-    x_fiscal._penny = fiscal_dict.get("penny")
+    x_fiscal.road_delimiter = fiscal_dict.get("road_delimiter")
+    x_fiscal.fund_coin = fiscal_dict.get("fund_coin")
+    x_fiscal.respect_bit = fiscal_dict.get("respect_bit")
+    x_fiscal.penny = fiscal_dict.get("penny")
     x_fiscal.outlaylogs = _get_outlaylogs_from_dict(fiscal_dict.get("outlaylogs"))
     return x_fiscal
 

--- a/src/f7_fiscal/test_fiscal_/test_fiscal_.py
+++ b/src/f7_fiscal/test_fiscal_/test_fiscal_.py
@@ -24,7 +24,7 @@ def test_FiscalUnit_Exists(env_dir_setup_cleanup):
     assert music_fiscal.fiscal_id == music_str
     assert not music_fiscal.timeline
     assert not music_fiscal.current_time
-    assert not music_fiscal.bud_history
+    assert not music_fiscal.outlaylogs
     assert music_fiscal.fiscals_dir == get_test_fiscals_dir()
     assert not music_fiscal._owners_dir
     assert not music_fiscal._journal_db
@@ -46,7 +46,7 @@ def test_fiscalunit_shop_ReturnsFiscalUnit():
     assert music_fiscal.fiscal_id == music_str
     assert music_fiscal.timeline == timelineunit_shop()
     assert music_fiscal.current_time == 0
-    assert music_fiscal.bud_history == {}
+    assert music_fiscal.outlaylogs == {}
     assert music_fiscal.fiscals_dir is None
     assert music_fiscal._owners_dir is None
     assert music_fiscal._gifts_dir is None

--- a/src/f7_fiscal/test_fiscal_/test_fiscal_.py
+++ b/src/f7_fiscal/test_fiscal_/test_fiscal_.py
@@ -25,14 +25,15 @@ def test_FiscalUnit_Exists(env_dir_setup_cleanup):
     assert not music_fiscal.timeline
     assert not music_fiscal.current_time
     assert not music_fiscal.outlaylogs
+    assert not music_fiscal.road_delimiter
+    assert not music_fiscal.fund_coin
+    assert not music_fiscal.respect_bit
+    assert not music_fiscal.penny
     assert music_fiscal.fiscals_dir == get_test_fiscals_dir()
+    # Calculated fields
     assert not music_fiscal._owners_dir
     assert not music_fiscal._journal_db
     assert not music_fiscal._gifts_dir
-    assert not music_fiscal._road_delimiter
-    assert not music_fiscal._fund_coin
-    assert not music_fiscal._respect_bit
-    assert not music_fiscal._penny
 
 
 def test_fiscalunit_shop_ReturnsFiscalUnit():
@@ -47,13 +48,14 @@ def test_fiscalunit_shop_ReturnsFiscalUnit():
     assert music_fiscal.timeline == timelineunit_shop()
     assert music_fiscal.current_time == 0
     assert music_fiscal.outlaylogs == {}
+    assert music_fiscal.road_delimiter == default_road_delimiter_if_none()
+    assert music_fiscal.fund_coin == default_fund_coin_if_none()
+    assert music_fiscal.respect_bit == default_respect_bit_if_none()
+    assert music_fiscal.penny == default_penny_if_none()
     assert music_fiscal.fiscals_dir is None
+    # Calculated fields
     assert music_fiscal._owners_dir is None
     assert music_fiscal._gifts_dir is None
-    assert music_fiscal._road_delimiter == default_road_delimiter_if_none()
-    assert music_fiscal._fund_coin == default_fund_coin_if_none()
-    assert music_fiscal._respect_bit == default_respect_bit_if_none()
-    assert music_fiscal._penny == default_penny_if_none()
 
 
 def test_fiscalunit_shop_ReturnsFiscalUnitWith_fiscals_dir(env_dir_setup_cleanup):
@@ -85,18 +87,18 @@ def test_fiscalunit_shop_ReturnsFiscalUnitWith_road_delimiter(env_dir_setup_clea
         fiscals_dir=get_test_fiscals_dir(),
         current_time=x_current_time,
         in_memory_journal=True,
-        _road_delimiter=slash_str,
-        _fund_coin=x_fund_coin,
-        _respect_bit=x_respect_bit,
-        _penny=x_penny,
+        road_delimiter=slash_str,
+        fund_coin=x_fund_coin,
+        respect_bit=x_respect_bit,
+        penny=x_penny,
     )
 
     # THEN
     assert music_fiscal.current_time == x_current_time
-    assert music_fiscal._road_delimiter == slash_str
-    assert music_fiscal._fund_coin == x_fund_coin
-    assert music_fiscal._respect_bit == x_respect_bit
-    assert music_fiscal._penny == x_penny
+    assert music_fiscal.road_delimiter == slash_str
+    assert music_fiscal.fund_coin == x_fund_coin
+    assert music_fiscal.respect_bit == x_respect_bit
+    assert music_fiscal.penny == x_penny
 
 
 def test_FiscalUnit_set_fiscal_dirs_SetsCorrectDirsAndFiles(env_dir_setup_cleanup):
@@ -156,9 +158,9 @@ def test_FiscalUnit_init_owner_keeps_CorrectlySetsDirAndFiles(env_dir_setup_clea
     music_fiscal = fiscalunit_shop(
         music_str,
         get_test_fiscals_dir(),
-        _road_delimiter=slash_str,
-        _fund_coin=x_fund_coin,
-        _respect_bit=x_respect_bit,
+        road_delimiter=slash_str,
+        fund_coin=x_fund_coin,
+        respect_bit=x_respect_bit,
         in_memory_journal=True,
     )
     sue_str = "Sue"
@@ -294,18 +296,18 @@ def test_FiscalUnit_get_owner_hubunits_ReturnsCorrectObj(env_dir_setup_cleanup):
         fiscal_id=music_fiscal.fiscal_id,
         owner_id=sue_str,
         keep_road=None,
-        road_delimiter=music_fiscal._road_delimiter,
-        fund_coin=music_fiscal._fund_coin,
-        respect_bit=music_fiscal._respect_bit,
+        road_delimiter=music_fiscal.road_delimiter,
+        fund_coin=music_fiscal.fund_coin,
+        respect_bit=music_fiscal.respect_bit,
     )
     yao_hubunit = hubunit_shop(
         fiscals_dir=music_fiscal.fiscals_dir,
         fiscal_id=music_fiscal.fiscal_id,
         owner_id=yao_str,
         keep_road=None,
-        road_delimiter=music_fiscal._road_delimiter,
-        fund_coin=music_fiscal._fund_coin,
-        respect_bit=music_fiscal._respect_bit,
+        road_delimiter=music_fiscal.road_delimiter,
+        fund_coin=music_fiscal.fund_coin,
+        respect_bit=music_fiscal.respect_bit,
     )
     assert music_all_owners.get(sue_str) == sue_hubunit
     assert music_all_owners.get(yao_str) == yao_hubunit

--- a/src/f7_fiscal/test_fiscal_/test_fiscal_bud_history.py
+++ b/src/f7_fiscal/test_fiscal_/test_fiscal_bud_history.py
@@ -7,7 +7,7 @@ def test_FiscalUnit_set_outlaylog_SetsAttr():
     # ESTABLISH
     music_str = "music"
     music_fiscal = fiscalunit_shop(music_str, get_test_fiscals_dir())
-    assert music_fiscal.bud_history == {}
+    assert music_fiscal.outlaylogs == {}
 
     # WHEN
     sue_str = "Sue"
@@ -15,8 +15,8 @@ def test_FiscalUnit_set_outlaylog_SetsAttr():
     music_fiscal.set_outlaylog(sue_outlaylog)
 
     # THEN
-    assert music_fiscal.bud_history != {}
-    assert music_fiscal.bud_history.get(sue_str) == sue_outlaylog
+    assert music_fiscal.outlaylogs != {}
+    assert music_fiscal.outlaylogs.get(sue_str) == sue_outlaylog
 
 
 def test_FiscalUnit_outlaylog_exists_ReturnsObj():
@@ -71,7 +71,7 @@ def test_FiscalUnit_add_outlaylog_SetsAttr():
     # ESTABLISH
     music_str = "music"
     music_fiscal = fiscalunit_shop(music_str, get_test_fiscals_dir())
-    assert music_fiscal.bud_history == {}
+    assert music_fiscal.outlaylogs == {}
 
     # WHEN
     bob_str = "Bob"
@@ -87,7 +87,7 @@ def test_FiscalUnit_add_outlaylog_SetsAttr():
     music_fiscal.add_outlaylog(sue_str, sue_x7_timestamp, sue_x7_magnitude)
 
     # THEN
-    assert music_fiscal.bud_history != {}
+    assert music_fiscal.outlaylogs != {}
     sue_outlaylog = outlaylog_shop(sue_str)
     sue_outlaylog.add_episode(sue_x4_timestamp, sue_x4_magnitude)
     sue_outlaylog.add_episode(sue_x7_timestamp, sue_x7_magnitude)

--- a/src/f7_fiscal/test_fiscal_/test_fiscal_json.py
+++ b/src/f7_fiscal/test_fiscal_/test_fiscal_json.py
@@ -106,10 +106,10 @@ def test_get_from_dict_ReturnsFiscalUnit():
     music_fiscal.add_outlaylog(sue_str, sue_x4_timestamp, sue_x4_magnitude)
     music_fiscal.add_outlaylog(sue_str, sue_x7_timestamp, sue_x7_magnitude)
     music_fiscal.current_time = sue_current_time
-    music_fiscal._road_delimiter = sue_road_delimiter
-    music_fiscal._fund_coin = sue_fund_coin
-    music_fiscal._respect_bit = sue_respect_bit
-    music_fiscal._penny = sue_penny
+    music_fiscal.road_delimiter = sue_road_delimiter
+    music_fiscal.fund_coin = sue_fund_coin
+    music_fiscal.respect_bit = sue_respect_bit
+    music_fiscal.penny = sue_penny
     x_dict = music_fiscal.get_dict()
 
     # WHEN
@@ -119,10 +119,10 @@ def test_get_from_dict_ReturnsFiscalUnit():
     assert x_fiscal.fiscal_id == music_str
     assert x_fiscal.timeline.timeline_label == sue_timeline_label
     assert x_fiscal.current_time == sue_current_time
-    assert x_fiscal._road_delimiter == sue_road_delimiter
-    assert x_fiscal._fund_coin == sue_fund_coin
-    assert x_fiscal._respect_bit == sue_respect_bit
-    assert x_fiscal._penny == sue_penny
+    assert x_fiscal.road_delimiter == sue_road_delimiter
+    assert x_fiscal.fund_coin == sue_fund_coin
+    assert x_fiscal.respect_bit == sue_respect_bit
+    assert x_fiscal.penny == sue_penny
     assert x_fiscal.outlaylogs == music_fiscal.outlaylogs
     assert x_fiscal.fiscals_dir == music_fiscal.fiscals_dir
     assert x_fiscal == music_fiscal
@@ -151,10 +151,10 @@ def test_get_from_json_ReturnsFiscalUnit():
     music_fiscal.add_outlaylog(sue_str, sue_x4_timestamp, sue_x4_magnitude)
     music_fiscal.add_outlaylog(sue_str, sue_x7_timestamp, sue_x7_magnitude)
     music_fiscal.current_time = sue_current_time
-    music_fiscal._road_delimiter = sue_road_delimiter
-    music_fiscal._fund_coin = sue_fund_coin
-    music_fiscal._respect_bit = sue_respect_bit
-    music_fiscal._penny = sue_penny
+    music_fiscal.road_delimiter = sue_road_delimiter
+    music_fiscal.fund_coin = sue_fund_coin
+    music_fiscal.respect_bit = sue_respect_bit
+    music_fiscal.penny = sue_penny
     music_json = music_fiscal.get_json()
 
     # WHEN
@@ -164,10 +164,10 @@ def test_get_from_json_ReturnsFiscalUnit():
     assert x_fiscal.fiscal_id == music_str
     assert x_fiscal.timeline.timeline_label == sue_timeline_label
     assert x_fiscal.current_time == sue_current_time
-    assert x_fiscal._road_delimiter == sue_road_delimiter
-    assert x_fiscal._fund_coin == sue_fund_coin
-    assert x_fiscal._respect_bit == sue_respect_bit
-    assert x_fiscal._penny == sue_penny
+    assert x_fiscal.road_delimiter == sue_road_delimiter
+    assert x_fiscal.fund_coin == sue_fund_coin
+    assert x_fiscal.respect_bit == sue_respect_bit
+    assert x_fiscal.penny == sue_penny
     assert x_fiscal.outlaylogs == music_fiscal.outlaylogs
     assert x_fiscal.fiscals_dir == music_fiscal.fiscals_dir
     assert x_fiscal == music_fiscal

--- a/src/f7_fiscal/test_fiscal_/test_fiscal_json.py
+++ b/src/f7_fiscal/test_fiscal_/test_fiscal_json.py
@@ -44,13 +44,13 @@ def test_FiscalUnit_get_dict_ReturnsObj():
     assert x_dict.get("fund_coin") == default_fund_coin_if_none()
     assert x_dict.get("respect_bit") == default_respect_bit_if_none()
     assert x_dict.get("penny") == default_penny_if_none()
-    assert x_dict.get("bud_history") == music_fiscal._get_bud_history_dict()
-    print(f"{ music_fiscal._get_bud_history_dict()=}")
+    assert x_dict.get("outlaylogs") == music_fiscal._get_outlaylogs_dict()
+    print(f"{ music_fiscal._get_outlaylogs_dict()=}")
     assert list(x_dict.keys()) == [
         "fiscal_id",
         "timeline",
         "current_time",
-        "bud_history",
+        "outlaylogs",
         "road_delimiter",
         "fund_coin",
         "respect_bit",
@@ -123,7 +123,7 @@ def test_get_from_dict_ReturnsFiscalUnit():
     assert x_fiscal._fund_coin == sue_fund_coin
     assert x_fiscal._respect_bit == sue_respect_bit
     assert x_fiscal._penny == sue_penny
-    assert x_fiscal.bud_history == music_fiscal.bud_history
+    assert x_fiscal.outlaylogs == music_fiscal.outlaylogs
     assert x_fiscal.fiscals_dir == music_fiscal.fiscals_dir
     assert x_fiscal == music_fiscal
 
@@ -168,6 +168,6 @@ def test_get_from_json_ReturnsFiscalUnit():
     assert x_fiscal._fund_coin == sue_fund_coin
     assert x_fiscal._respect_bit == sue_respect_bit
     assert x_fiscal._penny == sue_penny
-    assert x_fiscal.bud_history == music_fiscal.bud_history
+    assert x_fiscal.outlaylogs == music_fiscal.outlaylogs
     assert x_fiscal.fiscals_dir == music_fiscal.fiscals_dir
     assert x_fiscal == music_fiscal


### PR DESCRIPTION
## Summary by Sourcery

Refactor the `FiscalUnit` class by renaming `bud_history` to `outlaylogs` and changing several private attributes to public. Update tests to align with these changes.

Enhancements:
- Refactor the `FiscalUnit` class by renaming the `bud_history` attribute to `outlaylogs` and updating related methods and references accordingly.
- Replace private attributes with public ones for `road_delimiter`, `fund_coin`, `respect_bit`, and `penny` in the `FiscalUnit` class to improve accessibility and consistency.

Tests:
- Update tests to reflect the renaming of `bud_history` to `outlaylogs` and the change from private to public attributes for `road_delimiter`, `fund_coin`, `respect_bit`, and `penny`.