### PR TITLE
175 enable documentation process

### DIFF
--- a/src/f09_brick/pandas_tool.py
+++ b/src/f09_brick/pandas_tool.py
@@ -261,6 +261,7 @@ def split_excel_into_dirs(
             # Define the output file path
             output_file = create_path(subdirectory, f"{file_name}.xlsx")
             upsert_sheet(output_file, sheet_name, filtered_df)
+            print(f"{output_file=} {sheet_name=}")
             # filtered_df.to_excel(output_file, index=False)
 
 

--- a/src/f10_etl/test/test_transformer_event_bricks_to_fiscal_bricks.py
+++ b/src/f10_etl/test/test_transformer_event_bricks_to_fiscal_bricks.py
@@ -1,0 +1,97 @@
+from src.f00_instrument.file import create_path
+from src.f04_gift.atom_config import face_id_str, fiscal_id_str
+from src.f07_fiscal.fiscal_config import cumlative_minute_str, hour_label_str
+from src.f08_pidgin.pidgin_config import event_id_str
+from src.f09_brick.pandas_tool import upsert_sheet, zoo_agg_str, sheet_exists
+from src.f10_etl.transformers import etl_event_bricks_to_fiscal_bricks
+from src.f10_etl.examples.etl_env import get_test_etl_dir, env_dir_setup_cleanup
+from pandas.testing import (
+    assert_frame_equal as pandas_assert_frame_equal,
+)
+from pandas import DataFrame, read_excel as pandas_read_excel
+
+
+def test_etl_event_bricks_to_fiscal_bricks_CreatesFaceBrickSheets_Scenario0_MultpleFaceIDs(
+    env_dir_setup_cleanup,
+):
+    # ESTABLISH
+    sue_str = "Sue"
+    zia_str = "Zia"
+    event3 = 3
+    event7 = 7
+    event9 = 9
+    minute_360 = 360
+    minute_420 = 420
+    hour6am = "6am"
+    hour7am = "7am"
+    br00003_columns = [
+        face_id_str(),
+        event_id_str(),
+        fiscal_id_str(),
+        hour_label_str(),
+        cumlative_minute_str(),
+    ]
+    music23_str = "music23"
+    music55_str = "music55"
+    sue0 = [sue_str, event3, music23_str, hour6am, minute_360]
+    sue1 = [sue_str, event3, music23_str, hour7am, minute_420]
+    zia0 = [zia_str, event7, music23_str, hour7am, minute_420]
+    zia1 = [zia_str, event9, music23_str, hour6am, minute_360]
+    zia2 = [zia_str, event9, music23_str, hour7am, minute_420]
+    zia3 = [zia_str, event9, music55_str, hour7am, minute_420]
+    example_event3_df = DataFrame([sue0, sue1], columns=br00003_columns)
+    example_event7_df = DataFrame([zia0], columns=br00003_columns)
+    example_event9_df = DataFrame([zia1, zia2, zia3], columns=br00003_columns)
+    x_etl_dir = get_test_etl_dir()
+    x_faces_dir = create_path(x_etl_dir, "faces")
+    br00003_filename = "br00003.xlsx"
+    sue_dir = create_path(x_faces_dir, sue_str)
+    zia_dir = create_path(x_faces_dir, zia_str)
+    event3_dir = create_path(sue_dir, event3)
+    event7_dir = create_path(zia_dir, event7)
+    event9_dir = create_path(zia_dir, event9)
+    event3_br00003_filepath = create_path(event3_dir, br00003_filename)
+    event7_br00003_filepath = create_path(event7_dir, br00003_filename)
+    event9_br00003_filepath = create_path(event9_dir, br00003_filename)
+    upsert_sheet(event3_br00003_filepath, zoo_agg_str(), example_event3_df)
+    upsert_sheet(event7_br00003_filepath, zoo_agg_str(), example_event7_df)
+    upsert_sheet(event9_br00003_filepath, zoo_agg_str(), example_event9_df)
+    e3_music23_dir = create_path(event3_dir, music23_str)
+    e7_music23_dir = create_path(event7_dir, music23_str)
+    e9_music23_dir = create_path(event9_dir, music23_str)
+    e9_music55_dir = create_path(event9_dir, music55_str)
+    e3_music23_br00003_filepath = create_path(e3_music23_dir, br00003_filename)
+    e7_music23_br00003_filepath = create_path(e7_music23_dir, br00003_filename)
+    e9_music23_br00003_filepath = create_path(e9_music23_dir, br00003_filename)
+    e9_music55_br00003_filepath = create_path(e9_music55_dir, br00003_filename)
+    print(f"{e3_music23_br00003_filepath=}")
+    print(f"{e7_music23_br00003_filepath=}")
+    print(f"{e9_music23_br00003_filepath=}")
+    print(f"{e9_music55_br00003_filepath=}")
+    assert sheet_exists(e3_music23_br00003_filepath, zoo_agg_str()) is False
+    assert sheet_exists(e7_music23_br00003_filepath, zoo_agg_str()) is False
+    assert sheet_exists(e9_music23_br00003_filepath, zoo_agg_str()) is False
+    assert sheet_exists(e9_music55_br00003_filepath, zoo_agg_str()) is False
+
+    # WHEN
+    etl_event_bricks_to_fiscal_bricks(x_faces_dir)
+
+    # THEN
+    assert sheet_exists(e7_music23_br00003_filepath, zoo_agg_str())
+    assert sheet_exists(e3_music23_br00003_filepath, zoo_agg_str())
+    assert sheet_exists(e9_music23_br00003_filepath, zoo_agg_str())
+    assert sheet_exists(e9_music55_br00003_filepath, zoo_agg_str())
+    gen_e3_music23_df = pandas_read_excel(e3_music23_br00003_filepath, zoo_agg_str())
+    gen_e7_music23_df = pandas_read_excel(e7_music23_br00003_filepath, zoo_agg_str())
+    gen_e9_music23_df = pandas_read_excel(e9_music23_br00003_filepath, zoo_agg_str())
+    gen_e9_music55_df = pandas_read_excel(e9_music55_br00003_filepath, zoo_agg_str())
+    expected_e9_music23_df = DataFrame([zia1, zia2], columns=br00003_columns)
+    expected_e9_music55_df = DataFrame([zia3], columns=br00003_columns)
+    print("gen_e9_music55_df")
+    print(f"{gen_e9_music55_df}")
+    print("expected_e9_music55_df")
+    print(f"{expected_e9_music55_df}")
+    pandas_assert_frame_equal(gen_e3_music23_df, example_event3_df)
+    pandas_assert_frame_equal(gen_e7_music23_df, example_event7_df)
+    pandas_assert_frame_equal(gen_e9_music23_df, expected_e9_music23_df)
+    pandas_assert_frame_equal(gen_e9_music55_df, expected_e9_music55_df)

--- a/src/f10_etl/test/test_transformer_face_bricks_to_event_bricks.py
+++ b/src/f10_etl/test/test_transformer_face_bricks_to_event_bricks.py
@@ -3,7 +3,7 @@ from src.f04_gift.atom_config import face_id_str, fiscal_id_str
 from src.f07_fiscal.fiscal_config import cumlative_minute_str, hour_label_str
 from src.f08_pidgin.pidgin_config import event_id_str
 from src.f09_brick.pandas_tool import upsert_sheet, zoo_agg_str, sheet_exists
-from src.f10_etl.transformers import etl_face_bricks_to_events_bricks
+from src.f10_etl.transformers import etl_face_bricks_to_event_bricks
 from src.f10_etl.examples.etl_env import get_test_etl_dir, env_dir_setup_cleanup
 from pandas.testing import (
     assert_frame_equal as pandas_assert_frame_equal,
@@ -60,7 +60,7 @@ def test_etl_face_bricks_to_event_bricks_CreatesFaceBrickSheets_Scenario0_Multpl
     assert sheet_exists(event9_br00003_filepath, zoo_agg_str()) is False
 
     # WHEN
-    etl_face_bricks_to_events_bricks(x_faces_dir)
+    etl_face_bricks_to_event_bricks(x_faces_dir)
 
     # THEN
     assert sheet_exists(event3_br00003_filepath, zoo_agg_str())

--- a/src/f10_etl/test/test_transformer_zoo_bricks_to_face_bricks.py
+++ b/src/f10_etl/test/test_transformer_zoo_bricks_to_face_bricks.py
@@ -1,7 +1,14 @@
 from src.f00_instrument.file import create_path
 from src.f04_gift.atom_config import face_id_str, fiscal_id_str
 from src.f07_fiscal.fiscal_config import cumlative_minute_str, hour_label_str
-from src.f08_pidgin.pidgin_config import event_id_str
+from src.f08_pidgin.pidgin_config import (
+    event_id_str,
+    inx_wall_str,
+    inx_acct_id_str,
+    otx_wall_str,
+    otx_acct_id_str,
+    unknown_word_str,
+)
 from src.f09_brick.pandas_tool import (
     get_sheet_names,
     upsert_sheet,
@@ -65,7 +72,7 @@ def test_etl_zoo_bricks_to_face_bricks_CreatesFaceBrickSheets_Scenario0_SingleFa
     assert get_sheet_names(sue_br00003_filepath) == [zoo_agg_str()]
 
 
-def test_etl_zoo_bricks_to_face_bricks_CreatesFaceBrickSheets_Scenario0_MultpleFaceIDs(
+def test_etl_zoo_bricks_to_face_bricks_CreatesFaceBrickSheets_Scenario1_MultpleFaceIDs(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -118,3 +125,68 @@ def test_etl_zoo_bricks_to_face_bricks_CreatesFaceBrickSheets_Scenario0_MultpleF
     example_zia_df = DataFrame([zia3], columns=brick_columns)
     pandas_assert_frame_equal(sue_br3_agg_df, example_sue_df)
     pandas_assert_frame_equal(zia_br3_agg_df, example_zia_df)
+
+
+def test_etl_zoo_bricks_to_face_bricks_Scenario2_PidginCategoryBricksAreNotLoaded(
+    env_dir_setup_cleanup,
+):
+    # ESTABLISH
+    sue_str = "Sue"
+    event3 = 3
+    minute_360 = 360
+    minute_420 = 420
+    hour6am = "6am"
+    hour7am = "7am"
+    br00003_columns = [
+        face_id_str(),
+        event_id_str(),
+        fiscal_id_str(),
+        hour_label_str(),
+        cumlative_minute_str(),
+    ]
+    music23_str = "music23"
+    sue3_0 = [sue_str, event3, music23_str, hour6am, minute_360]
+    sue3_1 = [sue_str, event3, music23_str, hour7am, minute_420]
+    br00003_zoo_agg_df = DataFrame([sue3_0, sue3_1], columns=br00003_columns)
+
+    br00043_columns = [
+        face_id_str(),
+        event_id_str(),
+        inx_wall_str(),
+        inx_acct_id_str(),
+        otx_wall_str(),
+        otx_acct_id_str(),
+        unknown_word_str(),
+    ]
+    sue43_0 = [sue_str, event3, ":", "Bob", ":", "Bobby", "Unknown"]
+    sue43_1 = [sue_str, event3, ":", "Bob", ":", "Bobby", "Unknown"]
+    br00043_zoo_agg_df = DataFrame([sue43_0, sue43_1], columns=br00043_columns)
+
+    x_etl_dir = get_test_etl_dir()
+    x_zoo_dir = create_path(x_etl_dir, "zoo")
+    x_faces_dir = create_path(x_etl_dir, "faces")
+    br00003_filename = "br00003.xlsx"
+    br00043_filename = "br00043.xlsx"
+    br00003_agg_file_path = create_path(x_zoo_dir, br00003_filename)
+    br00043_agg_file_path = create_path(x_zoo_dir, br00043_filename)
+    upsert_sheet(br00003_agg_file_path, zoo_agg_str(), br00003_zoo_agg_df)
+    upsert_sheet(br00043_agg_file_path, zoo_agg_str(), br00043_zoo_agg_df)
+    assert sheet_exists(br00003_agg_file_path, zoo_agg_str())
+    assert sheet_exists(br00043_agg_file_path, zoo_agg_str())
+
+    sue_dir = create_path(x_faces_dir, sue_str)
+    sue_br00003_filepath = create_path(sue_dir, br00003_filename)
+    sue_br00043_filepath = create_path(sue_dir, br00043_filename)
+    assert sheet_exists(sue_br00003_filepath, zoo_agg_str()) is False
+    assert sheet_exists(sue_br00043_filepath, zoo_agg_str()) is False
+
+    # WHEN
+    etl_zoo_bricks_to_face_bricks(x_zoo_dir, x_faces_dir)
+
+    # THEN
+    assert sheet_exists(sue_br00003_filepath, zoo_agg_str())
+    assert sheet_exists(sue_br00043_filepath, zoo_agg_str()) is False
+    sue_br3_agg_df = pandas_read_excel(sue_br00003_filepath, sheet_name=zoo_agg_str())
+    print(f"{sue_br3_agg_df.columns=}")
+    example_sue_df = DataFrame([sue3_0, sue3_1], columns=br00003_columns)
+    pandas_assert_frame_equal(sue_br3_agg_df, example_sue_df)

--- a/src/f10_etl/transformers.py
+++ b/src/f10_etl/transformers.py
@@ -547,12 +547,37 @@ def etl_zoo_bricks_to_face_bricks(zoo_dir: str, faces_dir: str):
 def etl_face_bricks_to_event_bricks(faces_dir: str):
     for face_id_dir in get_face_dirs(faces_dir):
         face_dir = create_path(faces_dir, face_id_dir)
-        for zoo_br_ref in get_existing_excel_brick_file_refs(face_dir):
-            zoo_brick_path = create_path(face_dir, zoo_br_ref.file_name)
+        for face_br_ref in get_existing_excel_brick_file_refs(face_dir):
+            face_brick_path = create_path(face_dir, face_br_ref.file_name)
             split_excel_into_dirs(
-                input_file=zoo_brick_path,
+                input_file=face_brick_path,
                 output_dir=face_dir,
                 column_name="event_id",
-                file_name=zoo_br_ref.brick_number,
+                file_name=face_br_ref.brick_number,
                 sheet_name="zoo_agg",
             )
+
+
+def etl_event_bricks_to_fiscal_bricks(faces_dir: str):
+    for event_brick_dir in _get_all_faces_dir_event_dirs(faces_dir):
+        print(f"{event_brick_dir=}")
+        for event_br_ref in get_existing_excel_brick_file_refs(event_brick_dir):
+            event_brick_path = create_path(event_brick_dir, event_br_ref.file_name)
+            split_excel_into_dirs(
+                input_file=event_brick_path,
+                output_dir=event_brick_dir,
+                column_name="fiscal_id",
+                file_name=event_br_ref.brick_number,
+                sheet_name="zoo_agg",
+            )
+
+        # event_brick_path = create_path(event_dir, event_br_ref.file_name)
+        # split_excel_into_dirs(
+        #     input_file=face_brick_path,
+        #     output_dir=face_dir,
+        #     column_name="event_id",
+        #     file_name=face_br_ref.brick_number,
+        #     sheet_name="zoo_agg",
+        # )
+
+        # print(f"{event_pidgin_dir=}")

--- a/src/f10_etl/transformers.py
+++ b/src/f10_etl/transformers.py
@@ -544,7 +544,7 @@ def etl_zoo_bricks_to_face_bricks(zoo_dir: str, faces_dir: str):
             )
 
 
-def etl_face_bricks_to_events_bricks(faces_dir: str):
+def etl_face_bricks_to_event_bricks(faces_dir: str):
     for face_id_dir in get_face_dirs(faces_dir):
         face_dir = create_path(faces_dir, face_id_dir)
         for zoo_br_ref in get_existing_excel_brick_file_refs(face_dir):

--- a/src/f10_etl/transformers.py
+++ b/src/f10_etl/transformers.py
@@ -9,6 +9,7 @@ from src.f09_brick.brick_config import (
 from src.f09_brick.brick import get_brickref_obj
 from src.f09_brick.pandas_tool import (
     get_zoo_staging_grouping_with_all_values_equal_df,
+    _get_pidgen_brick_format_filenames,
     get_new_sorting_columns,
     upsert_sheet,
     split_excel_into_dirs,
@@ -533,13 +534,14 @@ def etl_event_pidgins_csvs_to_pidgin_jsons(faces_dir: str):
 def etl_zoo_bricks_to_face_bricks(zoo_dir: str, faces_dir: str):
     for zoo_br_ref in get_existing_excel_brick_file_refs(zoo_dir):
         zoo_brick_path = create_path(zoo_dir, zoo_br_ref.file_name)
-        split_excel_into_dirs(
-            input_file=zoo_brick_path,
-            output_dir=faces_dir,
-            column_name="face_id",
-            file_name=zoo_br_ref.brick_number,
-            sheet_name="zoo_agg",
-        )
+        if zoo_br_ref.file_name not in _get_pidgen_brick_format_filenames():
+            split_excel_into_dirs(
+                input_file=zoo_brick_path,
+                output_dir=faces_dir,
+                column_name="face_id",
+                file_name=zoo_br_ref.brick_number,
+                sheet_name="zoo_agg",
+            )
 
 
 def etl_face_bricks_to_events_bricks(faces_dir: str):

--- a/src/f11_world/test/test_world_etl04_02_face_bricks_to_event_bricks.py
+++ b/src/f11_world/test/test_world_etl04_02_face_bricks_to_event_bricks.py
@@ -59,7 +59,7 @@ def test_WorldUnit_face_bricks_to_event_bricks_CreatesFaceBrickSheets_Scenario0_
     assert sheet_exists(event9_br00003_filepath, zoo_agg_str()) is False
 
     # WHEN
-    fizz_world.face_bricks_to_events_bricks()
+    fizz_world.face_bricks_to_event_bricks()
 
     # THEN
     assert sheet_exists(event3_br00003_filepath, zoo_agg_str())

--- a/src/f11_world/test/test_world_etl04_03_event_bricks_to_fiscal_bricks.py
+++ b/src/f11_world/test/test_world_etl04_03_event_bricks_to_fiscal_bricks.py
@@ -1,0 +1,96 @@
+from src.f00_instrument.file import create_path
+from src.f04_gift.atom_config import face_id_str, fiscal_id_str
+from src.f07_fiscal.fiscal_config import cumlative_minute_str, hour_label_str
+from src.f08_pidgin.pidgin_config import event_id_str
+from src.f09_brick.pandas_tool import upsert_sheet, zoo_agg_str, sheet_exists
+from src.f11_world.world import worldunit_shop
+from src.f11_world.examples.world_env import get_test_worlds_dir, env_dir_setup_cleanup
+from pandas.testing import (
+    assert_frame_equal as pandas_assert_frame_equal,
+)
+from pandas import DataFrame, read_excel as pandas_read_excel
+
+
+def test_world_event_bricks_to_fiscal_bricks_CreatesFaceBrickSheets_Scenario0_MultpleFaceIDs(
+    env_dir_setup_cleanup,
+):
+    # ESTABLISH
+    sue_str = "Sue"
+    zia_str = "Zia"
+    event3 = 3
+    event7 = 7
+    event9 = 9
+    minute_360 = 360
+    minute_420 = 420
+    hour6am = "6am"
+    hour7am = "7am"
+    br00003_columns = [
+        face_id_str(),
+        event_id_str(),
+        fiscal_id_str(),
+        hour_label_str(),
+        cumlative_minute_str(),
+    ]
+    music23_str = "music23"
+    music55_str = "music55"
+    sue0 = [sue_str, event3, music23_str, hour6am, minute_360]
+    sue1 = [sue_str, event3, music23_str, hour7am, minute_420]
+    zia0 = [zia_str, event7, music23_str, hour7am, minute_420]
+    zia1 = [zia_str, event9, music23_str, hour6am, minute_360]
+    zia2 = [zia_str, event9, music23_str, hour7am, minute_420]
+    zia3 = [zia_str, event9, music55_str, hour7am, minute_420]
+    example_event3_df = DataFrame([sue0, sue1], columns=br00003_columns)
+    example_event7_df = DataFrame([zia0], columns=br00003_columns)
+    example_event9_df = DataFrame([zia1, zia2, zia3], columns=br00003_columns)
+    br00003_filename = "br00003.xlsx"
+    fizz_world = worldunit_shop("fizz")
+    sue_dir = create_path(fizz_world._faces_dir, sue_str)
+    zia_dir = create_path(fizz_world._faces_dir, zia_str)
+    event3_dir = create_path(sue_dir, event3)
+    event7_dir = create_path(zia_dir, event7)
+    event9_dir = create_path(zia_dir, event9)
+    event3_br00003_filepath = create_path(event3_dir, br00003_filename)
+    event7_br00003_filepath = create_path(event7_dir, br00003_filename)
+    event9_br00003_filepath = create_path(event9_dir, br00003_filename)
+    upsert_sheet(event3_br00003_filepath, zoo_agg_str(), example_event3_df)
+    upsert_sheet(event7_br00003_filepath, zoo_agg_str(), example_event7_df)
+    upsert_sheet(event9_br00003_filepath, zoo_agg_str(), example_event9_df)
+    e3_music23_dir = create_path(event3_dir, music23_str)
+    e7_music23_dir = create_path(event7_dir, music23_str)
+    e9_music23_dir = create_path(event9_dir, music23_str)
+    e9_music55_dir = create_path(event9_dir, music55_str)
+    e3_music23_br00003_filepath = create_path(e3_music23_dir, br00003_filename)
+    e7_music23_br00003_filepath = create_path(e7_music23_dir, br00003_filename)
+    e9_music23_br00003_filepath = create_path(e9_music23_dir, br00003_filename)
+    e9_music55_br00003_filepath = create_path(e9_music55_dir, br00003_filename)
+    print(f"{e3_music23_br00003_filepath=}")
+    print(f"{e7_music23_br00003_filepath=}")
+    print(f"{e9_music23_br00003_filepath=}")
+    print(f"{e9_music55_br00003_filepath=}")
+    assert sheet_exists(e3_music23_br00003_filepath, zoo_agg_str()) is False
+    assert sheet_exists(e7_music23_br00003_filepath, zoo_agg_str()) is False
+    assert sheet_exists(e9_music23_br00003_filepath, zoo_agg_str()) is False
+    assert sheet_exists(e9_music55_br00003_filepath, zoo_agg_str()) is False
+
+    # WHEN
+    fizz_world.event_bricks_to_fiscal_bricks()
+
+    # THEN
+    assert sheet_exists(e7_music23_br00003_filepath, zoo_agg_str())
+    assert sheet_exists(e3_music23_br00003_filepath, zoo_agg_str())
+    assert sheet_exists(e9_music23_br00003_filepath, zoo_agg_str())
+    assert sheet_exists(e9_music55_br00003_filepath, zoo_agg_str())
+    gen_e3_music23_df = pandas_read_excel(e3_music23_br00003_filepath, zoo_agg_str())
+    gen_e7_music23_df = pandas_read_excel(e7_music23_br00003_filepath, zoo_agg_str())
+    gen_e9_music23_df = pandas_read_excel(e9_music23_br00003_filepath, zoo_agg_str())
+    gen_e9_music55_df = pandas_read_excel(e9_music55_br00003_filepath, zoo_agg_str())
+    expected_e9_music23_df = DataFrame([zia1, zia2], columns=br00003_columns)
+    expected_e9_music55_df = DataFrame([zia3], columns=br00003_columns)
+    print("gen_e9_music55_df")
+    print(f"{gen_e9_music55_df}")
+    print("expected_e9_music55_df")
+    print(f"{expected_e9_music55_df}")
+    pandas_assert_frame_equal(gen_e3_music23_df, example_event3_df)
+    pandas_assert_frame_equal(gen_e7_music23_df, example_event7_df)
+    pandas_assert_frame_equal(gen_e9_music23_df, expected_e9_music23_df)
+    pandas_assert_frame_equal(gen_e9_music55_df, expected_e9_music55_df)

--- a/src/f11_world/world.py
+++ b/src/f11_world/world.py
@@ -28,6 +28,7 @@ from src.f10_etl.transformers import (
     etl_event_pidgins_csvs_to_pidgin_jsons,
     etl_zoo_bricks_to_face_bricks,
     etl_face_bricks_to_event_bricks,
+    etl_event_bricks_to_fiscal_bricks,
 )
 from dataclasses import dataclass
 
@@ -119,6 +120,9 @@ class WorldUnit:
 
     def face_bricks_to_event_bricks(self):
         etl_face_bricks_to_event_bricks(self._faces_dir)
+
+    def event_bricks_to_fiscal_bricks(self):
+        etl_event_bricks_to_fiscal_bricks(self._faces_dir)
 
     def get_dict(self) -> dict:
         return {

--- a/src/f11_world/world.py
+++ b/src/f11_world/world.py
@@ -27,7 +27,7 @@ from src.f10_etl.transformers import (
     etl_event_pidgins_to_pidgin_csv_files,
     etl_event_pidgins_csvs_to_pidgin_jsons,
     etl_zoo_bricks_to_face_bricks,
-    etl_face_bricks_to_events_bricks,
+    etl_face_bricks_to_event_bricks,
 )
 from dataclasses import dataclass
 
@@ -117,8 +117,8 @@ class WorldUnit:
     def zoo_bricks_to_face_bricks(self):
         etl_zoo_bricks_to_face_bricks(self._zoo_dir, self._faces_dir)
 
-    def face_bricks_to_events_bricks(self):
-        etl_face_bricks_to_events_bricks(self._faces_dir)
+    def face_bricks_to_event_bricks(self):
+        etl_face_bricks_to_event_bricks(self._faces_dir)
 
     def get_dict(self) -> dict:
         return {


### PR DESCRIPTION
## Summary by Sourcery

Refactor the ETL process to improve the handling of bricks by excluding pidgin category bricks from being loaded into face bricks. Update the function names for consistency and clarity. Add new tests to verify the transformation of event bricks to fiscal bricks, ensuring the ETL process functions as expected.

Enhancements:
- Refactor the ETL process to exclude pidgin category bricks from being loaded into face bricks.

Tests:
- Add new tests for the 'etl_event_bricks_to_fiscal_bricks' function to ensure correct transformation of event bricks to fiscal bricks.