### PR TITLE
#346 zoo_to_otx working

### DIFF
--- a/src/f00_instrument/db_toolbox.py
+++ b/src/f00_instrument/db_toolbox.py
@@ -211,7 +211,7 @@ def get_groupby_sql_query(
     return f"{_get_grouping_select_clause(group_by_columns, value_columns)} FROM {x_table} {_get_grouping_groupby_clause(group_by_columns)}"
 
 
-def get_consistent_values_sql_query(
+def get_grouping_with_all_values_equal_sql_query(
     x_table: str, group_by_columns: list[str], value_columns: list[str]
 ) -> str:
     return f"{_get_grouping_select_clause(group_by_columns, value_columns)} FROM {x_table} {_get_grouping_groupby_clause(group_by_columns)} {_get_having_equal_value_clause(value_columns)}"

--- a/src/f00_instrument/test/test_db_tool.py
+++ b/src/f00_instrument/test/test_db_tool.py
@@ -11,7 +11,7 @@ from src.f00_instrument.db_toolbox import (
     _get_grouping_select_clause,
     _get_grouping_groupby_clause,
     _get_having_equal_value_clause,
-    get_consistent_values_sql_query,
+    get_grouping_with_all_values_equal_sql_query,
     get_groupby_sql_query,
 )
 from pytest import raises as pytest_raises
@@ -270,7 +270,7 @@ def test_get_groupby_sql_query_ReturnsObj_Scenario0():
     assert gen_select_clause == example_str
 
 
-def test_get_consistent_values_sql_query_ReturnsObj_Scenario0():
+def test_get_grouping_with_all_values_equal_sql_query_ReturnsObj_Scenario0():
     # ESTABLISH
     fizz_str = "fizz"
     buzz_str = "buzz"
@@ -281,7 +281,7 @@ def test_get_consistent_values_sql_query_ReturnsObj_Scenario0():
     x_table_name = "fizzybuzzy"
 
     # WHEN
-    gen_select_clause = get_consistent_values_sql_query(
+    gen_select_clause = get_grouping_with_all_values_equal_sql_query(
         x_table_name, x_group_by_columns, x_value_columns
     )
 

--- a/src/f09_brick/brick_config.py
+++ b/src/f09_brick/brick_config.py
@@ -264,6 +264,14 @@ def get_brick_numbers() -> set[str]:
     }
 
 
+def get_brick_format_filename(brick_number: str) -> str:
+
+    brick_number_substring = brick_number[2:]
+    for brick_format_filename in get_brick_format_filenames():
+        if brick_format_filename[13:18] == brick_number_substring:
+            return brick_format_filename
+
+
 def get_brick_format_headers() -> dict[str, list[str]]:
     return {
         "c400_number,current_time,fiscal_id,fund_coin,monthday_distortion,penny,respect_bit,road_delimiter,timeline_label,yr1_jan1_offset": brick_format_00000_fiscalunit_v0_0_0(),
@@ -292,8 +300,8 @@ def get_brick_format_headers() -> dict[str, list[str]]:
     }
 
 
-def get_brickref_dict(brick_filename: str) -> dict:
-    brickref_filename = get_json_filename(brick_filename)
+def get_brickref_from_file(brick_format_filename: str) -> dict:
+    brickref_filename = get_json_filename(brick_format_filename)
     brickref_json = open_file(get_brick_formats_dir(), brickref_filename)
     return get_dict_from_json(brickref_json)
 
@@ -301,7 +309,7 @@ def get_brickref_dict(brick_filename: str) -> dict:
 def get_quick_bricks_column_ref() -> dict[str, set[str]]:
     brick_number_dict = {}
     for brick_format_filename in get_brick_format_filenames():
-        brickref_dict = get_brickref_dict(brick_format_filename)
+        brickref_dict = get_brickref_from_file(brick_format_filename)
         brick_number = brickref_dict.get("brick_number")
         brick_number_dict[brick_number] = set(brickref_dict.get("attributes").keys())
     return brick_number_dict

--- a/src/f09_brick/test_brick_config/test_brick_config_.py
+++ b/src/f09_brick/test_brick_config/test_brick_config_.py
@@ -123,12 +123,13 @@ from src.f09_brick.brick_config import (
     delete_update_str,
     build_order_str,
     get_allowed_curds,
-    get_brickref_dict,
+    get_brickref_from_file,
     get_quick_bricks_column_ref,
     config_file_dir,
     get_brick_config_file_name,
     get_brick_config_dict,
     get_brick_format_filenames,
+    get_brick_format_filename,
     get_brick_numbers,
     brick_format_00021_bud_acctunit_v0_0_0,
     brick_format_00020_bud_acct_membership_v0_0_0,
@@ -541,7 +542,7 @@ def _validate_brick_format_files(brick_filenames: set[str]):
     # for every brick_format file there exists a unique brick_number always with leading zeros to make 5 digits
     brick_numbers_set = set()
     for brick_filename in brick_filenames:
-        ref_dict = get_brickref_dict(brick_filename)
+        ref_dict = get_brickref_from_file(brick_filename)
         print(f"{brick_filename=} {ref_dict.get(brick_number_str())=}")
         brick_number_value = ref_dict.get(brick_number_str())
         assert brick_number_value
@@ -582,6 +583,26 @@ def _validate_brick_format_files(brick_filenames: set[str]):
     assert brick_numbers_set == get_brick_numbers()
 
     return True
+
+
+def test_get_brick_format_filename_ReturnsObj():
+    # ESTABLISH
+    br00021_str = "br00021"
+    br00020_str = "br00020"
+    br00013_str = "br00013"
+
+    # WHEN
+    br00021_filename = get_brick_format_filename(br00021_str)
+    br00020_filename = get_brick_format_filename(br00020_str)
+    br00013_filename = get_brick_format_filename(br00013_str)
+
+    # THEN
+    assert br00021_filename == brick_format_00021_bud_acctunit_v0_0_0()
+    assert br00020_filename == brick_format_00020_bud_acct_membership_v0_0_0()
+    assert br00013_filename == brick_format_00013_itemunit_v0_0_0()
+
+    all_set = {get_brick_format_filename(br) for br in get_brick_numbers()}
+    assert all_set == get_brick_format_filenames()
 
 
 def set_brick_config_json(category: str, build_order: int):

--- a/src/f09_brick/test_brick_config/test_pandas_tool.py
+++ b/src/f09_brick/test_brick_config/test_pandas_tool.py
@@ -22,7 +22,7 @@ from src.f09_brick.pandas_tool import (
     get_ordered_csv,
     get_all_excel_sheet_names,
     get_relevant_columns_dataframe,
-    get_groupby_dataframe,
+    get_grouping_with_all_values_equal_df,
 )
 from os.path import exists as os_path_exists
 from pandas import DataFrame, ExcelWriter
@@ -218,13 +218,13 @@ def test_get_relevant_columns_dataframe_ReturnsObj_Scenario4_ColumnOrderCorrect(
     assert relevant_dataframe.columns.to_list() == [acct_id_str(), group_id_str()]
 
 
-def test_get_groupby_dataframe_ReturnsObj_Scenario0_EmptyDataframe():
+def test_get_grouping_with_all_values_equal_df_ReturnsObj_Scenario0_EmptyDataframe():
     # ESTABLISH
     df1 = DataFrame([[]], columns=[])
     group_by_list = [group_id_str(), acct_id_str()]
 
     # WHEN
-    group_by_dataframe = get_groupby_dataframe(df1, group_by_list)
+    group_by_dataframe = get_grouping_with_all_values_equal_df(df1, group_by_list)
 
     # THEN
     assert group_by_dataframe is not None
@@ -233,7 +233,7 @@ def test_get_groupby_dataframe_ReturnsObj_Scenario0_EmptyDataframe():
     assert group_by_dataframe.columns.to_list() == []
 
 
-def test_get_groupby_dataframe_ReturnsObj_Scenario1_GroupBySingleColumn():
+def test_get_grouping_with_all_values_equal_df_ReturnsObj_Scenario1_GroupBySingleColumn():
     # ESTABLISH
     df_columns = [group_id_str(), credor_respect_str()]
     before_df_values = [["AA0", "BB0"], ["AA0", "BB0"]]
@@ -241,7 +241,7 @@ def test_get_groupby_dataframe_ReturnsObj_Scenario1_GroupBySingleColumn():
     group_by_list = [group_id_str()]
 
     # WHEN
-    group_by_dataframe = get_groupby_dataframe(df1, group_by_list)
+    group_by_dataframe = get_grouping_with_all_values_equal_df(df1, group_by_list)
     print(f"{group_by_dataframe=}")
 
     # THEN
@@ -254,7 +254,7 @@ def test_get_groupby_dataframe_ReturnsObj_Scenario1_GroupBySingleColumn():
     assert group_by_dataframe.to_csv() == after_df.to_csv()
 
 
-def test_get_groupby_dataframe_ReturnsObj_Scenario2_GroupByExtraColumns():
+def test_get_grouping_with_all_values_equal_df_ReturnsObj_Scenario2_GroupByExtraColumns():
     # ESTABLISH
     df_columns = [group_id_str(), credor_respect_str()]
     before_df_values = [["AA0", "BB0"], ["AA0", "BB0"]]
@@ -262,7 +262,7 @@ def test_get_groupby_dataframe_ReturnsObj_Scenario2_GroupByExtraColumns():
     group_by_list = [group_id_str(), acct_id_str()]
 
     # WHEN
-    group_by_dataframe = get_groupby_dataframe(df1, group_by_list)
+    group_by_dataframe = get_grouping_with_all_values_equal_df(df1, group_by_list)
     print(f"{group_by_dataframe=}")
 
     # THEN
@@ -275,7 +275,7 @@ def test_get_groupby_dataframe_ReturnsObj_Scenario2_GroupByExtraColumns():
     assert group_by_dataframe.to_csv() == after_df.to_csv()
 
 
-def test_get_groupby_dataframe_ReturnsObj_Scenario3_GroupByExtraColumns():
+def test_get_grouping_with_all_values_equal_df_ReturnsObj_Scenario3_GroupByExtraColumns():
     # ESTABLISH
     df_columns = [group_id_str(), credor_respect_str(), "column3"]
     before_df_values = [["AA0", "BB0", "CC0"], ["AA0", "BB0", "CC0"]]
@@ -283,7 +283,7 @@ def test_get_groupby_dataframe_ReturnsObj_Scenario3_GroupByExtraColumns():
     group_by_list = [group_id_str(), acct_id_str(), credor_respect_str()]
 
     # WHEN
-    group_by_dataframe = get_groupby_dataframe(df1, group_by_list)
+    group_by_dataframe = get_grouping_with_all_values_equal_df(df1, group_by_list)
     print(f"{group_by_dataframe=}")
 
     # THEN
@@ -296,7 +296,7 @@ def test_get_groupby_dataframe_ReturnsObj_Scenario3_GroupByExtraColumns():
     assert group_by_dataframe.to_csv() == after_df.to_csv()
 
 
-def test_get_groupby_dataframe_ReturnsObj_Scenario4_GroupByExtraColumns():
+def test_get_grouping_with_all_values_equal_df_ReturnsObj_Scenario4_GroupByExtraColumns():
     # ESTABLISH
     df_columns = [group_id_str(), credor_respect_str(), "column3"]
     before_df_values = [
@@ -308,7 +308,7 @@ def test_get_groupby_dataframe_ReturnsObj_Scenario4_GroupByExtraColumns():
     group_by_list = [group_id_str(), acct_id_str(), credor_respect_str()]
 
     # WHEN
-    group_by_dataframe = get_groupby_dataframe(df1, group_by_list)
+    group_by_dataframe = get_grouping_with_all_values_equal_df(df1, group_by_list)
     print(f"{group_by_dataframe=}")
 
     # THEN

--- a/src/f09_brick/test_brick_format/test_brick_column.py
+++ b/src/f09_brick/test_brick_format/test_brick_column.py
@@ -1,5 +1,5 @@
 from src.f02_bud.bud_tool import bud_acctunit_str
-from src.f04_gift.atom_config import acct_id_str, group_id_str, road_str
+from src.f04_gift.atom_config import acct_id_str, group_id_str, road_str, base_str
 from src.f09_brick.brick import BrickRef, brickref_shop
 
 
@@ -25,21 +25,21 @@ def test_brickref_shop_ReturnsObj():
     # THEN
     assert x_brickref.brick_name == x1_brick_name
     assert x_brickref.categorys == [bud_acctunit_str()]
-    assert x_brickref._attributes == set()
+    assert x_brickref._attributes == {}
 
 
 def test_BrickRef_set_attribute_SetsAttr():
     # ESTABLISH
     x_brickref = brickref_shop("0003", bud_acctunit_str())
     x_attribute = "1"
-    assert x_brickref._attributes == set()
+    assert x_brickref._attributes == {}
 
     # WHEN
-    x_brickref.set_attribute(x_attribute)
+    x_brickref.set_attribute(x_attribute, True)
 
     # THEN
-    assert x_brickref._attributes != set()
-    assert x_brickref._attributes == {x_attribute}
+    assert x_brickref._attributes != {}
+    assert x_brickref._attributes == {x_attribute: {"otx_key": True}}
 
 
 def test_BrickRef_get_headers_list_ReturnsObj_Scenario0():
@@ -58,7 +58,7 @@ def test_BrickRef_get_headers_list_ReturnsObj_Scenario1():
     # ESTABLISH
 
     x3_brickref = brickref_shop("0003", bud_acctunit_str())
-    x3_brickref.set_attribute(group_id_str())
+    x3_brickref.set_attribute(group_id_str(), True)
 
     # WHEN
     x_headers_list = x3_brickref.get_headers_list()
@@ -71,12 +71,91 @@ def test_BrickRef_get_headers_list_ReturnsObj_Scenario2():
     # ESTABLISH
 
     x3_brickref = brickref_shop("0003", bud_acctunit_str())
-    x3_brickref.set_attribute(road_str())
-    x3_brickref.set_attribute(group_id_str())
-    x3_brickref.set_attribute(acct_id_str())
+    x3_brickref.set_attribute(road_str(), True)
+    x3_brickref.set_attribute(group_id_str(), False)
+    x3_brickref.set_attribute(acct_id_str(), True)
 
     # WHEN
     x_headers_list = x3_brickref.get_headers_list()
 
     # THEN
     assert x_headers_list == [acct_id_str(), group_id_str(), road_str()]
+
+
+def test_BrickRef_get_otx_keys_list_ReturnsObj_Scenario0():
+    # ESTABLISH
+    x_brickref = brickref_shop("0003", bud_acctunit_str())
+
+    # WHEN
+    x_otx_keys_list = x_brickref.get_otx_keys_list()
+
+    # THEN
+    assert x_otx_keys_list == []
+
+
+def test_BrickRef_get_otx_keys_list_ReturnsObj_Scenario1():
+    # ESTABLISH
+
+    x3_brickref = brickref_shop("0003", bud_acctunit_str())
+    x3_brickref.set_attribute(group_id_str(), True)
+
+    # WHEN
+    x_otx_keys_list = x3_brickref.get_otx_keys_list()
+
+    # THEN
+    assert x_otx_keys_list == [group_id_str()]
+
+
+def test_BrickRef_get_otx_keys_list_ReturnsObj_Scenario2():
+    # ESTABLISH
+
+    x3_brickref = brickref_shop("0003", bud_acctunit_str())
+    x3_brickref.set_attribute(road_str(), True)
+    x3_brickref.set_attribute(group_id_str(), False)
+    x3_brickref.set_attribute(acct_id_str(), True)
+
+    # WHEN
+    x_otx_keys_list = x3_brickref.get_otx_keys_list()
+
+    # THEN
+    assert x_otx_keys_list == [acct_id_str(), road_str()]
+
+
+def test_BrickRef_get_otx_values_list_ReturnsObj_Scenario0():
+    # ESTABLISH
+    x_brickref = brickref_shop("0003", bud_acctunit_str())
+
+    # WHEN
+    x_otx_values_list = x_brickref.get_otx_values_list()
+
+    # THEN
+    assert x_otx_values_list == []
+
+
+def test_BrickRef_get_otx_values_list_ReturnsObj_Scenario1():
+    # ESTABLISH
+
+    x3_brickref = brickref_shop("0003", bud_acctunit_str())
+    x3_brickref.set_attribute(group_id_str(), True)
+
+    # WHEN
+    x_otx_values_list = x3_brickref.get_otx_values_list()
+
+    # THEN
+    assert x_otx_values_list == []
+
+
+def test_BrickRef_get_otx_values_list_ReturnsObj_Scenario2():
+    # ESTABLISH
+
+    x3_brickref = brickref_shop("0003", bud_acctunit_str())
+    x3_brickref.set_attribute(road_str(), True)
+    x3_brickref.set_attribute(group_id_str(), False)
+    x3_brickref.set_attribute(base_str(), False)
+    x3_brickref.set_attribute(acct_id_str(), False)
+
+    # WHEN
+    x_otx_values_list = x3_brickref.get_otx_values_list()
+
+    # THEN
+    assert x_otx_values_list == [acct_id_str(), group_id_str(), base_str()]

--- a/src/f09_brick/test_brick_format/test_brick_format_config.py
+++ b/src/f09_brick/test_brick_format/test_brick_format_config.py
@@ -28,13 +28,13 @@ from src.f04_gift.atom_config import (
 from src.f08_filter.filter_config import eon_id_str
 from src.f09_brick.brick import (
     _generate_brick_dataframe,
-    get_brickref,
+    get_brickref_obj,
     _get_headers_list,
 )
 from src.f09_brick.brick_config import (
     get_brick_formats_dir,
     get_brick_format_filenames,
-    get_brickref_dict,
+    get_brickref_from_file,
     brick_format_00013_itemunit_v0_0_0,
     brick_format_00019_itemunit_v0_0_0,
     brick_format_00020_bud_acct_membership_v0_0_0,
@@ -77,12 +77,12 @@ def test_get_brick_formats_dir_ReturnsObj():
     assert brick_dir == f"{(src_brick_dir())}/brick_formats"
 
 
-def test_get_brickref_ReturnsObj():
+def test_get_brickref_obj_ReturnsObj():
     # ESTABLISH
     brick_name_00021 = brick_format_00021_bud_acctunit_v0_0_0()
 
     # WHEN
-    x_brickref = get_brickref(brick_name_00021)
+    x_brickref = get_brickref_obj(brick_name_00021)
 
     # THEN
     assert x_brickref.brick_name == brick_name_00021
@@ -109,7 +109,7 @@ def test_get_headers_list_ReturnsObj():
 
 
 def get_sorted_headers(brick_filename):
-    x_brickref = get_brickref_dict(brick_filename)
+    x_brickref = get_brickref_from_file(brick_filename)
     brick_attributes = set(x_brickref.get(attributes_str()).keys())
     brick_attributes.remove(face_id_str())
     brick_attributes.remove(eon_id_str())
@@ -192,15 +192,24 @@ def test_brick_FilesExist():
     assert len(brick_filenames) == len(get_brick_format_filenames())
 
 
-def test_get_brickref_HasCorrectAttrs_brick_format_00021_bud_acctunit_v0_0_0():
+def test_get_brickref_obj_HasCorrectAttrs_brick_format_00021_bud_acctunit_v0_0_0():
     # ESTABLISH
     brick_name = brick_format_00021_bud_acctunit_v0_0_0()
 
     # WHEN
-    format_00001_brickref = get_brickref(brick_name)
+    format_00001_brickref = get_brickref_obj(brick_name)
 
     # THEN
     assert len(format_00001_brickref._attributes) == 7
+    assert format_00001_brickref._attributes == {
+        "acct_id": {"otx_key": True},
+        "credit_belief": {"otx_key": False},
+        "debtit_belief": {"otx_key": False},
+        "eon_id": {"otx_key": True},
+        "face_id": {"otx_key": True},
+        "fiscal_id": {"otx_key": True},
+        "owner_id": {"otx_key": True},
+    }
     headers_list = format_00001_brickref.get_headers_list()
     assert headers_list[0] == face_id_str()
     assert headers_list[1] == eon_id_str()
@@ -211,12 +220,12 @@ def test_get_brickref_HasCorrectAttrs_brick_format_00021_bud_acctunit_v0_0_0():
     assert headers_list[6] == debtit_belief_str()
 
 
-def test_get_brickref_HasCorrectAttrs_brick_format_00020_bud_acct_membership_v0_0_0():
+def test_get_brickref_obj_HasCorrectAttrs_brick_format_00020_bud_acct_membership_v0_0_0():
     # ESTABLISH
     brick_name = brick_format_00020_bud_acct_membership_v0_0_0()
 
     # WHEN
-    format_00021_brickref = get_brickref(brick_name)
+    format_00021_brickref = get_brickref_obj(brick_name)
 
     # THEN
     assert len(format_00021_brickref._attributes) == 8
@@ -231,12 +240,12 @@ def test_get_brickref_HasCorrectAttrs_brick_format_00020_bud_acct_membership_v0_
     assert headers_list[7] == debtit_vote_str()
 
 
-def test_get_brickref_HasCorrectAttrs_brick_format_00013_itemunit_v0_0_0():
+def test_get_brickref_obj_HasCorrectAttrs_brick_format_00013_itemunit_v0_0_0():
     # ESTABLISH
     brick_name = brick_format_00013_itemunit_v0_0_0()
 
     # WHEN
-    format_00003_brickref = get_brickref(brick_name)
+    format_00003_brickref = get_brickref_obj(brick_name)
 
     # THEN
     assert len(format_00003_brickref._attributes) == 8
@@ -251,12 +260,12 @@ def test_get_brickref_HasCorrectAttrs_brick_format_00013_itemunit_v0_0_0():
     assert headers_list[7] == pledge_str()
 
 
-def test_get_brickref_HasCorrectAttrs_brick_format_00019_itemunit_v0_0_0():
+def test_get_brickref_obj_HasCorrectAttrs_brick_format_00019_itemunit_v0_0_0():
     # ESTABLISH
     brick_name = brick_format_00019_itemunit_v0_0_0()
 
     # WHEN
-    format_00019_brickref = get_brickref(brick_name)
+    format_00019_brickref = get_brickref_obj(brick_name)
 
     # THEN
     assert len(format_00019_brickref._attributes) == 14

--- a/src/f09_brick/test_brick_format/test_brick_format_dataframes.py
+++ b/src/f09_brick/test_brick_format/test_brick_format_dataframes.py
@@ -19,7 +19,7 @@ from src.f04_gift.atom_config import (
     debtit_vote_str,
     credit_vote_str,
 )
-from src.f09_brick.brick import create_brick_df, get_brickref, save_brick_csv
+from src.f09_brick.brick import create_brick_df, get_brickref_obj, save_brick_csv
 from src.f09_brick.brick_config import (
     brick_format_00021_bud_acctunit_v0_0_0,
     brick_format_00020_bud_acct_membership_v0_0_0,
@@ -57,7 +57,7 @@ def test_create_brick_df_Arg_brick_format_00021_bud_acctunit_v0_0_0():
 
     # THEN
     array_headers = list(acct_dataframe.columns)
-    acct_brickref = get_brickref(x_brick_name)
+    acct_brickref = get_brickref_obj(x_brick_name)
     assert array_headers == acct_brickref.get_headers_list()
     assert acct_dataframe.loc[0, fiscal_id_str()] == music_fiscal_id
     assert acct_dataframe.loc[0, owner_id_str()] == sue_budunit._owner_id
@@ -114,7 +114,7 @@ def test_create_brick_df_Arg_brick_format_00020_bud_acct_membership_v0_0_0():
 
     # THEN
     array_headers = list(membership_dataframe.columns)
-    acct_brickref = get_brickref(x_brick_name)
+    acct_brickref = get_brickref_obj(x_brick_name)
     print(f"{len(membership_dataframe)=}")
     assert array_headers == acct_brickref.get_headers_list()
     assert membership_dataframe.loc[0, fiscal_id_str()] == music_fiscal_id
@@ -166,7 +166,7 @@ def test_create_brick_df_Arg_brick_format_00013_itemunit_v0_0_0():
 
     # THEN
     array_headers = list(itemunit_format.columns)
-    assert array_headers == get_brickref(x_brick_name).get_headers_list()
+    assert array_headers == get_brickref_obj(x_brick_name).get_headers_list()
 
     assert itemunit_format.loc[0, owner_id_str()] == sue_budunit._owner_id
     assert itemunit_format.loc[0, pledge_str()] == ""
@@ -199,7 +199,7 @@ def test_save_brick_csv_Arg_brick_format_00019_itemunit_v0_0_0():
 
     # THEN
     array_headers = list(brick_df.columns)
-    assert array_headers == get_brickref(x_brick_name).get_headers_list()
+    assert array_headers == get_brickref_obj(x_brick_name).get_headers_list()
     # for x_array_header in array_headers:
     #     print(f"{x_array_header=}")
 

--- a/src/f09_brick/test_brick_format/test_brick_format_generate_brick.py
+++ b/src/f09_brick/test_brick_format/test_brick_format_generate_brick.py
@@ -21,7 +21,7 @@ from src.f04_gift.atom_config import (
     credit_vote_str,
 )
 from src.f04_gift.atom import atomunit_shop
-from src.f09_brick.brick import create_brick_df, make_deltaunit, get_brickref
+from src.f09_brick.brick import create_brick_df, make_deltaunit, get_brickref_obj
 from src.f09_brick.brick_config import (
     brick_format_00021_bud_acctunit_v0_0_0,
     brick_format_00020_bud_acct_membership_v0_0_0,
@@ -195,7 +195,7 @@ def test_create_brick_df_Arg_brick_format_00013_itemunit_v0_0_0_Scenario_budunit
 
         # THEN
         array_headers = list(itemunit_format.columns)
-        assert array_headers == get_brickref(x_brick_name).get_headers_list()
+        assert array_headers == get_brickref_obj(x_brick_name).get_headers_list()
         assert len(itemunit_format) == 251
 
 

--- a/src/f09_brick/test_brick_format/test_brick_format_import.py
+++ b/src/f09_brick/test_brick_format/test_brick_format_import.py
@@ -10,7 +10,7 @@ from src.f04_gift.atom_config import (
 from src.f05_listen.hubunit import hubunit_shop
 from src.f09_brick.brick import (
     create_brick_df,
-    get_brickref,
+    get_brickref_obj,
     save_brick_csv,
     load_brick_csv,
 )
@@ -52,7 +52,7 @@ def test_open_csv_ReturnsObj():
 
     # THEN
     array_headers = list(acct_dataframe.columns)
-    acct_brickref = get_brickref(j1_brickname)
+    acct_brickref = get_brickref_obj(j1_brickname)
     assert array_headers == acct_brickref.get_headers_list()
     assert acct_dataframe.loc[0, fiscal_id_str()] == music_fiscal_id
     assert acct_dataframe.loc[0, owner_id_str()] == sue_budunit._owner_id
@@ -233,5 +233,5 @@ def test_load_brick_csv_csvToVoice(
 
 #         # THEN
 #         array_headers = list(itemunit_format.columns)
-#         assert array_headers == get_brickref(x_brick_name).get_headers_list()
+#         assert array_headers == get_brickref_obj(x_brick_name).get_headers_list()
 #         assert len(itemunit_format) == 251

--- a/src/f10_world/test/test_world_jungle.py
+++ b/src/f10_world/test/test_world_jungle.py
@@ -93,9 +93,9 @@ def test_WorldUnit_zoo_to_otx_CreatesOtxSheets_Scenario0_GroupByWorks(
         hour_label_str(),
         cumlative_minute_str(),
     ]
-    row1 = [sue_str, eon_1, minute_360, music23_str, hour6am]
-    row2 = [sue_str, eon_1, minute_420, music23_str, hour7am]
-    row3 = [sue_str, eon_1, minute_420, music23_str, hour7am]
+    row1 = [sue_str, eon_1, music23_str, hour6am, minute_360]
+    row2 = [sue_str, eon_1, music23_str, hour7am, minute_420]
+    row3 = [sue_str, eon_1, music23_str, hour7am, minute_420]
     df1 = DataFrame([row1, row2, row3], columns=brick_columns)
     with ExcelWriter(jungle_file_path) as writer:
         df1.to_excel(writer, sheet_name="example1_br00003")
@@ -114,9 +114,8 @@ def test_WorldUnit_zoo_to_otx_CreatesOtxSheets_Scenario0_GroupByWorks(
     assert list(ex_otx_df.columns) == list(gen_otx_df.columns)
     assert len(gen_otx_df) > 0
     assert len(ex_otx_df) == len(gen_otx_df)
-    assert ex_otx_df == gen_otx_df
-
-    assert 1 == 2
+    assert len(gen_otx_df) == 2
+    assert ex_otx_df.to_csv() == gen_otx_df.to_csv()
 
 
 def test_WorldUnit_zoo_to_otx_CreatesOtxSheets_Scenario1_GroupByOnlyNonConflictingRecords(
@@ -127,10 +126,9 @@ def test_WorldUnit_zoo_to_otx_CreatesOtxSheets_Scenario1_GroupByOnlyNonConflicti
     music_world = worldunit_shop(music23_str)
     sue_str = "Sue"
     eon_1 = 1
-    eon_2 = 2
     minute_360 = 360
     minute_420 = 420
-    minute_480 = 428
+    minute_480 = 480
     hour6am = "6am"
     hour7am = "7am"
     ex_file_name = "fizzbuzz.xlsx"
@@ -139,17 +137,31 @@ def test_WorldUnit_zoo_to_otx_CreatesOtxSheets_Scenario1_GroupByOnlyNonConflicti
     brick_columns = [
         face_id_str(),
         eon_id_str(),
-        cumlative_minute_str(),
         fiscal_id_str(),
         hour_label_str(),
+        cumlative_minute_str(),
     ]
-    row1 = [sue_str, eon_1, minute_360, music23_str, hour6am]
-    row2_good = [sue_str, eon_1, minute_420, music23_str, hour7am]
-    row2_poor = [sue_str, eon_1, minute_480, music23_str, hour7am]
-    df1 = DataFrame([row1, row2_good, row2_poor], columns=brick_columns)
-    br00003_ex1_str = "example1_br00003"
+    row1 = [sue_str, eon_1, music23_str, hour6am, minute_360]
+    row2 = [sue_str, eon_1, music23_str, hour7am, minute_420]
+    row3 = [sue_str, eon_1, music23_str, hour7am, minute_480]
+    df1 = DataFrame([row1, row2, row3], columns=brick_columns)
     with ExcelWriter(jungle_file_path) as writer:
-        df1.to_excel(writer, sheet_name=br00003_ex1_str, index=False)
+        df1.to_excel(writer, sheet_name="example1_br00003")
     music_world.jungle_to_zoo()
     zoo_df = pandas_read_excel(zoo_file_path, sheet_name="zoo")
     assert len(zoo_df) == 3
+
+    # WHEN
+    music_world.zoo_to_otx()
+
+    # THEN
+    gen_otx_df = pandas_read_excel(zoo_file_path, sheet_name="otx")
+    ex_otx_df = DataFrame([row1], columns=brick_columns)
+    # print(f"{gen_otx_df.columns=}")
+    print(f"{gen_otx_df=}")
+    assert len(ex_otx_df.columns) == len(gen_otx_df.columns)
+    assert list(ex_otx_df.columns) == list(gen_otx_df.columns)
+    assert len(gen_otx_df) > 0
+    assert len(ex_otx_df) == len(gen_otx_df)
+    assert len(gen_otx_df) == 1
+    assert ex_otx_df.to_csv() == gen_otx_df.to_csv()

--- a/src/f10_world/world.py
+++ b/src/f10_world/world.py
@@ -19,12 +19,20 @@ from src.f01_road.road import (
 )
 from src.f07_fiscal.fiscal import FiscalUnit
 from src.f08_filter.filter import FilterUnit, filterunit_shop
-from src.f09_brick.brick_config import get_brick_numbers, get_quick_bricks_column_ref
+from src.f09_brick.brick_config import (
+    get_brick_numbers,
+    get_brick_format_filename,
+    get_quick_bricks_column_ref,
+)
+from src.f09_brick.brick import get_brickref_obj
 from src.f09_brick.filter_toolbox import (
     save_all_csvs_from_filterunit,
     init_filterunit_from_dir,
 )
-from src.f09_brick.pandas_tool import get_new_sorting_columns
+from src.f09_brick.pandas_tool import (
+    get_new_sorting_columns,
+    get_grouping_with_all_values_equal_df,
+)
 from src.f10_world.world_tool import get_all_brick_dataframes
 from pandas import (
     ExcelWriter,
@@ -86,9 +94,13 @@ class ZooToOtxTransformer:
     def _group_by_brick_columns(
         self, zoo_df: DataFrame, brick_number: str
     ) -> DataFrame:
-        brick_columns_set = get_quick_bricks_column_ref().get(brick_number)
+        brick_filename = get_brick_format_filename(brick_number)
+        brickref = get_brickref_obj(brick_filename)
+        required_columns = brickref.get_otx_keys_list()
+        brick_columns_set = set(brickref._attributes.keys())
         brick_columns_list = get_new_sorting_columns(brick_columns_set)
-        return zoo_df[brick_columns_list]
+        zoo_df = zoo_df[brick_columns_list]
+        return get_grouping_with_all_values_equal_df(zoo_df, required_columns)
 
     # def _read_and_tag_dataframe(self, ref):
     #     x_file_path = create_file_path(ref.file_dir, ref.file_name)


### PR DESCRIPTION
## Summary by Sourcery

Refactor the BrickRef class to use a dictionary for attributes, allowing for more complex metadata handling. Update related functions and tests to support this change, including renaming functions for clarity and adding new test cases to verify the updated logic.

Enhancements:
- Refactor the BrickRef class to use a dictionary for attributes, allowing for additional metadata such as 'otx_key'.
- Rename functions to better reflect their purpose, such as changing 'get_groupby_dataframe' to 'get_grouping_with_all_values_equal_df'.
- Improve the logic for grouping dataframes by ensuring all values are equal within groups.

Tests:
- Add new test cases for the BrickRef class to verify the functionality of new methods like 'get_otx_keys_list' and 'get_otx_values_list'.
- Update existing test cases to accommodate changes in the BrickRef class and related functions, ensuring they reflect the new attribute handling logic.