### PR TITLE
175 enable documentation process

### DIFF
--- a/src/f10_etl/test/test_transformer_aft_face_ideas_csv_to_fiscal_db.py
+++ b/src/f10_etl/test/test_transformer_aft_face_ideas_csv_to_fiscal_db.py
@@ -153,71 +153,71 @@ def test_create_cmty_staging_tables_CreatesCmtyStagingTables(
         assert cmty_weekday_pragma == cursor.fetchall()
 
 
-# def test_populate_cmty_staging_tables_PopulatesCmtyStagingTables(
-#     env_dir_setup_cleanup,
-# ):
-#     # ESTABLISH
-#     sue_inx = "Suzy"
-#     bob_inx = "Bob"
-#     yao_inx = "Yao"
-#     event3 = 3
-#     event7 = 7
-#     accord23_str = "accord23"
-#     aft_faces_dir = get_test_etl_dir()
-#     sue_aft_dir = create_path(aft_faces_dir, sue_inx)
-#     br00011_str = "br00011"
-#     br00011_csv_filename = f"{br00011_str}.csv"
-#     br00011_csv_str = f"""{face_name_str()},{event_int_str()},{cmty_title_str()},{owner_name_str()},{acct_name_str()}
-# {sue_inx},{event3},{accord23_str},{bob_inx},{bob_inx}
-# {sue_inx},{event3},{accord23_str},{yao_inx},{bob_inx}
-# {sue_inx},{event3},{accord23_str},{yao_inx},{yao_inx}
-# {sue_inx},{event7},{accord23_str},{yao_inx},{yao_inx}
-# """
-#     save_file(sue_aft_dir, br00011_csv_filename, br00011_csv_str)
+def test_populate_cmty_staging_tables_PopulatesCmtyStagingTables(
+    env_dir_setup_cleanup,
+):
+    # ESTABLISH
+    sue_inx = "Suzy"
+    bob_inx = "Bob"
+    yao_inx = "Yao"
+    event3 = 3
+    event7 = 7
+    accord23_str = "accord23"
+    aft_faces_dir = get_test_etl_dir()
+    sue_aft_dir = create_path(aft_faces_dir, sue_inx)
+    br00011_str = "br00011"
+    br00011_csv_filename = f"{br00011_str}.csv"
+    br00011_csv_str = f"""{face_name_str()},{event_int_str()},{cmty_title_str()},{owner_name_str()},{acct_name_str()}
+{sue_inx},{event3},{accord23_str},{bob_inx},{bob_inx}
+{sue_inx},{event3},{accord23_str},{yao_inx},{bob_inx}
+{sue_inx},{event3},{accord23_str},{yao_inx},{yao_inx}
+{sue_inx},{event7},{accord23_str},{yao_inx},{yao_inx}
+"""
+    save_file(sue_aft_dir, br00011_csv_filename, br00011_csv_str)
 
-#     cmtyunit_tablename = f"{cmtyunit_str()}_staging"
-#     with sqlite3_connect(":memory:") as fiscal_db_conn:
-#         etl_aft_face_csv_files_to_fiscal_db(fiscal_db_conn, aft_faces_dir)
-#         create_cmty_staging_tables(fiscal_db_conn)
-#         cursor = fiscal_db_conn.cursor()
-#         cursor.execute(f"SELECT * FROM {cmtyunit_tablename}")
-#         cmtyunit_db_rows = cursor.fetchall()
-#         assert cmtyunit_db_rows == []
+    cmtyunit_tablename = f"{cmtyunit_str()}_staging"
+    with sqlite3_connect(":memory:") as fiscal_db_conn:
+        etl_aft_face_csv_files_to_fiscal_db(fiscal_db_conn, aft_faces_dir)
+        create_cmty_staging_tables(fiscal_db_conn)
+        cursor = fiscal_db_conn.cursor()
+        cursor.execute(f"SELECT * FROM {cmtyunit_tablename}")
+        cmtyunit_db_rows = cursor.fetchall()
+        assert cmtyunit_db_rows == []
 
-#         # WHEN
-#         populate_cmty_staging_tables(fiscal_db_conn)
+        # WHEN
+        populate_cmty_staging_tables(fiscal_db_conn)
 
-#         # THEN
-#         cursor.execute(f"SELECT * FROM {cmtyunit_tablename}")
-#         cmtyunit_db_rows = cursor.fetchall()
-#         expected_row1 = (
-#             br00011_str,  # idea_number
-#             sue_inx,  # face_name
-#             event3,  # event_int
-#             accord23_str,  # cmty_title
-#             None,  # fund_coin
-#             None,  # penny
-#             None,  # respect_bit
-#             None,  # current_time
-#             None,  # bridge
-#             None,  # c400_number
-#             None,  # yr1_jan1_offset
-#             None,  # monthday_distortion
-#             None,  # timeline_title
-#         )
-#         expected_row2 = (
-#             br00011_str,  # idea_number
-#             sue_inx,  # face_name
-#             event7,  # event_int
-#             accord23_str,  # cmty_title
-#             None,  # fund_coin
-#             None,  # penny
-#             None,  # respect_bit
-#             None,  # current_time
-#             None,  # bridge
-#             None,  # c400_number
-#             None,  # yr1_jan1_offset
-#             None,  # monthday_distortion
-#             None,  # timeline_title
-#         )
-#         assert cmtyunit_db_rows == [expected_row1, expected_row2]
+        # THEN
+        cursor.execute(f"SELECT * FROM {cmtyunit_tablename}")
+        cmtyunit_db_rows = cursor.fetchall()
+        expected_row1 = (
+            br00011_str,  # idea_number
+            sue_inx,  # face_name
+            event3,  # event_int
+            accord23_str,  # cmty_title
+            None,  # fund_coin
+            None,  # penny
+            None,  # respect_bit
+            None,  # current_time
+            None,  # bridge
+            None,  # c400_number
+            None,  # yr1_jan1_offset
+            None,  # monthday_distortion
+            None,  # timeline_title
+        )
+        expected_row2 = (
+            br00011_str,  # idea_number
+            sue_inx,  # face_name
+            event7,  # event_int
+            accord23_str,  # cmty_title
+            None,  # fund_coin
+            None,  # penny
+            None,  # respect_bit
+            None,  # current_time
+            None,  # bridge
+            None,  # c400_number
+            None,  # yr1_jan1_offset
+            None,  # monthday_distortion
+            None,  # timeline_title
+        )
+        assert cmtyunit_db_rows == [expected_row1, expected_row2]

--- a/src/f10_etl/test/test_transformer_aft_face_ideas_csv_to_fiscal_db.py
+++ b/src/f10_etl/test/test_transformer_aft_face_ideas_csv_to_fiscal_db.py
@@ -19,7 +19,7 @@ from src.f08_pidgin.pidgin_config import event_int_str
 from src.f09_idea.pandas_tool import get_pragma_table_fetchall, get_sorting_columns
 from src.f10_etl.transformers import (
     etl_aft_face_csv_files_to_fiscal_db,
-    create_cmty_staging_tables,
+    create_cmty_tables,
     populate_cmty_staging_tables,
 )
 from src.f10_etl.examples.etl_env import get_test_etl_dir, env_dir_setup_cleanup
@@ -83,79 +83,123 @@ def test_etl_aft_face_csv_files_to_fiscal_db_DBChanges(
         assert br00011_db_rows == expected_data
 
 
-def test_create_cmty_staging_tables_CreatesCmtyStagingTables(
+def test_create_cmty_tables_CreatesCmtyStagingTables(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
-    cmtyunit_tablename = f"{cmtyunit_str()}_staging"
-    cmty_deal_episode_tablename = f"{cmty_deal_episode_str()}_staging"
-    cmty_cashbook_tablename = f"{cmty_cashbook_str()}_staging"
-    cmty_hour_tablename = f"{cmty_timeline_hour_str()}_staging"
-    cmty_month_tablename = f"{cmty_timeline_month_str()}_staging"
-    cmty_weekday_tablename = f"{cmty_timeline_weekday_str()}_staging"
+    agg_str = "_agg"
+    cmtyunit_agg_tablename = f"{cmtyunit_str()}{agg_str}"
+    cmtydeal_agg_tablename = f"{cmty_deal_episode_str()}{agg_str}"
+    cmtycash_agg_tablename = f"{cmty_cashbook_str()}{agg_str}"
+    cmtyhour_agg_tablename = f"{cmty_timeline_hour_str()}{agg_str}"
+    cmtymont_agg_tablename = f"{cmty_timeline_month_str()}{agg_str}"
+    cmtyweek_agg_tablename = f"{cmty_timeline_weekday_str()}{agg_str}"
+    staging_str = "_staging"
+    cmtyunit_stage_tablename = f"{cmtyunit_str()}{staging_str}"
+    cmtydeal_stage_tablename = f"{cmty_deal_episode_str()}{staging_str}"
+    cmtycash_stage_tablename = f"{cmty_cashbook_str()}{staging_str}"
+    cmtyhour_stage_tablename = f"{cmty_timeline_hour_str()}{staging_str}"
+    cmtymont_stage_tablename = f"{cmty_timeline_month_str()}{staging_str}"
+    cmtyweek_stage_tablename = f"{cmty_timeline_weekday_str()}{staging_str}"
     cmtyunit_args = get_cmty_config_args(cmtyunit_str()).keys()
-    cmty_deal_episode_args = get_cmty_config_args(cmty_deal_episode_str()).keys()
-    cmty_cashbook_args = get_cmty_config_args(cmty_cashbook_str()).keys()
-    cmty_hour_args = get_cmty_config_args(cmty_timeline_hour_str()).keys()
-    cmty_month_args = get_cmty_config_args(cmty_timeline_month_str()).keys()
-    cmty_weekday_args = get_cmty_config_args(cmty_timeline_weekday_str()).keys()
-    common_columns = ["idea_number", "face_name", "event_int"]
-    cmtyunit_columns = copy_copy(common_columns)
-    cmty_deal_episode_columns = copy_copy(common_columns)
-    cmty_cashbook_columns = copy_copy(common_columns)
-    cmty_hour_columns = copy_copy(common_columns)
-    cmty_month_columns = copy_copy(common_columns)
-    cmty_weekday_columns = copy_copy(common_columns)
-    cmtyunit_columns.extend(get_sorting_columns(cmtyunit_args))
-    cmty_deal_episode_columns.extend(get_sorting_columns(cmty_deal_episode_args))
-    cmty_cashbook_columns.extend(get_sorting_columns(cmty_cashbook_args))
-    cmty_hour_columns.extend(get_sorting_columns(cmty_hour_args))
-    cmty_month_columns.extend(get_sorting_columns(cmty_month_args))
-    cmty_weekday_columns.extend(get_sorting_columns(cmty_weekday_args))
-    cmtyunit_pragma = get_pragma_table_fetchall(cmtyunit_columns)
-    cmty_deal_episode_pragma = get_pragma_table_fetchall(cmty_deal_episode_columns)
-    cmty_cashbook_pragma = get_pragma_table_fetchall(cmty_cashbook_columns)
-    cmty_hour_pragma = get_pragma_table_fetchall(cmty_hour_columns)
-    cmty_month_pragma = get_pragma_table_fetchall(cmty_month_columns)
-    cmty_weekday_pragma = get_pragma_table_fetchall(cmty_weekday_columns)
+    cmtydeal_args = get_cmty_config_args(cmty_deal_episode_str()).keys()
+    cmtycash_args = get_cmty_config_args(cmty_cashbook_str()).keys()
+    cmtyhour_args = get_cmty_config_args(cmty_timeline_hour_str()).keys()
+    cmtymont_args = get_cmty_config_args(cmty_timeline_month_str()).keys()
+    cmtyweek_args = get_cmty_config_args(cmty_timeline_weekday_str()).keys()
+    staging_columns = ["idea_number", "face_name", "event_int"]
+    cmtyunit_agg_columns = get_sorting_columns(cmtyunit_args)
+    cmtydeal_agg_columns = get_sorting_columns(cmtydeal_args)
+    cmtycash_agg_columns = get_sorting_columns(cmtycash_args)
+    cmtyhour_agg_columns = get_sorting_columns(cmtyhour_args)
+    cmtymont_agg_columns = get_sorting_columns(cmtymont_args)
+    cmtyweek_agg_columns = get_sorting_columns(cmtyweek_args)
+    cmtyunit_agg_pragma = get_pragma_table_fetchall(cmtyunit_agg_columns)
+    cmtydeal_agg_pragma = get_pragma_table_fetchall(cmtydeal_agg_columns)
+    cmtycash_agg_pragma = get_pragma_table_fetchall(cmtycash_agg_columns)
+    cmtyhour_agg_pragma = get_pragma_table_fetchall(cmtyhour_agg_columns)
+    cmtymont_agg_pragma = get_pragma_table_fetchall(cmtymont_agg_columns)
+    cmtyweek_agg_pragma = get_pragma_table_fetchall(cmtyweek_agg_columns)
+
+    cmtyunit_stage_columns = copy_copy(staging_columns)
+    cmtydeal_stage_columns = copy_copy(staging_columns)
+    cmtycash_stage_columns = copy_copy(staging_columns)
+    cmtyhour_stage_columns = copy_copy(staging_columns)
+    cmtymont_stage_columns = copy_copy(staging_columns)
+    cmtyweek_stage_columns = copy_copy(staging_columns)
+    cmtyunit_stage_columns.extend(cmtyunit_agg_columns)
+    cmtydeal_stage_columns.extend(cmtydeal_agg_columns)
+    cmtycash_stage_columns.extend(cmtycash_agg_columns)
+    cmtyhour_stage_columns.extend(cmtyhour_agg_columns)
+    cmtymont_stage_columns.extend(cmtymont_agg_columns)
+    cmtyweek_stage_columns.extend(cmtyweek_agg_columns)
+    cmtyunit_stage_pragma = get_pragma_table_fetchall(cmtyunit_stage_columns)
+    cmtydeal_stage_pragma = get_pragma_table_fetchall(cmtydeal_stage_columns)
+    cmtycash_stage_pragma = get_pragma_table_fetchall(cmtycash_stage_columns)
+    cmtyhour_stage_pragma = get_pragma_table_fetchall(cmtyhour_stage_columns)
+    cmtymont_stage_pragma = get_pragma_table_fetchall(cmtymont_stage_columns)
+    cmtyweek_stage_pragma = get_pragma_table_fetchall(cmtyweek_stage_columns)
 
     with sqlite3_connect(":memory:") as fiscal_db_conn:
-        assert db_table_exists(fiscal_db_conn, cmtyunit_tablename) is False
-        assert db_table_exists(fiscal_db_conn, cmty_deal_episode_tablename) is False
-        assert db_table_exists(fiscal_db_conn, cmty_cashbook_tablename) is False
-        assert db_table_exists(fiscal_db_conn, cmty_hour_tablename) is False
-        assert db_table_exists(fiscal_db_conn, cmty_month_tablename) is False
-        assert db_table_exists(fiscal_db_conn, cmty_weekday_tablename) is False
+        assert db_table_exists(fiscal_db_conn, cmtyunit_agg_tablename) is False
+        assert db_table_exists(fiscal_db_conn, cmtydeal_agg_tablename) is False
+        assert db_table_exists(fiscal_db_conn, cmtycash_agg_tablename) is False
+        assert db_table_exists(fiscal_db_conn, cmtyhour_agg_tablename) is False
+        assert db_table_exists(fiscal_db_conn, cmtymont_agg_tablename) is False
+        assert db_table_exists(fiscal_db_conn, cmtyweek_agg_tablename) is False
+        assert db_table_exists(fiscal_db_conn, cmtyunit_stage_tablename) is False
+        assert db_table_exists(fiscal_db_conn, cmtydeal_stage_tablename) is False
+        assert db_table_exists(fiscal_db_conn, cmtycash_stage_tablename) is False
+        assert db_table_exists(fiscal_db_conn, cmtyhour_stage_tablename) is False
+        assert db_table_exists(fiscal_db_conn, cmtymont_stage_tablename) is False
+        assert db_table_exists(fiscal_db_conn, cmtyweek_stage_tablename) is False
 
         # WHEN
-        create_cmty_staging_tables(fiscal_db_conn)
+        create_cmty_tables(fiscal_db_conn)
 
         # THEN
-        assert db_table_exists(fiscal_db_conn, cmtyunit_tablename)
-        assert db_table_exists(fiscal_db_conn, cmty_deal_episode_tablename)
-        assert db_table_exists(fiscal_db_conn, cmty_cashbook_tablename)
-        assert db_table_exists(fiscal_db_conn, cmty_hour_tablename)
-        assert db_table_exists(fiscal_db_conn, cmty_month_tablename)
-        assert db_table_exists(fiscal_db_conn, cmty_weekday_tablename)
+        assert db_table_exists(fiscal_db_conn, cmtyunit_agg_tablename)
+        assert db_table_exists(fiscal_db_conn, cmtydeal_agg_tablename)
+        assert db_table_exists(fiscal_db_conn, cmtycash_agg_tablename)
+        assert db_table_exists(fiscal_db_conn, cmtyhour_agg_tablename)
+        assert db_table_exists(fiscal_db_conn, cmtymont_agg_tablename)
+        assert db_table_exists(fiscal_db_conn, cmtyweek_agg_tablename)
+
+        assert db_table_exists(fiscal_db_conn, cmtyunit_stage_tablename)
+        assert db_table_exists(fiscal_db_conn, cmtydeal_stage_tablename)
+        assert db_table_exists(fiscal_db_conn, cmtycash_stage_tablename)
+        assert db_table_exists(fiscal_db_conn, cmtyhour_stage_tablename)
+        assert db_table_exists(fiscal_db_conn, cmtymont_stage_tablename)
+        assert db_table_exists(fiscal_db_conn, cmtyweek_stage_tablename)
         cursor = fiscal_db_conn.cursor()
-        cursor.execute(f"PRAGMA table_info({cmtyunit_tablename})")
-        print(f"{cmtyunit_pragma=}")
-        assert cmtyunit_pragma == cursor.fetchall()
-        cursor.execute(f"PRAGMA table_info({cmty_deal_episode_tablename})")
-        assert cmty_deal_episode_pragma == cursor.fetchall()
-        cursor.execute(f"PRAGMA table_info({cmty_cashbook_tablename})")
-        assert cmty_cashbook_pragma == cursor.fetchall()
-        cursor.execute(f"PRAGMA table_info({cmty_hour_tablename})")
-        assert cmty_hour_pragma == cursor.fetchall()
-        cursor.execute(f"PRAGMA table_info({cmty_month_tablename})")
-        assert cmty_month_pragma == cursor.fetchall()
-        cursor.execute(f"PRAGMA table_info({cmty_weekday_tablename})")
-        assert cmty_weekday_pragma == cursor.fetchall()
+        cursor.execute(f"PRAGMA table_info({cmtyunit_agg_tablename})")
+        assert cmtyunit_agg_pragma == cursor.fetchall()
+        cursor.execute(f"PRAGMA table_info({cmtydeal_agg_tablename})")
+        assert cmtydeal_agg_pragma == cursor.fetchall()
+        cursor.execute(f"PRAGMA table_info({cmtycash_agg_tablename})")
+        assert cmtycash_agg_pragma == cursor.fetchall()
+        cursor.execute(f"PRAGMA table_info({cmtyhour_agg_tablename})")
+        assert cmtyhour_agg_pragma == cursor.fetchall()
+        cursor.execute(f"PRAGMA table_info({cmtymont_agg_tablename})")
+        assert cmtymont_agg_pragma == cursor.fetchall()
+        cursor.execute(f"PRAGMA table_info({cmtyweek_agg_tablename})")
+        assert cmtyweek_agg_pragma == cursor.fetchall()
+
+        cursor.execute(f"PRAGMA table_info({cmtyunit_stage_tablename})")
+        assert cmtyunit_stage_pragma == cursor.fetchall()
+        cursor.execute(f"PRAGMA table_info({cmtydeal_stage_tablename})")
+        assert cmtydeal_stage_pragma == cursor.fetchall()
+        cursor.execute(f"PRAGMA table_info({cmtycash_stage_tablename})")
+        assert cmtycash_stage_pragma == cursor.fetchall()
+        cursor.execute(f"PRAGMA table_info({cmtyhour_stage_tablename})")
+        assert cmtyhour_stage_pragma == cursor.fetchall()
+        cursor.execute(f"PRAGMA table_info({cmtymont_stage_tablename})")
+        assert cmtymont_stage_pragma == cursor.fetchall()
+        cursor.execute(f"PRAGMA table_info({cmtyweek_stage_tablename})")
+        assert cmtyweek_stage_pragma == cursor.fetchall()
 
 
-def test_populate_cmty_staging_tables_PopulatesCmtyStagingTables(
-    env_dir_setup_cleanup,
-):
+def test_populate_cmty_staging_tables_PopulatesCmtyStagingTables(env_dir_setup_cleanup):
     # ESTABLISH
     sue_inx = "Suzy"
     bob_inx = "Bob"
@@ -178,7 +222,7 @@ def test_populate_cmty_staging_tables_PopulatesCmtyStagingTables(
     cmtyunit_tablename = f"{cmtyunit_str()}_staging"
     with sqlite3_connect(":memory:") as fiscal_db_conn:
         etl_aft_face_csv_files_to_fiscal_db(fiscal_db_conn, aft_faces_dir)
-        create_cmty_staging_tables(fiscal_db_conn)
+        create_cmty_tables(fiscal_db_conn)
         cursor = fiscal_db_conn.cursor()
         cursor.execute(f"SELECT * FROM {cmtyunit_tablename}")
         cmtyunit_db_rows = cursor.fetchall()

--- a/src/f10_etl/transformers.py
+++ b/src/f10_etl/transformers.py
@@ -745,7 +745,11 @@ def etl_aft_face_csv_files_to_fiscal_db(conn: sqlite3_Connection, faces_aft_dir:
             csv_path = create_path(face_dir, csv_filename)
             if os_path_exists(csv_path):
                 insert_idea_csv(csv_path, conn, f"{idea_number}_staging")
+
+
+def etl_idea_staging_to_cmty_staging(conn):
     create_cmty_staging_tables(conn)
+    populate_cmty_staging_tables(conn)
 
 
 def create_cmty_staging_tables(conn: sqlite3_Connection):

--- a/src/f10_etl/transformers.py
+++ b/src/f10_etl/transformers.py
@@ -748,53 +748,73 @@ def etl_aft_face_csv_files_to_fiscal_db(conn: sqlite3_Connection, faces_aft_dir:
 
 
 def etl_idea_staging_to_cmty_staging(conn):
-    create_cmty_staging_tables(conn)
+    create_cmty_tables(conn)
     populate_cmty_staging_tables(conn)
 
 
-def create_cmty_staging_tables(conn: sqlite3_Connection):
-    common_columns = ["idea_number", "face_name", "event_int"]
-    cmtyunit_cols = copy_copy(common_columns)
-    cmty_deal_episode_cols = copy_copy(common_columns)
-    cmty_cashbook_cols = copy_copy(common_columns)
-    cmty_hour_cols = copy_copy(common_columns)
-    cmty_month_cols = copy_copy(common_columns)
-    cmty_weekday_cols = copy_copy(common_columns)
-
-    cmtyunit_cols.extend(
-        [
-            "cmty_title",
-            "fund_coin",
-            "penny",
-            "respect_bit",
-            "current_time",
-            "bridge",
-            "c400_number",
-            "yr1_jan1_offset",
-            "monthday_distortion",
-            "timeline_title",
-        ]
-    )
-    cmty_deal_episode_cols.extend(["cmty_title", "owner_name", "time_int", "quota"])
-    cmty_cashbook_cols.extend(
-        ["cmty_title", "owner_name", "acct_name", "time_int", "amount"]
-    )
-    cmty_hour_cols.extend(["cmty_title", "hour_title", "cumlative_minute"])
-    cmty_month_cols.extend(["cmty_title", "month_title", "cumlative_day"])
-    cmty_weekday_cols.extend(["cmty_title", "weekday_title", "weekday_order"])
+def create_cmty_tables(conn: sqlite3_Connection):
+    cmtyunit_agg_cols = [
+        "cmty_title",
+        "fund_coin",
+        "penny",
+        "respect_bit",
+        "current_time",
+        "bridge",
+        "c400_number",
+        "yr1_jan1_offset",
+        "monthday_distortion",
+        "timeline_title",
+    ]
+    cmtydeal_agg_cols = ["cmty_title", "owner_name", "time_int", "quota"]
+    cmtycash_agg_cols = [
+        "cmty_title",
+        "owner_name",
+        "acct_name",
+        "time_int",
+        "amount",
+    ]
+    cmtyhour_agg_cols = ["cmty_title", "hour_title", "cumlative_minute"]
+    cmtymont_agg_cols = ["cmty_title", "month_title", "cumlative_day"]
+    cmtyweek_agg_cols = ["cmty_title", "weekday_title", "weekday_order"]
+    cmtyunit_agg = "cmtyunit_agg"
+    cmtydeal_agg = "cmty_deal_episode_agg"
+    cmtycash_agg = "cmty_cashbook_agg"
+    cmtyhour_agg = "cmty_timeline_hour_agg"
+    cmtymont_agg = "cmty_timeline_month_agg"
+    cmtyweek_agg = "cmty_timeline_weekday_agg"
     col_types = get_idea_sqlite_types()
-    cmtyunit = "cmtyunit_staging"
-    cmtydeal = "cmty_deal_episode_staging"
-    cmtycash = "cmty_cashbook_staging"
-    cmtyhour = "cmty_timeline_hour_staging"
-    cmtymont = "cmty_timeline_month_staging"
-    cmtyweek = "cmty_timeline_weekday_staging"
-    create_table_from_columns(conn, cmtyunit, cmtyunit_cols, col_types)
-    create_table_from_columns(conn, cmtydeal, cmty_deal_episode_cols, col_types)
-    create_table_from_columns(conn, cmtycash, cmty_cashbook_cols, col_types)
-    create_table_from_columns(conn, cmtyhour, cmty_hour_cols, col_types)
-    create_table_from_columns(conn, cmtymont, cmty_month_cols, col_types)
-    create_table_from_columns(conn, cmtyweek, cmty_weekday_cols, col_types)
+    create_table_from_columns(conn, cmtyunit_agg, cmtyunit_agg_cols, col_types)
+    create_table_from_columns(conn, cmtydeal_agg, cmtydeal_agg_cols, col_types)
+    create_table_from_columns(conn, cmtycash_agg, cmtycash_agg_cols, col_types)
+    create_table_from_columns(conn, cmtyhour_agg, cmtyhour_agg_cols, col_types)
+    create_table_from_columns(conn, cmtymont_agg, cmtymont_agg_cols, col_types)
+    create_table_from_columns(conn, cmtyweek_agg, cmtyweek_agg_cols, col_types)
+
+    staging_columns = ["idea_number", "face_name", "event_int"]
+    cmtyunit_stage_cols = copy_copy(staging_columns)
+    cmtydeal_stage_cols = copy_copy(staging_columns)
+    cmtycash_stage_cols = copy_copy(staging_columns)
+    cmtyhour_stage_cols = copy_copy(staging_columns)
+    cmtymont_stage_cols = copy_copy(staging_columns)
+    cmtyweek_stage_cols = copy_copy(staging_columns)
+    cmtyunit_stage_cols.extend(cmtyunit_agg_cols)
+    cmtydeal_stage_cols.extend(cmtydeal_agg_cols)
+    cmtycash_stage_cols.extend(cmtycash_agg_cols)
+    cmtyhour_stage_cols.extend(cmtyhour_agg_cols)
+    cmtymont_stage_cols.extend(cmtymont_agg_cols)
+    cmtyweek_stage_cols.extend(cmtyweek_agg_cols)
+    cmtyunit_stage = "cmtyunit_staging"
+    cmtydeal_stage = "cmty_deal_episode_staging"
+    cmtycash_stage = "cmty_cashbook_staging"
+    cmtyhour_stage = "cmty_timeline_hour_staging"
+    cmtymont_stage = "cmty_timeline_month_staging"
+    cmtyweek_stage = "cmty_timeline_weekday_staging"
+    create_table_from_columns(conn, cmtyunit_stage, cmtyunit_stage_cols, col_types)
+    create_table_from_columns(conn, cmtydeal_stage, cmtydeal_stage_cols, col_types)
+    create_table_from_columns(conn, cmtycash_stage, cmtycash_stage_cols, col_types)
+    create_table_from_columns(conn, cmtyhour_stage, cmtyhour_stage_cols, col_types)
+    create_table_from_columns(conn, cmtymont_stage, cmtymont_stage_cols, col_types)
+    create_table_from_columns(conn, cmtyweek_stage, cmtyweek_stage_cols, col_types)
 
 
 def populate_cmty_staging_tables(fiscal_db_conn: sqlite3_Connection):

--- a/src/f11_world/test/test_world_etl05_00_aft_face_ideas_to_cmty_staging.py
+++ b/src/f11_world/test/test_world_etl05_00_aft_face_ideas_to_cmty_staging.py
@@ -131,12 +131,13 @@ def test_WorldUnit_memory_fiscal_db_conn_CreatesCmtyStagingTables(
 
     # WHEN / THEN
     if platform_system() != "Linux":  # bug on github commit
-        cmtyunit_tablename = f"{cmtyunit_str()}_staging"
-        cmty_deal_episode_tablename = f"{cmty_deal_episode_str()}_staging"
-        cmty_cashbook_tablename = f"{cmty_cashbook_str()}_staging"
-        cmty_hour_tablename = f"{cmty_timeline_hour_str()}_staging"
-        cmty_month_tablename = f"{cmty_timeline_month_str()}_staging"
-        cmty_weekday_tablename = f"{cmty_timeline_weekday_str()}_staging"
+        staging_str = "_staging"
+        cmtyunit_tablename = f"{cmtyunit_str()}{staging_str}"
+        cmty_deal_episode_tablename = f"{cmty_deal_episode_str()}{staging_str}"
+        cmty_cashbook_tablename = f"{cmty_cashbook_str()}{staging_str}"
+        cmty_hour_tablename = f"{cmty_timeline_hour_str()}{staging_str}"
+        cmty_month_tablename = f"{cmty_timeline_month_str()}{staging_str}"
+        cmty_weekday_tablename = f"{cmty_timeline_weekday_str()}{staging_str}"
         cmtyunit_args = get_cmty_config_args(cmtyunit_str()).keys()
         cmty_deal_episode_args = get_cmty_config_args(cmty_deal_episode_str()).keys()
         cmty_cashbook_args = get_cmty_config_args(cmty_cashbook_str()).keys()
@@ -191,67 +192,67 @@ def test_WorldUnit_memory_fiscal_db_conn_CreatesCmtyStagingTables(
             assert cmty_weekday_pragma == cursor.fetchall()
 
 
-# def test_WorldUnit_memory_fiscal_db_conn_PopulatesCmtyStagingTables(
-#     env_dir_setup_cleanup,
-# ):
-#     # ESTABLISH
-#     sue_inx = "Suzy"
-#     bob_inx = "Bob"
-#     yao_inx = "Yao"
-#     event3 = 3
-#     event7 = 7
-#     accord23_str = "accord23"
-#     fizz_world = worldunit_shop("fizz")
-#     sue_aft_dir = create_path(fizz_world._faces_aft_dir, sue_inx)
-#     br00011_str = "br00011"
-#     br00011_csv_filename = f"{br00011_str}.csv"
-#     br00011_csv_str = f"""{face_name_str()},{event_int_str()},{cmty_title_str()},{owner_name_str()},{acct_name_str()}
-# {sue_inx},{event3},{accord23_str},{bob_inx},{bob_inx}
-# {sue_inx},{event3},{accord23_str},{yao_inx},{bob_inx}
-# {sue_inx},{event3},{accord23_str},{yao_inx},{yao_inx}
-# {sue_inx},{event7},{accord23_str},{yao_inx},{yao_inx}
-# """
-#     save_file(sue_aft_dir, br00011_csv_filename, br00011_csv_str)
-#     fizz_world = worldunit_shop("Fizz")
+def test_WorldUnit_memory_fiscal_db_conn_PopulatesCmtyStagingTables(
+    env_dir_setup_cleanup,
+):
+    # ESTABLISH
+    sue_inx = "Suzy"
+    bob_inx = "Bob"
+    yao_inx = "Yao"
+    event3 = 3
+    event7 = 7
+    accord23_str = "accord23"
+    fizz_world = worldunit_shop("fizz")
+    sue_aft_dir = create_path(fizz_world._faces_aft_dir, sue_inx)
+    br00011_str = "br00011"
+    br00011_csv_filename = f"{br00011_str}.csv"
+    br00011_csv_str = f"""{face_name_str()},{event_int_str()},{cmty_title_str()},{owner_name_str()},{acct_name_str()}
+{sue_inx},{event3},{accord23_str},{bob_inx},{bob_inx}
+{sue_inx},{event3},{accord23_str},{yao_inx},{bob_inx}
+{sue_inx},{event3},{accord23_str},{yao_inx},{yao_inx}
+{sue_inx},{event7},{accord23_str},{yao_inx},{yao_inx}
+"""
+    save_file(sue_aft_dir, br00011_csv_filename, br00011_csv_str)
+    fizz_world = worldunit_shop("Fizz")
 
-#     # WHEN / THEN
-#     if platform_system() != "Linux":  # bug on github commit
-#         cmtyunit_tablename = f"{cmtyunit_str()}_staging"
-#         with fizz_world.memory_fiscal_db_conn() as fiscal_db_conn:
-#             cursor = fiscal_db_conn.cursor()
-#             cursor.execute(f"SELECT * FROM {cmtyunit_tablename}")
-#             cmtyunit_db_rows = cursor.fetchall()
-#             expected_row1 = (
-#                 br00011_str,
-#                 sue_inx,
-#                 event3,
-#                 accord23_str,  # cmty_title
-#                 None,  # fund_coin
-#                 None,  # penny
-#                 None,  # respect_bit
-#                 None,  # current_time
-#                 None,  # bridge
-#                 None,  # c400_number
-#                 None,  # yr1_jan1_offset
-#                 None,  # monthday_distortion
-#                 None,  # timeline_title
-#             )
-#             expected_row2 = (
-#                 br00011_str,
-#                 sue_inx,
-#                 event7,
-#                 accord23_str,  # cmty_title
-#                 None,  # fund_coin
-#                 None,  # penny
-#                 None,  # respect_bit
-#                 None,  # current_time
-#                 None,  # bridge
-#                 None,  # c400_number
-#                 None,  # yr1_jan1_offset
-#                 None,  # monthday_distortion
-#                 None,  # timeline_title
-#             )
-#             assert cmtyunit_db_rows == [expected_row1, expected_row2]
+    # WHEN / THEN
+    if platform_system() != "Linux":  # bug on github commit
+        cmtyunit_tablename = f"{cmtyunit_str()}_staging"
+        with fizz_world.memory_fiscal_db_conn() as fiscal_db_conn:
+            cursor = fiscal_db_conn.cursor()
+            cursor.execute(f"SELECT * FROM {cmtyunit_tablename}")
+            cmtyunit_db_rows = cursor.fetchall()
+            expected_row1 = (
+                br00011_str,
+                sue_inx,
+                event3,
+                accord23_str,  # cmty_title
+                None,  # fund_coin
+                None,  # penny
+                None,  # respect_bit
+                None,  # current_time
+                None,  # bridge
+                None,  # c400_number
+                None,  # yr1_jan1_offset
+                None,  # monthday_distortion
+                None,  # timeline_title
+            )
+            expected_row2 = (
+                br00011_str,
+                sue_inx,
+                event7,
+                accord23_str,  # cmty_title
+                None,  # fund_coin
+                None,  # penny
+                None,  # respect_bit
+                None,  # current_time
+                None,  # bridge
+                None,  # c400_number
+                None,  # yr1_jan1_offset
+                None,  # monthday_distortion
+                None,  # timeline_title
+            )
+            assert cmtyunit_db_rows == [expected_row1, expected_row2]
 
 
 # def test_WorldUnit_aft_faces_ideas_to_cmty_staging_CreatesCorrectTables(

--- a/src/f11_world/test/test_world_etl05_00_aft_face_ideas_to_cmty_staging.py
+++ b/src/f11_world/test/test_world_etl05_00_aft_face_ideas_to_cmty_staging.py
@@ -131,65 +131,99 @@ def test_WorldUnit_memory_fiscal_db_conn_CreatesCmtyStagingTables(
 
     # WHEN / THEN
     if platform_system() != "Linux":  # bug on github commit
+        agg_str = "_agg"
+        cmtyunit_agg_tablename = f"{cmtyunit_str()}{agg_str}"
+        cmtydeal_agg_tablename = f"{cmty_deal_episode_str()}{agg_str}"
+        cmtycash_agg_tablename = f"{cmty_cashbook_str()}{agg_str}"
+        cmtyhour_agg_tablename = f"{cmty_timeline_hour_str()}{agg_str}"
+        cmtymont_agg_tablename = f"{cmty_timeline_month_str()}{agg_str}"
+        cmtyweek_agg_tablename = f"{cmty_timeline_weekday_str()}{agg_str}"
         staging_str = "_staging"
-        cmtyunit_tablename = f"{cmtyunit_str()}{staging_str}"
-        cmty_deal_episode_tablename = f"{cmty_deal_episode_str()}{staging_str}"
-        cmty_cashbook_tablename = f"{cmty_cashbook_str()}{staging_str}"
-        cmty_hour_tablename = f"{cmty_timeline_hour_str()}{staging_str}"
-        cmty_month_tablename = f"{cmty_timeline_month_str()}{staging_str}"
-        cmty_weekday_tablename = f"{cmty_timeline_weekday_str()}{staging_str}"
+        cmtyunit_stage_tablename = f"{cmtyunit_str()}{staging_str}"
+        cmtydeal_stage_tablename = f"{cmty_deal_episode_str()}{staging_str}"
+        cmtycash_stage_tablename = f"{cmty_cashbook_str()}{staging_str}"
+        cmtyhour_stage_tablename = f"{cmty_timeline_hour_str()}{staging_str}"
+        cmtymont_stage_tablename = f"{cmty_timeline_month_str()}{staging_str}"
+        cmtyweek_stage_tablename = f"{cmty_timeline_weekday_str()}{staging_str}"
         cmtyunit_args = get_cmty_config_args(cmtyunit_str()).keys()
-        cmty_deal_episode_args = get_cmty_config_args(cmty_deal_episode_str()).keys()
-        cmty_cashbook_args = get_cmty_config_args(cmty_cashbook_str()).keys()
-        cmty_hour_args = get_cmty_config_args(cmty_timeline_hour_str()).keys()
-        cmty_month_args = get_cmty_config_args(cmty_timeline_month_str()).keys()
-        cmty_weekday_args = get_cmty_config_args(cmty_timeline_weekday_str()).keys()
-        common_columns = ["idea_number", "face_name", "event_int"]
-        cmtyunit_columns = copy_copy(common_columns)
-        cmty_deal_episode_columns = copy_copy(common_columns)
-        cmty_cashbook_columns = copy_copy(common_columns)
-        cmty_hour_columns = copy_copy(common_columns)
-        cmty_month_columns = copy_copy(common_columns)
-        cmty_weekday_columns = copy_copy(common_columns)
-        cmtyunit_columns.extend(get_sorting_columns(cmtyunit_args))
-        cmty_deal_episode_columns.extend(get_sorting_columns(cmty_deal_episode_args))
-        cmty_cashbook_columns.extend(get_sorting_columns(cmty_cashbook_args))
-        cmty_hour_columns.extend(get_sorting_columns(cmty_hour_args))
-        cmty_month_columns.extend(get_sorting_columns(cmty_month_args))
-        cmty_weekday_columns.extend(get_sorting_columns(cmty_weekday_args))
-        cmtyunit_pragma = get_pragma_table_fetchall(cmtyunit_columns)
-        cmty_deal_episode_pragma = get_pragma_table_fetchall(cmty_deal_episode_columns)
-        cmty_cashbook_pragma = get_pragma_table_fetchall(cmty_cashbook_columns)
-        cmty_hour_pragma = get_pragma_table_fetchall(cmty_hour_columns)
-        cmty_month_pragma = get_pragma_table_fetchall(cmty_month_columns)
-        cmty_weekday_pragma = get_pragma_table_fetchall(cmty_weekday_columns)
-        cmtyunit_pragma = get_pragma_table_fetchall(cmtyunit_columns)
-        cmty_deal_episode_pragma = get_pragma_table_fetchall(cmty_deal_episode_columns)
-        cmty_cashbook_pragma = get_pragma_table_fetchall(cmty_cashbook_columns)
-        cmty_hour_pragma = get_pragma_table_fetchall(cmty_hour_columns)
-        cmty_month_pragma = get_pragma_table_fetchall(cmty_month_columns)
-        cmty_weekday_pragma = get_pragma_table_fetchall(cmty_weekday_columns)
+        cmtydeal_args = get_cmty_config_args(cmty_deal_episode_str()).keys()
+        cmtycash_args = get_cmty_config_args(cmty_cashbook_str()).keys()
+        cmtyhour_args = get_cmty_config_args(cmty_timeline_hour_str()).keys()
+        cmtymont_args = get_cmty_config_args(cmty_timeline_month_str()).keys()
+        cmtyweek_args = get_cmty_config_args(cmty_timeline_weekday_str()).keys()
+        staging_columns = ["idea_number", "face_name", "event_int"]
+        cmtyunit_agg_columns = get_sorting_columns(cmtyunit_args)
+        cmtydeal_agg_columns = get_sorting_columns(cmtydeal_args)
+        cmtycash_agg_columns = get_sorting_columns(cmtycash_args)
+        cmtyhour_agg_columns = get_sorting_columns(cmtyhour_args)
+        cmtymont_agg_columns = get_sorting_columns(cmtymont_args)
+        cmtyweek_agg_columns = get_sorting_columns(cmtyweek_args)
+        cmtyunit_agg_pragma = get_pragma_table_fetchall(cmtyunit_agg_columns)
+        cmtydeal_agg_pragma = get_pragma_table_fetchall(cmtydeal_agg_columns)
+        cmtycash_agg_pragma = get_pragma_table_fetchall(cmtycash_agg_columns)
+        cmtyhour_agg_pragma = get_pragma_table_fetchall(cmtyhour_agg_columns)
+        cmtymont_agg_pragma = get_pragma_table_fetchall(cmtymont_agg_columns)
+        cmtyweek_agg_pragma = get_pragma_table_fetchall(cmtyweek_agg_columns)
+
+        cmtyunit_stage_columns = copy_copy(staging_columns)
+        cmtydeal_stage_columns = copy_copy(staging_columns)
+        cmtycash_stage_columns = copy_copy(staging_columns)
+        cmtyhour_stage_columns = copy_copy(staging_columns)
+        cmtymont_stage_columns = copy_copy(staging_columns)
+        cmtyweek_stage_columns = copy_copy(staging_columns)
+        cmtyunit_stage_columns.extend(cmtyunit_agg_columns)
+        cmtydeal_stage_columns.extend(cmtydeal_agg_columns)
+        cmtycash_stage_columns.extend(cmtycash_agg_columns)
+        cmtyhour_stage_columns.extend(cmtyhour_agg_columns)
+        cmtymont_stage_columns.extend(cmtymont_agg_columns)
+        cmtyweek_stage_columns.extend(cmtyweek_agg_columns)
+        cmtyunit_stage_pragma = get_pragma_table_fetchall(cmtyunit_stage_columns)
+        cmtydeal_stage_pragma = get_pragma_table_fetchall(cmtydeal_stage_columns)
+        cmtycash_stage_pragma = get_pragma_table_fetchall(cmtycash_stage_columns)
+        cmtyhour_stage_pragma = get_pragma_table_fetchall(cmtyhour_stage_columns)
+        cmtymont_stage_pragma = get_pragma_table_fetchall(cmtymont_stage_columns)
+        cmtyweek_stage_pragma = get_pragma_table_fetchall(cmtyweek_stage_columns)
 
         with fizz_world.memory_fiscal_db_conn() as fiscal_db_conn:
-            assert db_table_exists(fiscal_db_conn, cmtyunit_tablename)
-            assert db_table_exists(fiscal_db_conn, cmty_deal_episode_tablename)
-            assert db_table_exists(fiscal_db_conn, cmty_cashbook_tablename)
-            assert db_table_exists(fiscal_db_conn, cmty_hour_tablename)
-            assert db_table_exists(fiscal_db_conn, cmty_month_tablename)
-            assert db_table_exists(fiscal_db_conn, cmty_weekday_tablename)
+            assert db_table_exists(fiscal_db_conn, cmtyunit_agg_tablename)
+            assert db_table_exists(fiscal_db_conn, cmtydeal_agg_tablename)
+            assert db_table_exists(fiscal_db_conn, cmtycash_agg_tablename)
+            assert db_table_exists(fiscal_db_conn, cmtyhour_agg_tablename)
+            assert db_table_exists(fiscal_db_conn, cmtymont_agg_tablename)
+            assert db_table_exists(fiscal_db_conn, cmtyweek_agg_tablename)
+
+            assert db_table_exists(fiscal_db_conn, cmtyunit_stage_tablename)
+            assert db_table_exists(fiscal_db_conn, cmtydeal_stage_tablename)
+            assert db_table_exists(fiscal_db_conn, cmtycash_stage_tablename)
+            assert db_table_exists(fiscal_db_conn, cmtyhour_stage_tablename)
+            assert db_table_exists(fiscal_db_conn, cmtymont_stage_tablename)
+            assert db_table_exists(fiscal_db_conn, cmtyweek_stage_tablename)
             cursor = fiscal_db_conn.cursor()
-            cursor.execute(f"PRAGMA table_info({cmtyunit_tablename})")
-            assert cmtyunit_pragma == cursor.fetchall()
-            cursor.execute(f"PRAGMA table_info({cmty_deal_episode_tablename})")
-            assert cmty_deal_episode_pragma == cursor.fetchall()
-            cursor.execute(f"PRAGMA table_info({cmty_cashbook_tablename})")
-            assert cmty_cashbook_pragma == cursor.fetchall()
-            cursor.execute(f"PRAGMA table_info({cmty_hour_tablename})")
-            assert cmty_hour_pragma == cursor.fetchall()
-            cursor.execute(f"PRAGMA table_info({cmty_month_tablename})")
-            assert cmty_month_pragma == cursor.fetchall()
-            cursor.execute(f"PRAGMA table_info({cmty_weekday_tablename})")
-            assert cmty_weekday_pragma == cursor.fetchall()
+            cursor.execute(f"PRAGMA table_info({cmtyunit_agg_tablename})")
+            assert cmtyunit_agg_pragma == cursor.fetchall()
+            cursor.execute(f"PRAGMA table_info({cmtydeal_agg_tablename})")
+            assert cmtydeal_agg_pragma == cursor.fetchall()
+            cursor.execute(f"PRAGMA table_info({cmtycash_agg_tablename})")
+            assert cmtycash_agg_pragma == cursor.fetchall()
+            cursor.execute(f"PRAGMA table_info({cmtyhour_agg_tablename})")
+            assert cmtyhour_agg_pragma == cursor.fetchall()
+            cursor.execute(f"PRAGMA table_info({cmtymont_agg_tablename})")
+            assert cmtymont_agg_pragma == cursor.fetchall()
+            cursor.execute(f"PRAGMA table_info({cmtyweek_agg_tablename})")
+            assert cmtyweek_agg_pragma == cursor.fetchall()
+
+            cursor.execute(f"PRAGMA table_info({cmtyunit_stage_tablename})")
+            assert cmtyunit_stage_pragma == cursor.fetchall()
+            cursor.execute(f"PRAGMA table_info({cmtydeal_stage_tablename})")
+            assert cmtydeal_stage_pragma == cursor.fetchall()
+            cursor.execute(f"PRAGMA table_info({cmtycash_stage_tablename})")
+            assert cmtycash_stage_pragma == cursor.fetchall()
+            cursor.execute(f"PRAGMA table_info({cmtyhour_stage_tablename})")
+            assert cmtyhour_stage_pragma == cursor.fetchall()
+            cursor.execute(f"PRAGMA table_info({cmtymont_stage_tablename})")
+            assert cmtymont_stage_pragma == cursor.fetchall()
+            cursor.execute(f"PRAGMA table_info({cmtyweek_stage_tablename})")
+            assert cmtyweek_stage_pragma == cursor.fetchall()
 
 
 def test_WorldUnit_memory_fiscal_db_conn_PopulatesCmtyStagingTables(

--- a/src/f11_world/world.py
+++ b/src/f11_world/world.py
@@ -38,6 +38,7 @@ from src.f10_etl.transformers import (
     etl_aft_event_ideas_to_cmty_ideas,
     etl_aft_face_ideas_to_csv_files,
     etl_aft_face_csv_files_to_fiscal_db,
+    etl_idea_staging_to_cmty_staging,
 )
 from dataclasses import dataclass
 from sqlite3 import connect as sqlite3_connect
@@ -171,6 +172,7 @@ class WorldUnit:
     def memory_fiscal_db_conn(self):
         conn = sqlite3_connect(":memory:")
         etl_aft_face_csv_files_to_fiscal_db(conn, self._faces_aft_dir)
+        etl_idea_staging_to_cmty_staging(conn)
         return conn
 
     def aft_faces_ideas_to_cmty_staging(self):


### PR DESCRIPTION
## Summary by Sourcery

Create cmtyunit_agg, cmty_deal_episode_agg, cmty_cashbook_agg, cmty_timeline_hour_agg, cmty_timeline_month_agg, and cmty_timeline_weekday_agg tables. Populate the cmtyunit_staging table with community title data.

New Features:
- Added new aggregate tables for community units, deal episodes, cashbooks, and timeline hours, months, and weekdays.

Tests:
- Updated tests to reflect the new table structure and data population.