### PR TITLE
closes #502 replace "CorrectObj" with "Obj"

### DIFF
--- a/src/f00_instrument/test/test_db_tool.py
+++ b/src/f00_instrument/test/test_db_tool.py
@@ -33,19 +33,19 @@ from sqlite3 import (
 )
 
 
-def test_sqlite_null_ReturnsCorrectObj():
+def test_sqlite_null_ReturnsObj():
     assert sqlite_null(True)
     assert sqlite_null("yea") == "yea"
     assert sqlite_null(None) == "NULL"
 
 
-def test_sqlite_bool_ReturnsCorrectObj():
+def test_sqlite_bool_ReturnsObj():
     assert sqlite_bool(x_int=0) is False
     assert sqlite_bool(x_int=1)
     assert sqlite_bool(x_int=None) == "NULL"
 
 
-def test_sqlite_str_ReturnsCorrectObj():
+def test_sqlite_str_ReturnsObj():
     assert sqlite_str(True) == "TRUE"
     assert sqlite_str(False) == "FALSE"
     # WHEN / THEN
@@ -54,7 +54,7 @@ def test_sqlite_str_ReturnsCorrectObj():
     assert str(excinfo.value) == "function requires boolean"
 
 
-def test_sqlite_create_insert_sqlstr_ReturnsCorrectObj():
+def test_sqlite_create_insert_sqlstr_ReturnsObj():
     # ESTABLISH
     x_table = "kubo_trains"
     eagle_id_str = "eagle_id"
@@ -157,7 +157,7 @@ def test_rowdata_shop_ReturnsObjWithoutNone():
     assert x_rowdata.row_dict == {"name": "Earth", "radius": 6378}
 
 
-def test_get_rowdata_ReturnsCorrectObj():
+def test_get_rowdata_ReturnsObj():
     # ESTABLISH
     x_tablename = "earth"
 

--- a/src/f00_instrument/test/test_dict_tool.py
+++ b/src/f00_instrument/test/test_dict_tool.py
@@ -341,7 +341,7 @@ def test_get_from_nested_dict_ReturnsNoneWhen_if_missing_return_None_True():
     assert x_value is None
 
 
-def test_get_positive_int_ReturnsCorrectObj():
+def test_get_positive_int_ReturnsObj():
     # ESTABLISH / WHEN / THEN
     assert get_positive_int(None) == 0
     assert get_positive_int("sports") == 0

--- a/src/f00_instrument/test/test_file.py
+++ b/src/f00_instrument/test/test_file.py
@@ -192,7 +192,7 @@ def test_get_dir_file_strs_correctlyGrabsFileData(env_dir_setup_cleanup):
     assert files_dict.get(x2_file_name) == x2_file_str
 
 
-def test_get_dir_file_strs_delete_extensions_ReturnsCorrectObj(env_dir_setup_cleanup):
+def test_get_dir_file_strs_delete_extensions_ReturnsObj(env_dir_setup_cleanup):
     # ESTABLISH
     env_dir = get_instrument_temp_env_dir()
     x1_name = "x1"
@@ -376,7 +376,7 @@ def test_count_files_ReturnsNoneIfDirectoryDoesNotExist(
     assert dir_count is None
 
 
-def test_get_directory_path_ReturnsCorrectObj():
+def test_get_directory_path_ReturnsObj():
     # ESTABLISH
     texas_str = "texas"
     dallas_str = "dallas"
@@ -397,7 +397,7 @@ def test_get_directory_path_ReturnsCorrectObj():
     assert kern_path == create_path(elpaso_path, kern_str)
 
 
-def test_is_path_valid_ReturnsCorrectObj():
+def test_is_path_valid_ReturnsObj():
     # ESTABLISH / WHEN / THEN
     assert is_path_valid("run")
     assert is_path_valid("run/trail")
@@ -411,13 +411,13 @@ def test_is_path_valid_ReturnsCorrectObj():
     assert is_path_valid("run//trail////")
 
 
-def test_can_active_usser_edit_paths_ReturnsCorrectObj():
+def test_can_active_usser_edit_paths_ReturnsObj():
     # ESTABLISH / WHEN / THEN
     """I am not able to test this correctly. For now make sure it runs."""
     assert can_active_usser_edit_paths()
 
 
-def test_is_path_existent_or_creatable_ReturnsCorrectObj():
+def test_is_path_existent_or_creatable_ReturnsObj():
     # ESTABLISH / WHEN / THEN
     """I am not able to test this correctly. For now make sure it runs."""
     assert is_path_existent_or_creatable("run")
@@ -428,7 +428,7 @@ def test_is_path_existent_or_creatable_ReturnsCorrectObj():
     assert is_path_existent_or_creatable("run///trail")
 
 
-def test_is_path_probably_creatable_ReturnsCorrectObj():
+def test_is_path_probably_creatable_ReturnsObj():
     # ESTABLISH / WHEN / THEN
     """I am not able to test this correctly. For now make sure it runs."""
     assert is_path_probably_creatable("run")
@@ -436,7 +436,7 @@ def test_is_path_probably_creatable_ReturnsCorrectObj():
     assert is_path_probably_creatable("run///trail") is False
 
 
-def test_is_path_existent_or_probably_creatable_ReturnsCorrectObj():
+def test_is_path_existent_or_probably_creatable_ReturnsObj():
     # ESTABLISH / WHEN / THEN
     """I am not able to test this correctly. For now make sure it runs."""
     assert is_path_existent_or_probably_creatable("run")

--- a/src/f01_road/test/test_finance_.py
+++ b/src/f01_road/test/test_finance_.py
@@ -35,7 +35,7 @@ def test_BitNum_exists():
     assert inspect_getdoc(y_BitNum) == inspect_str
 
 
-def test_default_respect_bit_if_None_ReturnsCorrectObj():
+def test_default_respect_bit_if_None_ReturnsObj():
     # ESTABLISH / WHEN / THEN
     assert default_respect_bit_if_None() == 1
     assert default_respect_bit_if_None(None) == 1
@@ -73,7 +73,7 @@ def test_PennyNum_exists():
     assert inspect_getdoc(y_pennynum) == "Smallest Unit of Money"
 
 
-def test_default_penny_if_None_ReturnsCorrectObj():
+def test_default_penny_if_None_ReturnsObj():
     # ESTABLISH / WHEN / THEN
     assert default_penny_if_None() == 1
     assert default_penny_if_None(5) == 5
@@ -140,7 +140,7 @@ def test_FundCoin_exists():
     assert inspect_getdoc(y_fund_coinnum) == inspect_str
 
 
-def test_default_fund_coin_if_None_ReturnsCorrectObj():
+def test_default_fund_coin_if_None_ReturnsObj():
     # ESTABLISH / WHEN / THEN
     assert default_fund_coin_if_None() == 1
     assert default_fund_coin_if_None(5) == 5

--- a/src/f01_road/test/test_jaar_config.py
+++ b/src/f01_road/test/test_jaar_config.py
@@ -18,7 +18,7 @@ def test_voice_str():
     assert voice_str() == "voice"
 
 
-def test_get_rootpart_of_keep_dir_ReturnsCorrectObj():
+def test_get_rootpart_of_keep_dir_ReturnsObj():
     # ESTABLISH / WHEN / THEN
     assert get_rootpart_of_keep_dir() == "itemroot"
 

--- a/src/f01_road/test/test_road_core.py
+++ b/src/f01_road/test/test_road_core.py
@@ -235,7 +235,7 @@ def test_road_get_root_title_from_road_ReturnsTitleUnit():
     assert get_root_title_from_road(roses_road) == casa_str
 
 
-def test_road_get_parent_road_ReturnsCorrectObj_Scenario0():
+def test_road_get_parent_road_ReturnsObj_Scenario0():
     # ESTABLISH
     x_s = default_bridge_if_None()
     casa_str = "casa"
@@ -252,7 +252,7 @@ def test_road_get_parent_road_ReturnsCorrectObj_Scenario0():
     assert get_parent_road(roses_road, x_s) == bloomers_road
 
 
-def test_road_get_parent_road_ReturnsCorrectObj_Scenario1():
+def test_road_get_parent_road_ReturnsObj_Scenario1():
     # ESTABLISH
     x_s = "/"
     casa_str = "casa"
@@ -269,7 +269,7 @@ def test_road_get_parent_road_ReturnsCorrectObj_Scenario1():
     assert get_parent_road(roses_road, x_s) == bloomers_road
 
 
-def test_road_create_road_without_root_title_ReturnsCorrectObj():
+def test_road_create_road_without_root_title_ReturnsObj():
     # ESTABLISH
     x_s = default_bridge_if_None()
     casa_str = "casa"
@@ -384,11 +384,11 @@ def test_road_get_forefather_roads_ReturnsAncestorRoadUnitsWithoutClean():
     assert x_roads == texas_forefather_roads
 
 
-def test_road_get_default_fiscal_title_ReturnsCorrectObj():
+def test_road_get_default_fiscal_title_ReturnsObj():
     assert root_title() == "ZZ"
 
 
-def test_road_create_road_from_titles_ReturnsCorrectObj():
+def test_road_create_road_from_titles_ReturnsObj():
     # ESTABLISH
     x_s = default_bridge_if_None()
     root_list = get_all_road_titles(root_title())
@@ -409,7 +409,7 @@ def test_road_create_road_from_titles_ReturnsCorrectObj():
     assert roses_road == create_road_from_titles(roses_list)
 
 
-def test_road_create_road_ReturnsCorrectObj():
+def test_road_create_road_ReturnsObj():
     # ESTABLISH
     x_s = default_bridge_if_None()
     casa_str = "casa"
@@ -440,7 +440,7 @@ def test_is_titleunit_ReturnsObj():
     assert is_titleunit(RoadUnit("ZZ"), x_s)
 
 
-def test_get_diff_road_ReturnsCorrectObj():
+def test_get_diff_road_ReturnsObj():
     # ESTABLISH
     x_s = default_bridge_if_None()
     casa_str = "casa"
@@ -582,7 +582,7 @@ def test_validate_titleunit_RaisesErrorWhenTitleUnit():
     )
 
 
-def test_roadunit_valid_dir_path_ReturnsCorrectObj_simple_bridge():
+def test_roadunit_valid_dir_path_ReturnsObj_simple_bridge():
     # ESTABLISH
     comma_str = ","
     # WHEN / THEN
@@ -595,7 +595,7 @@ def test_roadunit_valid_dir_path_ReturnsCorrectObj_simple_bridge():
     ) or platform_system() == "Linux"
 
 
-def test_roadunit_valid_dir_path_ReturnsCorrectObj_complicated_bridge():
+def test_roadunit_valid_dir_path_ReturnsObj_complicated_bridge():
     # ESTABLISH
     question_str = "?"
     sport_str = "sport"
@@ -615,7 +615,7 @@ def test_roadunit_valid_dir_path_ReturnsCorrectObj_complicated_bridge():
     ) or platform_system() == "Linux"
 
 
-def test_roadunit_valid_dir_path_ReturnsCorrectObjWhereSlashNotbridgeEdgeCases():
+def test_roadunit_valid_dir_path_ReturnsObjWhereSlashNotbridgeEdgeCases():
     # ESTABLISH
     question_str = "?"
     sport_str = "sport"

--- a/src/f02_bud/test_/test_healer.py
+++ b/src/f02_bud/test_/test_healer.py
@@ -82,7 +82,7 @@ def test_HealerLink_del_healer_name_CorrectlyDeletes_healer_names_v1():
     assert len(x_healerlink._healer_names) == 1
 
 
-def test_HealerLink_healer_name_exists_ReturnsCorrectObj():
+def test_HealerLink_healer_name_exists_ReturnsObj():
     # ESTABLISH
     x_healerlink = healerlink_shop()
     yao_str = "Yao"
@@ -98,7 +98,7 @@ def test_HealerLink_healer_name_exists_ReturnsCorrectObj():
     assert x_healerlink.healer_name_exists(sue_str) is False
 
 
-def test_HealerLink_any_healer_name_exists_ReturnsCorrectObj():
+def test_HealerLink_any_healer_name_exists_ReturnsObj():
     # ESTABLISH
     x_healerlink = healerlink_shop()
     assert x_healerlink.any_healer_name_exists() is False
@@ -122,7 +122,7 @@ def test_HealerLink_any_healer_name_exists_ReturnsCorrectObj():
     assert x_healerlink.any_healer_name_exists() is False
 
 
-def test_healerlink_get_from_dict_ReturnsCorrectObj():
+def test_healerlink_get_from_dict_ReturnsObj():
     # ESTABLISH
     empty_dict = {}
 

--- a/src/f02_bud/test_/test_origin.py
+++ b/src/f02_bud/test_/test_origin.py
@@ -14,7 +14,7 @@ def test_OriginHold_exists():
     assert originhold_x.importance == bob_importance
 
 
-def test_originhold_shop_ReturnsCorrectObj():
+def test_originhold_shop_ReturnsObj():
     # ESTABLISH
     bob_str = "Bob"
     bob_importance = 4
@@ -62,7 +62,7 @@ def test_OriginUnit_exists():
     assert originunit_x._originholds is None
 
 
-def test_originunit_ReturnsCorrectObj():
+def test_originunit_ReturnsObj():
     # ESTABLISH / WHEN
     originunit_x = originunit_shop()
 

--- a/src/f02_bud/test_/test_premise_.py
+++ b/src/f02_bud/test_/test_premise_.py
@@ -32,7 +32,7 @@ def test_PremiseUnit_Exists():
     assert email_premise.bridge is None
 
 
-def test_premiseunit_shop_ReturnsCorrectObj():
+def test_premiseunit_shop_ReturnsObj():
     # ESTABLISH
     casa_str = "casa"
     casa_road = create_road(root_title(), casa_str)

--- a/src/f02_bud/test_/test_premisestatusfinder.py
+++ b/src/f02_bud/test_/test_premisestatusfinder.py
@@ -32,7 +32,7 @@ def test_PremiseStatusFinder_Exists():
     assert x_pbsd.fact_nigh_full == x_fact_nigh_full
 
 
-def test_premisestatusfinder_shop_ReturnsCorrectObj():
+def test_premisestatusfinder_shop_ReturnsObj():
     # ESTABLISH
     x_premise_open = 1
     x_premise_nigh = 1
@@ -127,7 +127,7 @@ def test_PremiseStatusFinder_check_attr_CorrectlyRaisesError():
     )
 
 
-def test_PremiseStatusFinder_AbbrevationMethodsReturnCorrectObjs():
+def test_PremiseStatusFinder_AbbrevationMethodsReturnsObjs():
     # ESTABLISH
     x_premise_open = 1
     x_premise_nigh = 2
@@ -292,7 +292,7 @@ def get_fig(pd: float, graphics_bool: bool) -> plotly_figure:
     return fig
 
 
-def test_PremiseStatusFinder_get_active_ReturnsCorrectObj(graphics_bool):
+def test_PremiseStatusFinder_get_active_ReturnsObj(graphics_bool):
     """Check scenarios PremiseUnit._active. Plotly graph can be used to identify problems."""
     # # Case A
     assert premisestatusfinder_shop(0.3, 0.7, 1, 0.1, 1.2).get_active()

--- a/src/f02_bud/test_/test_reason_item.py
+++ b/src/f02_bud/test_/test_reason_item.py
@@ -49,7 +49,7 @@ def test_reasoncore_shop_ReturnsCorrectAttrWith_bridge():
     assert casa_reason.bridge == slash_str
 
 
-def test_reasonheir_shop_ReturnsCorrectObj():
+def test_reasonheir_shop_ReturnsObj():
     # ESTABLISH
     casa_str = "casa"
     casa_road = create_road(root_title(), casa_str)
@@ -220,7 +220,7 @@ def test_ReasonHeir_set_status_BudNoneCorrectlySetsStatusFalse():
     assert wkday_reason._status is False
 
 
-def test_reasonunit_shop_ReturnsCorrectObj():
+def test_reasonunit_shop_ReturnsObj():
     # ESTABLISH
     wkday_str = "weekday"
     wkday_road = create_road(root_title(), wkday_str)
@@ -304,7 +304,7 @@ def test_ReasonUnit_get_dict_ReturnsCorrectDictWithTwoPremisesReasons():
     assert wkday_reason_dict == static_wkday_reason_dict
 
 
-def test_reasons_get_from_dict_ReturnsCorrectObj():
+def test_reasons_get_from_dict_ReturnsObj():
     # ESTABLISH
     wkday_str = "weekday"
     wkday_road = create_road(root_title(), wkday_str)
@@ -413,7 +413,7 @@ def test_ReasonCore_premise_exists_ReturnsObj():
     assert day_reason.premise_exists(day_road)
 
 
-def test_ReasonCore_get_single_premis_ReturnsCorrectObj():
+def test_ReasonCore_get_single_premis_ReturnsObj():
     # ESTABLISH
     day_road = create_road(root_title(), "day")
     day_reason = reasoncore_shop(base=day_road)

--- a/src/f02_bud/test_/test_reason_team.py
+++ b/src/f02_bud/test_/test_reason_team.py
@@ -44,7 +44,7 @@ def test_teamunit_shop_ifEmptyReturnsCorrectWithCorrectAttributes():
     assert x_teamunit._teamlinks == set()
 
 
-def test_create_teamunit_ReturnsCorrectObj():
+def test_create_teamunit_ReturnsObj():
     # ESTABLISH
     swim_team_tag = GroupLabel("swimmers")
 
@@ -85,7 +85,7 @@ def test_TeamUnit_set_teamlink_CorrectlySets_teamlinks_v1():
     assert len(x_teamunit._teamlinks) == 1
 
 
-def test_TeamUnit_teamlink_exists_ReturnsCorrectObj():
+def test_TeamUnit_teamlink_exists_ReturnsObj():
     # ESTABLISH
     x_teamunit = teamunit_shop()
     yao_str = "Yao"
@@ -438,7 +438,7 @@ def test_TeamHeir_set_teamlink_TeamUnit_NotEqual_ParentTeamHeir_NonEmpty():
 #     )
 
 
-def test_TeamUnit_get_teamlink_ReturnsCorrectObj():
+def test_TeamUnit_get_teamlink_ReturnsObj():
     # ESTABLISH
     climb_str = ",climbers"
     hike_str = ",hikers"

--- a/src/f02_bud/test_/test_tree_metrics.py
+++ b/src/f02_bud/test_/test_tree_metrics.py
@@ -16,7 +16,7 @@ def test_TreeMetrics_Exists():
     assert x_tree_metrics.all_item_uids_are_unique is None
 
 
-def test_treemetrics_shop_ReturnsCorrectObj():
+def test_treemetrics_shop_ReturnsObj():
     # ESTABLISH / WHEN
     x_tree_metrics = treemetrics_shop()
 

--- a/src/f02_bud/test__item/test_item_.py
+++ b/src/f02_bud/test__item/test_item_.py
@@ -125,7 +125,7 @@ def test_itemunit_shop_Allows_doesNotAllow_massToBeNegative():
     assert x_itemunit.mass == zero_int
 
 
-def test_itemunit_shop_NonNoneParametersReturnsCorrectObj():
+def test_itemunit_shop_NonNoneParametersReturnsObj():
     # ESTABLISH
     x_healerlink = healerlink_shop({"Sue", "Yao"})
     x_problem_bool = True
@@ -180,7 +180,7 @@ def test_itemunit_shop_ReturnsObjWithParameters():
     assert sport_item.stop_want == sport_stop_want
 
 
-def test_ItemUnit_get_obj_key_ReturnsCorrectObj():
+def test_ItemUnit_get_obj_key_ReturnsObj():
     # ESTABLISH
     round_str = "round_stuff"
     round_road = create_road(root_title(), round_str)
@@ -193,7 +193,7 @@ def test_ItemUnit_get_obj_key_ReturnsCorrectObj():
     assert ball_item.get_obj_key() == ball_str
 
 
-def test_ItemUnit_get_road_ReturnsCorrectObj():
+def test_ItemUnit_get_road_ReturnsObj():
     # ESTABLISH
     round_str = "round_stuff"
     slash_str = "/"

--- a/src/f02_bud/test__item/test_item_active_status.py
+++ b/src/f02_bud/test__item/test_item_active_status.py
@@ -139,7 +139,7 @@ def test_ItemUnit_awardheir_exists_ReturnsObj():
     assert sport_itemunit.awardheir_exists()
 
 
-def test_ItemUnit_set_awardheirs_fund_give_fund_take_ReturnsCorrectObj_NoValues():
+def test_ItemUnit_set_awardheirs_fund_give_fund_take_ReturnsObj_NoValues():
     # ESTABLISH /WHEN
     sport_str = "sport"
     sport_item = itemunit_shop(sport_str)
@@ -260,7 +260,7 @@ def test_ItemUnit_set_reasonunit_SetsAttr():
     assert x_reasonunit.base == dirty_str
 
 
-def test_ItemUnit_reasonunit_exists_ReturnsCorrectObj():
+def test_ItemUnit_reasonunit_exists_ReturnsObj():
     # ESTABLISH
     clean_str = "clean"
     clean_item = itemunit_shop(clean_str)
@@ -274,7 +274,7 @@ def test_ItemUnit_reasonunit_exists_ReturnsCorrectObj():
     assert clean_item.reasonunit_exists(dirty_str)
 
 
-def test_ItemUnit_get_reasonunit_ReturnsCorrectObj():
+def test_ItemUnit_get_reasonunit_ReturnsObj():
     # ESTABLISH
     clean_str = "clean"
     clean_item = itemunit_shop(clean_str)
@@ -289,7 +289,7 @@ def test_ItemUnit_get_reasonunit_ReturnsCorrectObj():
     assert x_reasonunit.base == dirty_str
 
 
-def test_ItemUnit_get_reasonheir_ReturnsCorrectObj():
+def test_ItemUnit_get_reasonheir_ReturnsObj():
     # ESTABLISH
     clean_str = "clean"
     clean_item = itemunit_shop(clean_str)
@@ -361,7 +361,7 @@ def test_ItemUnit_set_factunit_SetsAttr():
     assert clean_item.factunits.get(dirty_str)
 
 
-def test_ItemUnit_factunit_exists_ReturnsCorrectObj():
+def test_ItemUnit_factunit_exists_ReturnsObj():
     # ESTABLISH
     clean_str = "clean"
     clean_item = itemunit_shop(clean_str)

--- a/src/f02_bud/test__item/test_item_attr_holder.py
+++ b/src/f02_bud/test__item/test_item_attr_holder.py
@@ -57,7 +57,7 @@ def test_ItemAttrHolder_CorrectlyCalculatesPremiseRanges():
     # assert item_attr.reason_premise_morph is None
 
 
-def test_itemattrholder_shop_ReturnsCorrectObj():
+def test_itemattrholder_shop_ReturnsObj():
     # ESTABLISH
     sue_healerlink = healerlink_shop({"Sue", "Yim"})
 

--- a/src/f02_bud/test__item/test_item_dict.py
+++ b/src/f02_bud/test__item/test_item_dict.py
@@ -12,7 +12,7 @@ from src.f02_bud.origin import originunit_shop
 from src.f02_bud.item import itemunit_shop, get_obj_from_item_dict
 
 
-def test_get_obj_from_item_dict_ReturnsCorrectObj():
+def test_get_obj_from_item_dict_ReturnsObj():
     # ESTABLISH
     field_str = "_is_expanded"
     # WHEN / THEN

--- a/src/f02_bud/test__item/test_item_kid.py
+++ b/src/f02_bud/test__item/test_item_kid.py
@@ -124,7 +124,7 @@ def test_ItemUnit_clear_kids_CorrectlySetsAttr():
     assert len(nation_item._kids) == 0
 
 
-def test_ItemUnit_get_kid_ReturnsCorrectObj():
+def test_ItemUnit_get_kid_ReturnsObj():
     # ESTABLISH
     nation_str = "nation-state"
     nation_road = create_road(root_title(), nation_str)

--- a/src/f02_bud/test_acct/test__membership.py
+++ b/src/f02_bud/test_acct/test__membership.py
@@ -54,7 +54,7 @@ def test_MemberShip_exists():
     assert swim_membership._acct_name is None
 
 
-def test_membership_shop_ReturnsCorrectObj():
+def test_membership_shop_ReturnsObj():
     # ESTABLISH
     swim_str = ",swim"
     swim_credit_vote = 3.0
@@ -81,7 +81,7 @@ def test_membership_shop_ReturnsCorrectObj():
     assert swim_membership._acct_name is None
 
 
-def test_membership_shop_ReturnsCorrectObjAttr_acct_name():
+def test_membership_shop_ReturnsObjAttr_acct_name():
     # ESTABLISH
     swim_str = ",swim"
     yao_str = "Yao"
@@ -293,7 +293,7 @@ def test_AwardLink_exists():
     assert bikers_awardlink.take_force == 1.0
 
 
-def test_awardlink_shop_ReturnsCorrectObj():
+def test_awardlink_shop_ReturnsObj():
     # ESTABLISH
     bikers_str = "bikers"
     bikers_give_force = 3.0
@@ -367,7 +367,7 @@ def test_AwardLink_get_dict_ReturnsDictWithNecessaryDataForJSON():
     }
 
 
-def test_awardlinks_get_from_JSON_ReturnsCorrectObj_SimpleExample():
+def test_awardlinks_get_from_JSON_ReturnsObj_SimpleExample():
     # ESTABLISH
     teacher_str = "teachers"
     teacher_awardlink = awardlink_shop(
@@ -410,7 +410,7 @@ def test_AwardLine_exists():
     assert bikers_awardline._fund_take == bikers_fund_take
 
 
-def test_awardline_shop_ReturnsCorrectObj_exists():
+def test_awardline_shop_ReturnsObj_exists():
     # ESTABLISH
     bikers_str = "bikers"
     bikers_str = bikers_str

--- a/src/f02_bud/test_acct/test_acct_dict.py
+++ b/src/f02_bud/test_acct/test_acct_dict.py
@@ -189,7 +189,7 @@ def test_AcctUnit_get_dict_ReturnsDictWith_irrational_missing_job_ValuesIsNone()
     assert len(x_dict.keys()) == 10
 
 
-def test_acctunit_get_from_dict_ReturnsCorrectObjWith_bridge():
+def test_acctunit_get_from_dict_ReturnsObjWith_bridge():
     # ESTABLISH
     yao_str = ",Yao"
     slash_str = "/"
@@ -230,7 +230,7 @@ def test_acctunit_get_from_dict_Returns_memberships():
     assert after_yao_acctunit._bridge == slash_str
 
 
-def test_acctunits_get_from_dict_ReturnsCorrectObjWith_bridge():
+def test_acctunits_get_from_dict_ReturnsObjWith_bridge():
     # ESTABLISH
     yao_str = ",Yao"
     slash_str = "/"
@@ -246,7 +246,7 @@ def test_acctunits_get_from_dict_ReturnsCorrectObjWith_bridge():
     assert x_acctunits_objs.get(yao_str)._bridge == slash_str
 
 
-def test_acctunits_get_from_json_ReturnsCorrectObj_SimpleExampleWithIncompleteData():
+def test_acctunits_get_from_json_ReturnsObj_SimpleExampleWithIncompleteData():
     # ESTABLISH
     yao_str = "Yao"
     yao_credit_belief = 13

--- a/src/f02_bud/test_acct/test_acct_membership.py
+++ b/src/f02_bud/test_acct/test_acct_membership.py
@@ -62,7 +62,7 @@ def test_AcctUnit_set_membership_RaisesErrorIf_group_labelIsAcctNameAndNotAcctUn
     )
 
 
-def test_AcctUnit_get_membership_ReturnsCorrectObj():
+def test_AcctUnit_get_membership_ReturnsObj():
     # ESTABLISH
     run_str = ";run"
     fly_str = ";fly"
@@ -77,7 +77,7 @@ def test_AcctUnit_get_membership_ReturnsCorrectObj():
     assert yao_acctunit.get_membership(climb_str) is None
 
 
-def test_membership_exists_ReturnsCorrectObj():
+def test_membership_exists_ReturnsObj():
     # ESTABLISH
     run_str = ";run"
     fly_str = ";fly"
@@ -92,7 +92,7 @@ def test_membership_exists_ReturnsCorrectObj():
     assert yao_acctunit.membership_exists(climb_str) is False
 
 
-def test_memberships_exist_ReturnsCorrectObj():
+def test_memberships_exist_ReturnsObj():
     # ESTABLISH
     run_str = ";run"
     fly_str = ";fly"

--- a/src/f02_bud/test_acct/test_group.py
+++ b/src/f02_bud/test_acct/test_group.py
@@ -28,7 +28,7 @@ def test_GroupUnit_exists():
     assert swim_groupunit._fund_coin is None
 
 
-def test_groupunit_shop_ReturnsCorrectObj():
+def test_groupunit_shop_ReturnsObj():
     # ESTABLISH
     swim_str = ";swimmers"
     nation_road = create_road(root_title(), "nation-states")
@@ -53,7 +53,7 @@ def test_groupunit_shop_ReturnsCorrectObj():
     assert swim_groupunit._fund_coin == default_fund_coin_if_None()
 
 
-def test_groupunit_shop_ReturnsCorrectObj_bridge():
+def test_groupunit_shop_ReturnsObj_bridge():
     # ESTABLISH
     swim_str = "/swimmers"
     slash_str = "/"

--- a/src/f02_bud/test_bud/test_bud_.py
+++ b/src/f02_bud/test_bud/test_bud_.py
@@ -52,7 +52,7 @@ def test_BudUnit_Exists():
     assert str(type(x_bud.itemroot)).find("None") == 8
 
 
-def test_BudUnit_shop_ReturnsCorrectObjectWithFilledFields():
+def test_BudUnit_shop_ReturnsObjectWithFilledFields():
     # ESTABLISH
     sue_str = "Sue"
     iowa_fiscal_title = "Iowa"
@@ -108,7 +108,7 @@ def test_BudUnit_shop_ReturnsCorrectObjectWithFilledFields():
     assert str(type(x_bud.itemroot)).find(".item.ItemUnit'>") > 0
 
 
-def test_BudUnit_shop_ReturnsCorrectObjectWithCorrectEmptyField():
+def test_BudUnit_shop_ReturnsObjectWithCorrectEmptyField():
     # ESTABLISH / WHEN
     x_bud = budunit_shop()
 
@@ -191,7 +191,7 @@ def test_BudUnit_set_bridge_CorrectlySetsAttr():
     assert sue_bud.bridge == at_title_bridge
 
 
-def test_BudUnit_make_road_ReturnsCorrectObj():
+def test_BudUnit_make_road_ReturnsObj():
     # ESTABLISH
     x_fiscal_title = "accord45"
     slash_bridge = "/"

--- a/src/f02_bud/test_bud/test_bud_accts_.py
+++ b/src/f02_bud/test_bud/test_bud_accts_.py
@@ -181,7 +181,7 @@ def test_BudUnit_edit_acct_CorrectlyUpdatesObj():
     assert zia_acctunit.debtit_belief == new_zia_debtit_belief
 
 
-def test_BudUnit_get_acct_ReturnsCorrectObj():
+def test_BudUnit_get_acct_ReturnsObj():
     # ESTABLISH
     yao_bud = budunit_shop("Yao")
     zia_str = "Zia"

--- a/src/f02_bud/test_bud/test_bud_json.py
+++ b/src/f02_bud/test_bud/test_bud_json.py
@@ -285,7 +285,7 @@ def test_BudUnit_get_json_ReturnsCorrectJSON_BigExample():
     assert len(yao_bud.accts) == 22
 
 
-def test_budunit_get_from_json_ReturnsCorrectObjSimpleExample():
+def test_budunit_get_from_json_ReturnsObjSimpleExample():
     # ESTABLISH
     zia_bud = get_budunit_x1_3levels_1reason_1facts()
     zia_bud.set_max_tree_traverse(23)
@@ -438,7 +438,7 @@ def test_budunit_get_from_json_ReturnsCorrectItemRoot():
     assert json_itemroot.stop_want == zia_stop_want
 
 
-def test_budunit_get_from_json_ReturnsCorrectObj_bridge_Example():
+def test_budunit_get_from_json_ReturnsObj_bridge_Example():
     # ESTABLISH
     slash_bridge = "/"
     before_bob_bud = budunit_shop("Bob", bridge=slash_bridge)
@@ -454,7 +454,7 @@ def test_budunit_get_from_json_ReturnsCorrectObj_bridge_Example():
     assert after_bob_bud.bridge == before_bob_bud.bridge
 
 
-def test_budunit_get_from_json_ReturnsCorrectObj_bridge_AcctExample():
+def test_budunit_get_from_json_ReturnsObj_bridge_AcctExample():
     # ESTABLISH
     slash_bridge = "/"
     before_bob_bud = budunit_shop("Bob", bridge=slash_bridge)
@@ -471,7 +471,7 @@ def test_budunit_get_from_json_ReturnsCorrectObj_bridge_AcctExample():
     assert after_bob_acctunit._bridge == slash_bridge
 
 
-def test_budunit_get_from_json_ReturnsCorrectObj_bridge_GroupExample():
+def test_budunit_get_from_json_ReturnsObj_bridge_GroupExample():
     # ESTABLISH
     slash_bridge = "/"
     before_bob_bud = budunit_shop("Bob", bridge=slash_bridge)

--- a/src/f02_bud/test_bud_settle/test_tree_traverse_base.py
+++ b/src/f02_bud/test_bud_settle/test_tree_traverse_base.py
@@ -359,7 +359,7 @@ def test_BudUnit_settle_bud_DoesNotKeepUnneeded_awardheirs():
     assert len(swim_item._awardheirs) == 2
 
 
-def test_BudUnit_get_item_tree_ordered_road_list_ReturnsCorrectObj():
+def test_BudUnit_get_item_tree_ordered_road_list_ReturnsObj():
     # ESTABLISH
     sue_bud = get_budunit_with_4_levels()
     week_str = "weekdays"
@@ -399,7 +399,7 @@ def test_BudUnit_get_item_tree_ordered_road_list_CorrectlyCleansRangedItemRoadUn
     assert len(yao_bud.get_item_tree_ordered_road_list(no_range_descendants=True)) == 2
 
 
-def test_BudUnit_get_item_dict_ReturnsCorrectObjWhenSingle():
+def test_BudUnit_get_item_dict_ReturnsObjWhenSingle():
     # ESTABLISH
     sue_bud = budunit_shop("Sue")
     texas_str = "Texas"

--- a/src/f02_bud/test_bud_settle/test_tree_traverse_z_task_status.py
+++ b/src/f02_bud/test_bud_settle/test_tree_traverse_z_task_status.py
@@ -264,7 +264,7 @@ def test_BudUnit_settle_bud_CorrectlyCalculatesRangeAttributes():
     assert sue_budunit._item_dict.get(clean_road)._active is False
 
 
-def test_BudUnit_get_agenda_dict_ReturnsCorrectObj():
+def test_BudUnit_get_agenda_dict_ReturnsObj():
     # ESTABLISH
     sue_budunit = get_budunit_with_4_levels_and_2reasons()
 
@@ -346,7 +346,7 @@ def test_BudUnit_settle_bud_CorrectlySetsData_budunit_v001():
     assert yao_budunit._item_dict.get(laundry_road)._active is False
 
 
-def test_BudUnit_settle_bud_OptionWeekdaysReturnsCorrectObj_budunit_v001():
+def test_BudUnit_settle_bud_OptionWeekdaysReturnsObj_budunit_v001():
     # ESTABLISH
     yao_budunit = budunit_v001()
 
@@ -570,7 +570,7 @@ def test_BudUnit_settle_bud_EveryItemHasActiveStatus_budunit_v001():
     )
 
 
-def test_BudUnit_settle_bud_EveryTwoMonthReturnsCorrectObj_budunit_v001():
+def test_BudUnit_settle_bud_EveryTwoMonthReturnsObj_budunit_v001():
     # ESTABLISH
     yao_budunit = budunit_v001()
     minute_str = "day_minute"

--- a/src/f02_bud/test_bud_settle/test_z_agenda.py
+++ b/src/f02_bud/test_bud_settle/test_z_agenda.py
@@ -18,7 +18,7 @@ def get_tasks_count(agenda_dict: dict[RoadUnit, ItemUnit]) -> int:
     return sum(bool(x_itemunit._task) for x_itemunit in agenda_dict.values())
 
 
-def test_BudUnit_get_agenda_dict_ReturnsCorrectObj():
+def test_BudUnit_get_agenda_dict_ReturnsObj():
     # ESTABLISH
     sue_bud = get_budunit_with_4_levels()
 
@@ -509,7 +509,7 @@ def test_BudUnit_get_agenda_dict_IsSetByTeamUnit_2AcctGroup():
     assert len(yao_bud.get_agenda_dict()) == 1
 
 
-def test_BudUnit_get_all_pledges_ReturnsCorrectObj():
+def test_BudUnit_get_all_pledges_ReturnsObj():
     # ESTABLISH
     zia_str = "Zia"
     zia_bud = budunit_shop(zia_str)

--- a/src/f03_chrono/test/test_chrono_config_creg_.py
+++ b/src/f03_chrono/test/test_chrono_config_creg_.py
@@ -679,7 +679,7 @@ def test_BudUnit_create_agenda_item_CorrectlyCreatesAllBudAttributes():
     assert len(sue_bud.itemroot._kids) == 3
 
 
-def test_ItemCore_get_agenda_dict_ReturnsCorrectObj_BugFindAndFix_active_SettingError():  # https://github.com/jschalk/jaar/issues/69
+def test_ItemCore_get_agenda_dict_ReturnsObj_BugFindAndFix_active_SettingError():  # https://github.com/jschalk/jaar/issues/69
     # ESTABLISH
     sue_bud = budunit_shop("Sue")
     add_time_creg_itemunit(sue_bud)

--- a/src/f04_gift/test_atom/test_atom_config.py
+++ b/src/f04_gift/test_atom/test_atom_config.py
@@ -429,7 +429,7 @@ def test_get_sorted_jkey_keys_ReturnsObj_bud_item_reason_premiseunit():
     assert x_sorted_jkey_keys == [road_str(), base_str(), "need"]
 
 
-def test_get_flattened_atom_table_build_ReturnsCorrectObj():
+def test_get_flattened_atom_table_build_ReturnsObj():
     # ESTABLISH / WHEN
     atom_columns = get_flattened_atom_table_build()
 
@@ -439,7 +439,7 @@ def test_get_flattened_atom_table_build_ReturnsCorrectObj():
     # print(f"{atom_columns.keys()=}")
 
 
-def test_get_normalized_bud_table_build_ReturnsCorrectObj():
+def test_get_normalized_bud_table_build_ReturnsObj():
     # ESTABLISH / WHEN
     normalized_bud_table_build = get_normalized_bud_table_build()
     nx = normalized_bud_table_build

--- a/src/f04_gift/test_atom/test_atom_core.py
+++ b/src/f04_gift/test_atom/test_atom_core.py
@@ -27,7 +27,7 @@ def test_AtomUnit_exists():
     assert x_atomunit.atom_order is None
 
 
-def test_atomunit_shop_ReturnsCorrectObj():
+def test_atomunit_shop_ReturnsObj():
     # ESTABLISH
     bob_str = "Bob"
     bob_credit_belief = 55
@@ -84,7 +84,7 @@ def test_AtomUnit_set_jvalue_CorrectlySetsAttr():
     assert acctunit_atomunit.jvalues == {acct_name_str(): bob_str}
 
 
-def test_AtomUnit_get_value_ReturnsCorrectObj():
+def test_AtomUnit_get_value_ReturnsObj():
     # ESTABLISH
     bob_str = "Bob"
     acctunit_str = bud_acctunit_str()

--- a/src/f04_gift/test_atom/test_atom_json.py
+++ b/src/f04_gift/test_atom/test_atom_json.py
@@ -16,7 +16,7 @@ from src.f04_gift.atom import (
 from src.f00_instrument.dict_toolbox import x_is_json
 
 
-def test_AtomUnit_get_dict_ReturnsCorrectObj():
+def test_AtomUnit_get_dict_ReturnsObj():
     # ESTABLISH
     sports_str = "sports"
     sports_road = create_road("a", sports_str)
@@ -45,7 +45,7 @@ def test_AtomUnit_get_dict_ReturnsCorrectObj():
     }
 
 
-def test_AtomUnit_get_json_ReturnsCorrectObj():
+def test_AtomUnit_get_json_ReturnsObj():
     # ESTABLISH
     sports_str = "sports"
     sports_road = create_road("a", sports_str)
@@ -73,7 +73,7 @@ def test_AtomUnit_get_json_ReturnsCorrectObj():
     assert x_is_json(atom_json)
 
 
-def test_atomunit_get_from_json_ReturnsCorrectObj():
+def test_atomunit_get_from_json_ReturnsObj():
     # ESTABLISH
     sports_str = "sports"
     sports_road = create_road("a", sports_str)

--- a/src/f04_gift/test_atom/test_atom_sql.py
+++ b/src/f04_gift/test_atom/test_atom_sql.py
@@ -33,7 +33,7 @@ def test_AtomUnit_get_insert_sqlstr_RaisesErrorWhen_is_valid_False():
     )
 
 
-def test_AtomUnit_get_insert_sqlstr_ReturnsCorrectObj_BudUnitSimpleAttrs():
+def test_AtomUnit_get_insert_sqlstr_ReturnsObj_BudUnitSimpleAttrs():
     # WHEN
     new2_value = 66
     dimen = budunit_str()
@@ -53,7 +53,7 @@ VALUES (
     assert x_atomunit.get_insert_sqlstr() == example_sqlstr
 
 
-def test_AtomUnit_get_insert_sqlstr_ReturnsCorrectObj_item_factunit():
+def test_AtomUnit_get_insert_sqlstr_ReturnsObj_item_factunit():
     # ESTABLISH
     sports_str = "sports"
     sports_road = create_road("a", sports_str)
@@ -90,7 +90,7 @@ VALUES (
     assert generated_sqlstr == example_sqlstr
 
 
-def test_get_atomunit_from_rowdata_ReturnsCorrectObj_item_factunit():
+def test_get_atomunit_from_rowdata_ReturnsObj_item_factunit():
     # ESTABLISH
     sports_str = "sports"
     sports_road = create_road("a", sports_str)

--- a/src/f04_gift/test_delta/test_delta_.py
+++ b/src/f04_gift/test_delta/test_delta_.py
@@ -41,7 +41,7 @@ def test_DeltaUnit_exists():
     assert x_deltaunit._bud_build_validated is None
 
 
-def test_deltaunit_shop_ReturnsCorrectObj():
+def test_deltaunit_shop_ReturnsObj():
     # ESTABLISH / WHEN
     ex1_deltaunit = deltaunit_shop()
 
@@ -129,7 +129,7 @@ def test_ChangUnit_atomunit_exists_ReturnsObj_bud_acct_membership_str():
     assert x_deltaunit.atomunit_exists(bob_iowa_atomunit)
 
 
-def test_DeltaUnit_get_atom_ReturnsCorrectObj():
+def test_DeltaUnit_get_atom_ReturnsObj():
     # ESTABLISH
     ex1_deltaunit = deltaunit_shop()
     opt_arg1 = "tally"
@@ -204,7 +204,7 @@ def test_DeltaUnit_add_atomunit_CorrectlySets_BudUnit_acctunits():
     )
 
 
-def test_DeltaUnit_get_crud_atomunits_list_ReturnsCorrectObj():
+def test_DeltaUnit_get_crud_atomunits_list_ReturnsObj():
     # ESTABLISH
     ex1_deltaunit = get_deltaunit_example1()
     assert len(ex1_deltaunit.atomunits.get(atom_update()).keys()) == 1
@@ -227,7 +227,7 @@ def test_DeltaUnit_get_crud_atomunits_list_ReturnsCorrectObj():
     #         print(f"{x_atom.dimen=}")
 
 
-def test_DeltaUnit_get_dimen_sorted_atomunits_list_ReturnsCorrectObj():
+def test_DeltaUnit_get_dimen_sorted_atomunits_list_ReturnsObj():
     # ESTABLISH
     ex1_deltaunit = get_deltaunit_example1()
     update_dict = ex1_deltaunit.atomunits.get(atom_update())
@@ -311,7 +311,7 @@ def test_DeltaUnit_get_dimen_sorted_atomunits_list_ReturnsCorrectObj():
 #     assert x_atomunit == ex1_deltaunit.atomunits.get(atom_update()).get(x_attribute)
 
 
-def test_DeltaUnit_get_sorted_atomunits_ReturnsCorrectObj():
+def test_DeltaUnit_get_sorted_atomunits_ReturnsObj():
     # ESTABLISH
     ex1_deltaunit = get_deltaunit_example1()
     update_dict = ex1_deltaunit.atomunits.get(atom_update())
@@ -341,7 +341,7 @@ def test_DeltaUnit_get_sorted_atomunits_ReturnsCorrectObj():
     #         print(f"{x_atom.dimen=}")
 
 
-def test_DeltaUnit_get_sorted_atomunits_ReturnsCorrectObj_ItemUnitsSorted():
+def test_DeltaUnit_get_sorted_atomunits_ReturnsObj_ItemUnitsSorted():
     # ESTABLISH
     x_fiscal_title = root_title()
     sports_str = "sports"
@@ -374,7 +374,7 @@ def test_DeltaUnit_get_sorted_atomunits_ReturnsCorrectObj_ItemUnitsSorted():
     #         print(f"{x_atom.dimen=}")
 
 
-def test_DeltaUnit_get_sorted_atomunits_ReturnsCorrectObj_Road_Sorted():
+def test_DeltaUnit_get_sorted_atomunits_ReturnsObj_Road_Sorted():
     # ESTABLISH
     x_fiscal_title = root_title()
     sports_str = "sports"
@@ -410,7 +410,7 @@ def test_DeltaUnit_get_sorted_atomunits_ReturnsCorrectObj_Road_Sorted():
     #         print(f"{x_atom.dimen=}")
 
 
-def test_bud_built_from_delta_is_valid_ReturnsCorrectObjEstablishWithNoBud_scenario1():
+def test_bud_built_from_delta_is_valid_ReturnsObjEstablishWithNoBud_scenario1():
     # ESTABLISH
     sue_deltaunit = deltaunit_shop()
 
@@ -431,7 +431,7 @@ def test_bud_built_from_delta_is_valid_ReturnsCorrectObjEstablishWithNoBud_scena
     assert bud_built_from_delta_is_valid(sue_deltaunit) is False
 
 
-def test_bud_built_from_delta_is_valid_ReturnsCorrectObjEstablishWithNoBud_scenario2():
+def test_bud_built_from_delta_is_valid_ReturnsObjEstablishWithNoBud_scenario2():
     sue_deltaunit = deltaunit_shop()
     dimen = bud_acctunit_str()
     # WHEN
@@ -455,7 +455,7 @@ def test_bud_built_from_delta_is_valid_ReturnsCorrectObjEstablishWithNoBud_scena
     assert bud_built_from_delta_is_valid(sue_deltaunit) is False
 
 
-def test_DeltaUnit_get_ordered_atomunits_ReturnsCorrectObj_EstablishWithNoStartingNumber():
+def test_DeltaUnit_get_ordered_atomunits_ReturnsObj_EstablishWithNoStartingNumber():
     # ESTABLISH
     sue_deltaunit = deltaunit_shop()
     pool_atomunit = atomunit_shop(budunit_str(), atom_update())
@@ -494,7 +494,7 @@ def test_DeltaUnit_get_ordered_atomunits_ReturnsCorrectObj_EstablishWithNoStarti
     assert deltaunit_dict.get(2) == pool_atomunit
 
 
-def test_DeltaUnit_get_ordered_atomunits_ReturnsCorrectObj_EstablishWithStartingNumber():
+def test_DeltaUnit_get_ordered_atomunits_ReturnsObj_EstablishWithStartingNumber():
     # ESTABLISH
     sue_deltaunit = deltaunit_shop()
     pool_atomunit = atomunit_shop(budunit_str(), atom_update())
@@ -533,7 +533,7 @@ def test_DeltaUnit_get_ordered_atomunits_ReturnsCorrectObj_EstablishWithStarting
     assert deltaunit_dict.get(7) == pool_atomunit
 
 
-def test_DeltaUnit_get_ordered_dict_ReturnsCorrectObj_EstablishWithStartingNumber():
+def test_DeltaUnit_get_ordered_dict_ReturnsObj_EstablishWithStartingNumber():
     # ESTABLISH
     sue_deltaunit = deltaunit_shop()
     pool_atomunit = atomunit_shop(budunit_str(), atom_update())
@@ -610,7 +610,7 @@ def test_get_deltaunit_from_ordered_dict_ReturnsObj():
     assert generated_deltaunit == expected_deltaunit
 
 
-def test_DeltaUnit_get_json_ReturnsCorrectObj():
+def test_DeltaUnit_get_json_ReturnsObj():
     # ESTABLISH
     sue_deltaunit = deltaunit_shop()
     pool_atomunit = atomunit_shop(budunit_str(), atom_update())
@@ -637,7 +637,7 @@ def test_DeltaUnit_get_json_ReturnsCorrectObj():
     assert x_is_json(deltaunit_json)
 
 
-def test_DeltaUnit_atomunit_exists_ReturnsCorrectObj():
+def test_DeltaUnit_atomunit_exists_ReturnsObj():
     # ESTABLISH
     x_deltaunit = deltaunit_shop()
 

--- a/src/f04_gift/test_delta/test_delta_after_bud.py
+++ b/src/f04_gift/test_delta/test_delta_after_bud.py
@@ -41,7 +41,7 @@ from src.f04_gift.delta import deltaunit_shop
 from src.f04_gift.examples.example_deltas import get_deltaunit_example1
 
 
-def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_SimplestScenario():
+def test_DeltaUnit_get_edited_bud_ReturnsObj_SimplestScenario():
     # ESTABLISH
     ex1_deltaunit = deltaunit_shop()
 
@@ -56,7 +56,7 @@ def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_SimplestScenario():
     assert after_sue_budunit == before_sue_budunit
 
 
-def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnitSimpleAttrs():
+def test_DeltaUnit_get_edited_bud_ReturnsObj_BudUnitSimpleAttrs():
     # ESTABLISH
     sue_deltaunit = deltaunit_shop()
     sue_str = "Sue"
@@ -120,7 +120,7 @@ def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnitSimpleAttrs():
     assert after_sue_budunit.deal_time_int != before_sue_budunit.deal_time_int
 
 
-def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_delete_acct():
+def test_DeltaUnit_get_edited_bud_ReturnsObj_BudUnit_delete_acct():
     # ESTABLISH
     sue_deltaunit = deltaunit_shop()
     sue_str = "Sue"
@@ -146,7 +146,7 @@ def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_delete_acct():
     assert after_sue_budunit.acct_exists(zia_str) is False
 
 
-def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_insert_acct():
+def test_DeltaUnit_get_edited_bud_ReturnsObj_BudUnit_insert_acct():
     # ESTABLISH
     sue_deltaunit = deltaunit_shop()
     sue_str = "Sue"
@@ -179,7 +179,7 @@ def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_insert_acct():
     assert zia_acctunit.debtit_belief == x_debtit_belief
 
 
-def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_update_acct():
+def test_DeltaUnit_get_edited_bud_ReturnsObj_BudUnit_update_acct():
     # ESTABLISH
     sue_deltaunit = deltaunit_shop()
     sue_str = "Sue"
@@ -204,7 +204,7 @@ def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_update_acct():
     assert yao_acct.credit_belief == yao_credit_belief
 
 
-def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_delete_membership():
+def test_DeltaUnit_get_edited_bud_ReturnsObj_BudUnit_delete_membership():
     # ESTABLISH
     sue_str = "Sue"
     before_sue_budunit = budunit_shop(sue_str)
@@ -248,7 +248,7 @@ def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_delete_membership():
     assert len(after_group_labels_dict.get(fly_str)) == 2
 
 
-def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_insert_membership():
+def test_DeltaUnit_get_edited_bud_ReturnsObj_BudUnit_insert_membership():
     # ESTABLISH
     sue_str = "Sue"
     before_sue_budunit = budunit_shop(sue_str)
@@ -284,7 +284,7 @@ def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_insert_membership():
     assert after_yao_run_membership.credit_vote == yao_run_credit_vote
 
 
-def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_update_membership():
+def test_DeltaUnit_get_edited_bud_ReturnsObj_BudUnit_update_membership():
     # ESTABLISH
     sue_str = "Sue"
     before_sue_budunit = budunit_shop(sue_str)
@@ -317,7 +317,7 @@ def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_update_membership():
     assert after_yao_run_membership.debtit_vote == new_yao_run_debtit_vote
 
 
-def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_delete_itemunit():
+def test_DeltaUnit_get_edited_bud_ReturnsObj_BudUnit_delete_itemunit():
     # ESTABLISH
     sue_str = "Sue"
     before_sue_budunit = budunit_shop(sue_str)
@@ -352,7 +352,7 @@ def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_delete_itemunit():
     assert after_sue_budunit.item_exists(disc_road) is False
 
 
-def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_insert_itemunit():
+def test_DeltaUnit_get_edited_bud_ReturnsObj_BudUnit_insert_itemunit():
     # ESTABLISH
     sue_str = "Sue"
     before_sue_budunit = budunit_shop(sue_str)
@@ -398,7 +398,7 @@ def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_insert_itemunit():
     assert disc_item.stop_want == x_stop_want
 
 
-def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_update_itemunit_SimpleAttributes():
+def test_DeltaUnit_get_edited_bud_ReturnsObj_BudUnit_update_itemunit_SimpleAttributes():
     # ESTABLISH
     sue_str = "Sue"
     before_sue_budunit = budunit_shop(sue_str)
@@ -448,7 +448,7 @@ def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_update_itemunit_Simp
     assert after_sue_budunit.get_item_obj(ball_road).pledge
 
 
-def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_delete_item_awardlink():
+def test_DeltaUnit_get_edited_bud_ReturnsObj_BudUnit_delete_item_awardlink():
     # ESTABLISH
     sue_str = "Sue"
     before_sue_budunit = budunit_shop(sue_str)
@@ -498,7 +498,7 @@ def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_delete_item_awardlin
     assert len(after_sue_budunit.get_item_obj(disc_road).awardlinks) == 1
 
 
-def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_update_item_awardlink():
+def test_DeltaUnit_get_edited_bud_ReturnsObj_BudUnit_update_item_awardlink():
     # ESTABLISH
     sue_str = "Sue"
     before_sue_budunit = budunit_shop(sue_str)
@@ -540,7 +540,7 @@ def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_update_item_awardlin
     assert run_awardlink.take_force == x_take_force
 
 
-def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_insert_item_awardlink():
+def test_DeltaUnit_get_edited_bud_ReturnsObj_BudUnit_insert_item_awardlink():
     # ESTABLISH
     sue_str = "Sue"
     before_sue_budunit = budunit_shop(sue_str)
@@ -577,7 +577,7 @@ def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_insert_item_awardlin
     assert after_ball_item.awardlinks.get(run_str) is not None
 
 
-def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_insert_item_factunit():
+def test_DeltaUnit_get_edited_bud_ReturnsObj_BudUnit_insert_item_factunit():
     # ESTABLISH
     sue_str = "Sue"
     before_sue_au = budunit_shop(sue_str)
@@ -619,7 +619,7 @@ def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_insert_item_factunit
     assert after_ball_item.factunits.get(knee_road).fnigh == broken_fnigh
 
 
-def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_delete_item_factunit():
+def test_DeltaUnit_get_edited_bud_ReturnsObj_BudUnit_delete_item_factunit():
     # ESTABLISH
     sue_str = "Sue"
     before_sue_au = budunit_shop(sue_str)
@@ -655,7 +655,7 @@ def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_delete_item_factunit
     assert after_ball_item.factunits == {}
 
 
-def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_update_item_factunit():
+def test_DeltaUnit_get_edited_bud_ReturnsObj_BudUnit_update_item_factunit():
     # ESTABLISH
     sue_str = "Sue"
     before_sue_au = budunit_shop(sue_str)
@@ -705,7 +705,7 @@ def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_update_item_factunit
     assert after_ball_item.factunits.get(knee_road).fnigh == medical_fnigh
 
 
-def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_update_item_reason_premiseunit():
+def test_DeltaUnit_get_edited_bud_ReturnsObj_BudUnit_update_item_reason_premiseunit():
     # ESTABLISH
     sue_str = "Sue"
     before_sue_au = budunit_shop(sue_str)
@@ -762,7 +762,7 @@ def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_update_item_reason_p
     assert after_broken_premiseunit.divisor == broken_divisor
 
 
-def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_insert_item_reason_premiseunit():
+def test_DeltaUnit_get_edited_bud_ReturnsObj_BudUnit_insert_item_reason_premiseunit():
     # ESTABLISH
     sue_str = "Sue"
     before_sue_au = budunit_shop(sue_str)
@@ -817,7 +817,7 @@ def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_insert_item_reason_p
     assert after_medical_premiseunit.divisor == medical_divisor
 
 
-def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_delete_item_reason_premiseunit():
+def test_DeltaUnit_get_edited_bud_ReturnsObj_BudUnit_delete_item_reason_premiseunit():
     # ESTABLISH
     sue_str = "Sue"
     before_sue_au = budunit_shop(sue_str)
@@ -864,7 +864,7 @@ def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_delete_item_reason_p
     assert after_knee_reasonunit.get_premise(medical_road) is None
 
 
-def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_insert_item_reasonunit():
+def test_DeltaUnit_get_edited_bud_ReturnsObj_BudUnit_insert_item_reasonunit():
     # ESTABLISH
     sue_str = "Sue"
     before_sue_au = budunit_shop(sue_str)
@@ -906,7 +906,7 @@ def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_insert_item_reasonun
     )
 
 
-def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_update_item_reasonunit():
+def test_DeltaUnit_get_edited_bud_ReturnsObj_BudUnit_update_item_reasonunit():
     # ESTABLISH
     sue_str = "Sue"
     before_sue_au = budunit_shop(sue_str)
@@ -959,7 +959,7 @@ def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_update_item_reasonun
     )
 
 
-def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_delete_item_reasonunit():
+def test_DeltaUnit_get_edited_bud_ReturnsObj_BudUnit_delete_item_reasonunit():
     # ESTABLISH
     sue_str = "Sue"
     before_sue_au = budunit_shop(sue_str)
@@ -993,7 +993,7 @@ def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_delete_item_reasonun
     assert after_ball_item.get_reasonunit(knee_road) is None
 
 
-def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_insert_item_teamlink():
+def test_DeltaUnit_get_edited_bud_ReturnsObj_BudUnit_insert_item_teamlink():
     # ESTABLISH
     sue_str = "Sue"
     before_sue_au = budunit_shop(sue_str)
@@ -1021,7 +1021,7 @@ def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_insert_item_teamlink
     assert after_ball_itemunit.teamunit.get_teamlink(yao_str) is not None
 
 
-def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_delete_item_teamlink():
+def test_DeltaUnit_get_edited_bud_ReturnsObj_BudUnit_delete_item_teamlink():
     # ESTABLISH
     sue_str = "Sue"
     before_sue_au = budunit_shop(sue_str)
@@ -1051,7 +1051,7 @@ def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_delete_item_teamlink
     assert after_ball_itemunit.teamunit._teamlinks == set()
 
 
-def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_insert_item_healerlink():
+def test_DeltaUnit_get_edited_bud_ReturnsObj_BudUnit_insert_item_healerlink():
     # ESTABLISH
     sue_str = "Sue"
     before_sue_au = budunit_shop(sue_str)
@@ -1081,7 +1081,7 @@ def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_insert_item_healerli
     assert after_ball_itemunit.healerlink.healer_name_exists(yao_str)
 
 
-def test_DeltaUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_delete_item_healerlink():
+def test_DeltaUnit_get_edited_bud_ReturnsObj_BudUnit_delete_item_healerlink():
     # ESTABLISH
     sue_str = "Sue"
     before_sue_au = budunit_shop(sue_str)

--- a/src/f04_gift/test_gift/test_gift_.py
+++ b/src/f04_gift/test_gift/test_gift_.py
@@ -26,17 +26,17 @@ from src.f04_gift.examples.example_deltas import get_deltaunit_sue_example
 from pytest import raises as pytest_raises
 
 
-def test_get_gifts_folder_ReturnsCorrectObj():
+def test_get_gifts_folder_ReturnsObj():
     # ESTABLISH / WHEN / THEN
     assert get_gifts_folder() == "gifts"
 
 
-def test_init_gift_id_ReturnsCorrectObj():
+def test_init_gift_id_ReturnsObj():
     # ESTABLISH / WHEN / THEN
     assert init_gift_id() == 0
 
 
-def test_get_init_gift_id_if_None_ReturnsCorrectObj():
+def test_get_init_gift_id_if_None_ReturnsObj():
     # ESTABLISH / WHEN / THEN
     assert get_init_gift_id_if_None() == init_gift_id()
     assert get_init_gift_id_if_None(None) == init_gift_id()
@@ -59,7 +59,7 @@ def test_GiftUnit_exists():
     assert not x_giftunit.event_int
 
 
-def test_giftunit_shop_ReturnsCorrectObjEstablishWithEmptyArgs():
+def test_giftunit_shop_ReturnsObjEstablishWithEmptyArgs():
     # ESTABLISH
     bob_str = "Bob"
 
@@ -78,7 +78,7 @@ def test_giftunit_shop_ReturnsCorrectObjEstablishWithEmptyArgs():
     assert not bob_giftunit.event_int
 
 
-def test_giftunit_shop_ReturnsCorrectObjEstablishWithNonEmptyArgs():
+def test_giftunit_shop_ReturnsObjEstablishWithNonEmptyArgs():
     # ESTABLISH
     bob_str = "Bob"
     bob_gift_id = 13
@@ -115,7 +115,7 @@ def test_giftunit_shop_ReturnsCorrectObjEstablishWithNonEmptyArgs():
     assert bob_giftunit.event_int == accord45_e5_event_int
 
 
-def test_giftunit_shop_ReturnsCorrectObjEstablishWithSomeArgs_v1():
+def test_giftunit_shop_ReturnsObjEstablishWithSomeArgs_v1():
     # ESTABLISH
     bob_str = "Bob"
     yao_str = "Yao"
@@ -188,7 +188,7 @@ def test_GiftUnit_set_delta_start_SetsAttribute():
     assert bob_giftunit._delta_start == x_delta_start
 
 
-def test_GiftUnit_atomunit_exists_ReturnsCorrectObj():
+def test_GiftUnit_atomunit_exists_ReturnsObj():
     # ESTABLISH
     bob_str = "Bob"
     x_deltaunit = deltaunit_shop()
@@ -225,7 +225,7 @@ def test_GiftUnit_del_deltaunit_SetsAttribute():
     assert bob_giftunit._deltaunit == deltaunit_shop()
 
 
-def test_GiftUnit_get_step_dict_ReturnsCorrectObj_Simple():
+def test_GiftUnit_get_step_dict_ReturnsObj_Simple():
     # ESTABLISH
     bob_str = "Bob"
     sue_str = "Sue"
@@ -277,7 +277,7 @@ def test_GiftUnit_get_step_dict_ReturnsObj_WithDeltaUnitPopulated():
     assert sue_atomunits_dict.get(1) is not None
 
 
-def test_GiftUnit_get_step_dict_ReturnsCorrectObj_delta_start():
+def test_GiftUnit_get_step_dict_ReturnsObj_delta_start():
     # ESTABLISH
     bob_str = "Bob"
     sue_deltaunit = get_deltaunit_sue_example()
@@ -304,7 +304,7 @@ def test_GiftUnit_get_step_dict_ReturnsCorrectObj_delta_start():
     assert sue_atomunits_dict.get(x_delta_start + 1) is not None
 
 
-def test_GiftUnit_get_serializable_dict_ReturnsCorrectObj_Simple():
+def test_GiftUnit_get_serializable_dict_ReturnsObj_Simple():
     # ESTABLISH
     bob_str = "Bob"
     sue_str = "Sue"
@@ -404,7 +404,7 @@ def test_get_giftunit_from_json_ReturnsObj_WithDeltaUnitPopulated():
     assert generated_bob_giftunit == bob_giftunit
 
 
-def test_GiftUnit_get_delta_atom_numbers_ReturnsCorrectObj():
+def test_GiftUnit_get_delta_atom_numbers_ReturnsObj():
     # ESTABLISH
     bob_str = "Bob"
     yao_str = "Yao"
@@ -422,7 +422,7 @@ def test_GiftUnit_get_delta_atom_numbers_ReturnsCorrectObj():
     assert x_delta_atom_numbers == [x_delta_start, x_delta_start + 1]
 
 
-def test_GiftUnit_get_deltametric_dict_ReturnsCorrectObj():
+def test_GiftUnit_get_deltametric_dict_ReturnsObj():
     # ESTABLISH
     bob_str = "Bob"
     yao_str = "Yao"
@@ -456,7 +456,7 @@ def test_GiftUnit_get_deltametric_dict_ReturnsCorrectObj():
     assert x_dict.get(delta_max_str) is None
 
 
-def test_GiftUnit_get_deltametric_json_ReturnsCorrectObj():
+def test_GiftUnit_get_deltametric_json_ReturnsObj():
     # ESTABLISH
     bob_str = "Bob"
     sue_str = "Sue"
@@ -510,7 +510,7 @@ def test_GiftUnit_add_atomunit_CorrectlySets_BudUnit_acctunits():
     )
 
 
-def test_GiftUnit_get_edited_bud_ReturnsCorrectObj_BudUnit_insert_acct():
+def test_GiftUnit_get_edited_bud_ReturnsObj_BudUnit_insert_acct():
     # ESTABLISH
     sue_str = "Sue"
     sue_giftunit = giftunit_shop(sue_str)

--- a/src/f04_gift/test_gift/test_gift_file.py
+++ b/src/f04_gift/test_gift/test_gift_file.py
@@ -49,7 +49,7 @@ def test_GiftUnit_save_atom_file_SavesCorrectFile(env_dir_setup_cleanup):
     assert two_file_json == sports_atom.get_json()
 
 
-def test_GiftUnit_atom_file_exists_ReturnsCorrectObj(env_dir_setup_cleanup):
+def test_GiftUnit_atom_file_exists_ReturnsObj(env_dir_setup_cleanup):
     # ESTABLISH
     x_fiscal_dir = f_path(fiscals_dir(), fiscal_title())
     x_owners_dir = f_path(x_fiscal_dir, "owners")
@@ -76,7 +76,7 @@ def test_GiftUnit_atom_file_exists_ReturnsCorrectObj(env_dir_setup_cleanup):
     assert sue_giftunit.atom_file_exists(two_int)
 
 
-def test_GiftUnit_open_atom_file_ReturnsCorrectObj(env_dir_setup_cleanup):
+def test_GiftUnit_open_atom_file_ReturnsObj(env_dir_setup_cleanup):
     # ESTABLISH
     x_fiscal_dir = f_path(fiscals_dir(), fiscal_title())
     x_owners_dir = f_path(x_fiscal_dir, "owners")
@@ -140,7 +140,7 @@ def test_GiftUnit_save_gift_file_SavesCorrectFile(env_dir_setup_cleanup):
     print(f"{gift_file_dict.keys()=}")
 
 
-def test_GiftUnit_gift_file_exists_ReturnsCorrectObj(env_dir_setup_cleanup):
+def test_GiftUnit_gift_file_exists_ReturnsObj(env_dir_setup_cleanup):
     # ESTABLISH
     x_fiscal_dir = f_path(fiscals_dir(), fiscal_title())
     x_owners_dir = f_path(x_fiscal_dir, "owners")
@@ -236,7 +236,7 @@ def test_GiftUnit_create_deltaunit_from_atom_files_SetsAttr(env_dir_setup_cleanu
     assert sue_giftunit._deltaunit == static_deltaunit
 
 
-def test_create_giftunit_from_files_ReturnsCorrectObj(env_dir_setup_cleanup):
+def test_create_giftunit_from_files_ReturnsObj(env_dir_setup_cleanup):
     # ESTABLISH
     x_fiscal_dir = f_path(fiscals_dir(), fiscal_title())
     x_owners_dir = f_path(x_fiscal_dir, "owners")

--- a/src/f05_listen/test_basis_buds/test_basis_buds.py
+++ b/src/f05_listen/test_basis_buds/test_basis_buds.py
@@ -8,7 +8,7 @@ from src.f05_listen.basis_buds import (
 )
 
 
-def test_create_empty_bud_ReturnsCorrectObj():
+def test_create_empty_bud_ReturnsObj():
     # ESTABLISH
     yao_str = "Yao"
     slash_str = "/"
@@ -53,7 +53,7 @@ def test_create_empty_bud_ReturnsCorrectObj():
     assert yao_empty_job.accts == {}
 
 
-def test_create_listen_basis_ReturnsCorrectObj():
+def test_create_listen_basis_ReturnsObj():
     # ESTABLISH
     yao_str = "Yao"
     slash_str = "/"
@@ -101,7 +101,7 @@ def test_create_listen_basis_ReturnsCorrectObj():
     assert job_zia_acctunit._inallocable_debtit_belief == 0
 
 
-def test_get_default_voice_bud_ReturnsCorrectObj():
+def test_get_default_voice_bud_ReturnsObj():
     # ESTABLISH
     sue_str = "Sue"
     blue_str = "blue"

--- a/src/f05_listen/test_hubunit/test_hubunit__core.py
+++ b/src/f05_listen/test_hubunit/test_hubunit__core.py
@@ -28,7 +28,7 @@ from pytest import raises as pytest_raises
 from os.path import exists as os_path_exists
 
 
-def test_get_keep_path_ReturnsCorrectObj():
+def test_get_keep_path_ReturnsObj():
     # ESTABLISH
     sue_str = "Sue"
     peru_str = "peru"
@@ -99,7 +99,7 @@ def test_HubUnit_RaisesError_keep_road_DoesNotExist():
     )
 
 
-def test_hubunit_shop_ReturnsCorrectObj():
+def test_hubunit_shop_ReturnsObj():
     # ESTABLISH
     x_fiscals_dir = "src/f07_fiscal/examples"
     x_fiscal_title = "accord45"
@@ -154,7 +154,7 @@ def test_hubunit_shop_ReturnsCorrectObj():
     assert x_hubunit.voice_path() == x_voicepath
 
 
-def test_hubunit_shop_ReturnsCorrectObjWhenEmpty():
+def test_hubunit_shop_ReturnsObjWhenEmpty():
     # ESTABLISH
     sue_str = "Sue"
     nation_str = "nation-state"

--- a/src/f05_listen/test_hubunit/test_hubunit_atom.py
+++ b/src/f05_listen/test_hubunit/test_hubunit_atom.py
@@ -14,7 +14,7 @@ from src.f05_listen.examples.listen_env import (
 from os.path import exists as os_path_exists
 
 
-def test_HubUnit_atom_file_name_ReturnsCorrectObj():
+def test_HubUnit_atom_file_name_ReturnsObj():
     # ESTABLISH
     yao_str = "Yao"
     yao_hubunit = hubunit_shop(fiscals_dir(), fiscal_title(), yao_str)
@@ -27,7 +27,7 @@ def test_HubUnit_atom_file_name_ReturnsCorrectObj():
     assert one_atom_file_name == f"{one_int}.json"
 
 
-def test_HubUnit_atom_file_path_ReturnsCorrectObj():
+def test_HubUnit_atom_file_path_ReturnsObj():
     # ESTABLISH
     yao_str = "Yao"
     yao_hubunit = hubunit_shop(fiscals_dir(), fiscal_title(), yao_str)
@@ -58,7 +58,7 @@ def test_HubUnit_save_valid_atom_file_CorrectlySavesFile(env_dir_setup_cleanup):
     assert atom_num == one_int
 
 
-def test_HubUnit_atom_file_exists_ReturnsCorrectObj(env_dir_setup_cleanup):
+def test_HubUnit_atom_file_exists_ReturnsObj(env_dir_setup_cleanup):
     # ESTABLISH
     yao_str = "Yao"
     yao_hubunit = hubunit_shop(fiscals_dir(), fiscal_title(), yao_str)
@@ -89,7 +89,7 @@ def test_HubUnit_delete_atom_file_CorrectlyDeletesFile(env_dir_setup_cleanup):
     assert yao_hubunit.atom_file_exists(ten_int) is False
 
 
-def test_HubUnit_get_max_atom_file_number_ReturnsCorrectObj(env_dir_setup_cleanup):
+def test_HubUnit_get_max_atom_file_number_ReturnsObj(env_dir_setup_cleanup):
     # ESTABLISH
     yao_str = "Yao"
     yao_hubunit = hubunit_shop(fiscals_dir(), fiscal_title(), yao_str)
@@ -101,7 +101,7 @@ def test_HubUnit_get_max_atom_file_number_ReturnsCorrectObj(env_dir_setup_cleanu
     assert yao_hubunit.get_max_atom_file_number() == ten_int
 
 
-def test_HubUnit_get_max_atom_file_number_ReturnsCorrectObjWhenDirIsEmpty(
+def test_HubUnit_get_max_atom_file_number_ReturnsObjWhenDirIsEmpty(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -112,7 +112,7 @@ def test_HubUnit_get_max_atom_file_number_ReturnsCorrectObjWhenDirIsEmpty(
     assert yao_hubunit.get_max_atom_file_number() is None
 
 
-def test_HubUnit_get_next_atom_file_number_ReturnsCorrectObj(env_dir_setup_cleanup):
+def test_HubUnit_get_next_atom_file_number_ReturnsObj(env_dir_setup_cleanup):
     # ESTABLISH
     yao_str = "Yao"
     yao_hubunit = hubunit_shop(fiscals_dir(), fiscal_title(), yao_str)

--- a/src/f05_listen/test_hubunit/test_hubunit_gift.py
+++ b/src/f05_listen/test_hubunit/test_hubunit_gift.py
@@ -24,7 +24,7 @@ from pytest import raises as pytest_raises
 from copy import deepcopy as copy_deepcopy
 
 
-def test_HubUnit_get_max_gift_file_number_ReturnsCorrectObj(env_dir_setup_cleanup):
+def test_HubUnit_get_max_gift_file_number_ReturnsObj(env_dir_setup_cleanup):
     # ESTABLISH
     sue_str = "Sue"
     sue_hubunit = hubunit_shop(env_dir(), fiscal_title(), sue_str)
@@ -44,7 +44,7 @@ def test_HubUnit_get_max_gift_file_number_ReturnsCorrectObj(env_dir_setup_cleanu
     assert sue_hubunit._get_next_gift_file_number() == 7
 
 
-def test_HubUnit_gift_file_exists_ReturnsCorrectObj(env_dir_setup_cleanup):
+def test_HubUnit_gift_file_exists_ReturnsObj(env_dir_setup_cleanup):
     # ESTABLISH
     sue_str = "Sue"
     sue_hubunit = hubunit_shop(env_dir(), fiscal_title(), sue_str)
@@ -305,7 +305,7 @@ def test_HubUnit_default_giftunit_ReturnsObjWithCorrect_gift_id_WhengiftFilesExi
     assert sue_giftunit._gifts_dir == sue_hubunit.gifts_dir()
 
 
-def test_HubUnit_get_giftunit_ReturnsCorrectObjWhenFilesDoesExist(
+def test_HubUnit_get_giftunit_ReturnsObjWhenFilesDoesExist(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH

--- a/src/f05_listen/test_hubunit/test_hubunit_soul.py
+++ b/src/f05_listen/test_hubunit/test_hubunit_soul.py
@@ -9,7 +9,7 @@ from src.f05_listen.examples.listen_env import (
 from os.path import exists as os_path_exists
 
 
-def test_HubUnit_default_soul_bud_ReturnsCorrectObj():
+def test_HubUnit_default_soul_bud_ReturnsObj():
     # ESTABLISH
     sue_str = "Sue"
     slash_str = "/"

--- a/src/f06_keep/test_keep/test_riverbook.py
+++ b/src/f06_keep/test_keep/test_riverbook.py
@@ -18,7 +18,7 @@ def test_RiverBook_Exists():
     assert x_riverbook._rivergrants is None
 
 
-def test_riverbook_shop_ReturnsCorrectObj():
+def test_riverbook_shop_ReturnsObj():
     # ESTABLISH
     yao_str = "Yao"
     yao_hubunit = hubunit_shop(None, None, yao_str)
@@ -33,7 +33,7 @@ def test_riverbook_shop_ReturnsCorrectObj():
     assert bob_riverbook._rivergrants == {}
 
 
-def test_create_riverbook_ReturnsCorrectObj():
+def test_create_riverbook_ReturnsObj():
     # ESTABLISH
     yao_str = "Yao"
     sue_str = "Sue"

--- a/src/f06_keep/test_keep/test_rivercycle.py
+++ b/src/f06_keep/test_keep/test_rivercycle.py
@@ -26,7 +26,7 @@ def test_RiverCylce_Exists():
     assert x_rivercycle.riverbooks is None
 
 
-def test_rivercycle_shop_ReturnsCorrectObj():
+def test_rivercycle_shop_ReturnsObj():
     # ESTABLISH
     one_int = 1
     yao_hubunit = hubunit_shop(None, None, "Yao")
@@ -80,7 +80,7 @@ def test_RiverCylce_set_riverbook_CorrectlySetsAttr():
     assert one_rivercycle.riverbooks == {bob_str: bob_riverbook}
 
 
-def test_RiverCylce_create_cylceledger_ReturnsCorrectObjOneRiverBook():
+def test_RiverCylce_create_cylceledger_ReturnsObjOneRiverBook():
     # ESTABLISH
     yao_str = "Yao"
     yao_hubunit = hubunit_shop(None, None, yao_str)
@@ -97,7 +97,7 @@ def test_RiverCylce_create_cylceledger_ReturnsCorrectObjOneRiverBook():
     assert one_cylceledger == {yao_str: book_point_amount}
 
 
-def test_RiverCylce_create_cylceledger_ReturnsCorrectObjTwoRiverBooks():
+def test_RiverCylce_create_cylceledger_ReturnsObjTwoRiverBooks():
     # ESTABLISH
     yao_str = "Yao"
     bob_str = "Bob"

--- a/src/f06_keep/test_keep/test_rivergrade.py
+++ b/src/f06_keep/test_keep/test_rivergrade.py
@@ -42,7 +42,7 @@ def test_RiverGrade_Exists():
     assert x_rivergrade.rewards_magnitude is None
 
 
-def test_rivergrade_shop_ReturnsCorrectObjWithArg():
+def test_rivergrade_shop_ReturnsObjWithArg():
     # ESTABLISH
     bob_str = "Bob"
     yao_hubunit = example_yao_hubunit()
@@ -75,7 +75,7 @@ def test_rivergrade_shop_ReturnsCorrectObjWithArg():
     assert x_rivergrade.rewards_magnitude is None
 
 
-def test_rivergrade_shop_ReturnsCorrectObjWithoutArgs():
+def test_rivergrade_shop_ReturnsObjWithoutArgs():
     # ESTABLISH
     bob_str = "Bob"
     yao_hubunit = example_yao_hubunit()
@@ -132,7 +132,7 @@ def test_RiverGrade_set_tax_due_amount_SetsCorrectAttrs():
     assert x_rivergrade.tax_paid_bool is True
 
 
-def test_RiverGrade_get_dict_ReturnsCorrectObj():
+def test_RiverGrade_get_dict_ReturnsObj():
     # ESTABLISH
     bob_str = "Bob"
     yao_hubunit = example_yao_hubunit()
@@ -192,7 +192,7 @@ def test_RiverGrade_get_dict_ReturnsCorrectObj():
     assert rivergrade_dict.get("rewards_magnitude") == x_rewards_magnitude
 
 
-def test_RiverGrade_get_json_ReturnsCorrectObj():
+def test_RiverGrade_get_json_ReturnsObj():
     # ESTABLISH
     bob_str = "Bob"
     yao_hubunit = example_yao_hubunit()

--- a/src/f06_keep/test_keep/test_riverrun_.py
+++ b/src/f06_keep/test_keep/test_riverrun_.py
@@ -51,7 +51,7 @@ def test_RiverRun_set_cycle_max_CorrectlySetsAttr():
     assert x_riverrun.cycle_max == 10
 
 
-def test_riverrun_shop_ReturnsCorrectObjWithArg():
+def test_riverrun_shop_ReturnsObjWithArg():
     # ESTABLISH
     ten_int = 10
     yao_hubunit = example_yao_hubunit()
@@ -84,7 +84,7 @@ def test_riverrun_shop_ReturnsCorrectObjWithArg():
     assert x_riverrun._cycle_payees_curr == set()
 
 
-def test_riverrun_shop_ReturnsCorrectObjWithoutArgs():
+def test_riverrun_shop_ReturnsObjWithoutArgs():
     # ESTABLISH
     yao_hubunit = example_yao_hubunit()
 
@@ -142,7 +142,7 @@ def test_RiverRun_delete_keep_credorledgers_owner_SetsAttr():
     assert x_riverrun.keep_credorledgers == {yao_str: {yao_str: 1}}
 
 
-def test_RiverRun_get_all_keep_credorledger_acct_names_ReturnsCorrectObj():
+def test_RiverRun_get_all_keep_credorledger_acct_names_ReturnsObj():
     # ESTABLISH
     yao_hubunit = example_yao_hubunit()
     yao_str = "Yao"

--- a/src/f06_keep/test_keep/test_riverrun_crud_tax_due.py
+++ b/src/f06_keep/test_keep/test_riverrun_crud_tax_due.py
@@ -5,7 +5,7 @@ from src.f06_keep.riverrun import riverrun_shop
 from src.f06_keep.examples.example_credorledgers import example_yao_hubunit
 
 
-def test_get_credorledger_ReturnsCorrectObj():
+def test_get_credorledger_ReturnsObj():
     # ESTABLISH
     yao_str = "Yao"
     bob_str = "Bob"
@@ -28,7 +28,7 @@ def test_get_credorledger_ReturnsCorrectObj():
     assert yao_credorledger.get(yao_str) == sue_credit_belief
 
 
-def test_get_credorledger_ReturnsCorrectObjWithNoEmpty_credit_belief():
+def test_get_credorledger_ReturnsObjWithNoEmpty_credit_belief():
     # ESTABLISH
     yao_str = "Yao"
     bob_str = "Bob"
@@ -51,7 +51,7 @@ def test_get_credorledger_ReturnsCorrectObjWithNoEmpty_credit_belief():
     assert len(yao_credorledger) == 2
 
 
-def test_get_debtorledger_ReturnsCorrectObj():
+def test_get_debtorledger_ReturnsObj():
     # ESTABLISH
     yao_str = "Yao"
     bob_str = "Bob"
@@ -74,7 +74,7 @@ def test_get_debtorledger_ReturnsCorrectObj():
     assert yao_debtorledger.get(yao_str) == yao_debtit_belief
 
 
-def test_get_debtorledger_ReturnsCorrectObjWithNoEmpty_debtit_belief():
+def test_get_debtorledger_ReturnsObjWithNoEmpty_debtit_belief():
     # ESTABLISH
     yao_str = "Yao"
     bob_str = "Bob"
@@ -232,7 +232,7 @@ def test_RiverRun_delete_tax_due_SetsAttr():
     assert bob_riverrun.acct_has_tax_due(yao_str) is False
 
 
-def test_RiverRun_get_acct_tax_due_ReturnsCorrectObj():
+def test_RiverRun_get_acct_tax_due_ReturnsObj():
     # ESTABLISH
     bob_str = "Bob"
     bob_money_amount = 1000

--- a/src/f06_keep/test_keep/test_riverrun_crud_tax_yield.py
+++ b/src/f06_keep/test_keep/test_riverrun_crud_tax_yield.py
@@ -132,7 +132,7 @@ def test_RiverRun_delete_tax_yield_SetsAttr():
     assert bob_riverrun.acct_has_tax_yield(yao_str) is False
 
 
-def test_RiverRun_get_acct_tax_yield_ReturnsCorrectObj():
+def test_RiverRun_get_acct_tax_yield_ReturnsObj():
     # ESTABLISH
     bob_str = "Bob"
     bob_money_amount = 1000
@@ -165,7 +165,7 @@ def test_RiverRun_get_acct_tax_yield_ReturnsCorrectObj():
     assert bob_riverrun.get_acct_tax_yield(zia_str) == 0
 
 
-def test_RiverRun_add_acct_tax_yield_ReturnsCorrectObj():
+def test_RiverRun_add_acct_tax_yield_ReturnsObj():
     # ESTABLISH
     bob_str = "Bob"
     bob_money_amount = 1000

--- a/src/f06_keep/test_keep/test_riverrun_levy.py
+++ b/src/f06_keep/test_keep/test_riverrun_levy.py
@@ -54,7 +54,7 @@ def test_RiverRun_levy_tax_dues_Molds_cycleledger_Scenario02():
     assert tax_got == 322
 
 
-def test_RiverRun_cycle_payees_vary_ReturnsCorrectObj():
+def test_RiverRun_cycle_payees_vary_ReturnsObj():
     # ESTABLISH
     yao_str = "Yao"
     x_riverrun = riverrun_shop(example_yao_hubunit())
@@ -69,7 +69,7 @@ def test_RiverRun_cycle_payees_vary_ReturnsCorrectObj():
     assert x_riverrun._cycle_payees_vary()
 
 
-def test_RiverRun_cycles_vary_ReturnsCorrectObj():
+def test_RiverRun_cycles_vary_ReturnsObj():
     # ESTABLISH
     yao_str = "Yao"
     yao_tax_got = 5

--- a/src/f07_fiscal/test_fiscal_/test_fiscal_.py
+++ b/src/f07_fiscal/test_fiscal_/test_fiscal_.py
@@ -192,7 +192,7 @@ def test_FiscalUnit_init_owner_keeps_CorrectlySetsDirAndFiles(env_dir_setup_clea
     assert os_path_exists(sue_hubunit.voice_path())
 
 
-def test_FiscalUnit_get_owner_soul_from_file_ReturnsCorrectObj(env_dir_setup_cleanup):
+def test_FiscalUnit_get_owner_soul_from_file_ReturnsObj(env_dir_setup_cleanup):
     # ESTABLISH
     accord45_str = "accord45"
     accord_fiscal = fiscalunit_shop(
@@ -289,7 +289,7 @@ def test_FiscalUnit__set_all_healer_dutys_CorrectlySetsdutys(
     assert os_path_exists(yao_dallas_yao_duty_file_path)
 
 
-def test_FiscalUnit_get_owner_hubunits_ReturnsCorrectObj(env_dir_setup_cleanup):
+def test_FiscalUnit_get_owner_hubunits_ReturnsObj(env_dir_setup_cleanup):
     # ESTABLISH
     accord_fiscal = fiscalunit_shop(
         "accord45", get_test_fiscals_dir(), in_memory_journal=True

--- a/src/f07_fiscal/test_fiscal_/test_fiscal_journal_.py
+++ b/src/f07_fiscal/test_fiscal_/test_fiscal_journal_.py
@@ -16,7 +16,7 @@ from os.path import exists as os_path_exists
 from pytest import raises as pytest_raises
 
 
-def test_FiscalUnit_get_journal_db_path_ReturnsCorrectObj():
+def test_FiscalUnit_get_journal_db_path_ReturnsObj():
     # ESTABLISH
     accord45_str = "accord45"
     accord_fiscal = FiscalUnit(

--- a/src/f07_fiscal/test_fiscal_/test_fiscal_kpis.py
+++ b/src/f07_fiscal/test_fiscal_/test_fiscal_kpis.py
@@ -18,7 +18,7 @@ from src.f07_fiscal.examples.example_fiscals import (
 from src.f07_fiscal.examples.fiscal_env import env_dir_setup_cleanup
 
 
-def test_get_fiscal_souls_accts_dataframe_ReturnsCorrectObj(
+def test_get_fiscal_souls_accts_dataframe_ReturnsObj(
     env_dir_setup_cleanup, graphics_bool
 ):
     # ESTABLISH
@@ -61,7 +61,7 @@ def test_get_fiscal_souls_accts_plotly_fig_DisplaysCorrectInfo(
     conditional_fig_show(x_fig, graphics_bool)
 
 
-def test_get_fiscal_voices_accts_dataframe_ReturnsCorrectObj(
+def test_get_fiscal_voices_accts_dataframe_ReturnsObj(
     env_dir_setup_cleanup, graphics_bool
 ):
     # ESTABLISH
@@ -107,7 +107,7 @@ def test_get_fiscal_voices_accts_plotly_fig_DisplaysCorrectInfo(
     conditional_fig_show(x_fig, graphics_bool)
 
 
-def test_get_fiscal_souls_agenda_dataframe_ReturnsCorrectObj(
+def test_get_fiscal_souls_agenda_dataframe_ReturnsObj(
     env_dir_setup_cleanup, graphics_bool
 ):
     # ESTABLISH
@@ -149,7 +149,7 @@ def test_get_fiscal_souls_agenda_plotly_fig_DisplaysCorrectInfo(
     conditional_fig_show(x_fig, graphics_bool)
 
 
-def test_get_fiscal_voices_agenda_dataframe_ReturnsCorrectObj(env_dir_setup_cleanup):
+def test_get_fiscal_voices_agenda_dataframe_ReturnsObj(env_dir_setup_cleanup):
     # ESTABLISH
     accord_fiscal = create_example_fiscal4()
     accord_fiscal.generate_all_voice_buds()

--- a/src/f09_idea/test_idea/test_idea_format_config.py
+++ b/src/f09_idea/test_idea/test_idea_format_config.py
@@ -158,7 +158,7 @@ def test_get_idea_format_headers_ReturnsObj():
     assert set(x_headers.values()) == get_idea_format_filenames()
 
 
-def test__generate_idea_dataframe_ReturnsCorrectObj():
+def test__generate_idea_dataframe_ReturnsObj():
     # ESTABLISH
     empty_d2 = []
     # WHEN
@@ -180,7 +180,7 @@ def for_all_ideas__generate_idea_dataframe():
     return True
 
 
-def test__generate_idea_dataframe_ReturnsCorrectObjForEvery_idea():
+def test__generate_idea_dataframe_ReturnsObjForEvery_idea():
     # ESTABLISH / WHEN / THEN
     assert for_all_ideas__generate_idea_dataframe()
 


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Standardize test method names by replacing "CorrectObj" with "Obj".