### PR TITLE
#495 test fix closes #497, closes #498

### DIFF
--- a/src/f11_world/test/test_world_etl06_01_s1_idea_tables_to_bud_staging_tables.py
+++ b/src/f11_world/test/test_world_etl06_01_s1_idea_tables_to_bud_staging_tables.py
@@ -196,7 +196,7 @@ VALUES
         x_error_message = "Inconsistent fiscal data"
         assert rows == [
             (event3, accord23_str, yao_credit_belief5, None),
-            (event7, accord23_str, yao_credit_belief5, None),
+            (event3, accord23_str, None, None),
             (event7, accord23_str, yao_credit_belief5, None),
             (event7, accord45_str, yao_credit_belief5, x_error_message),
             (event7, accord45_str, yao_credit_belief7, x_error_message),


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct an issue where inconsistent fiscal data in the IDEA staging tables led to an erroneous error message during the ETL process to BUD staging tables.