### PR TITLE
175 enable documentation process

### DIFF
--- a/src/f05_listen/cell.py
+++ b/src/f05_listen/cell.py
@@ -27,7 +27,7 @@ from src.f02_bud.bud_tool import (
 from dataclasses import dataclass
 from copy import deepcopy as copy_deepcopy, copy as copy_copy
 
-CELL_NODE_QUOTA_DEFAULT = 1000
+CELLNODE_QUOTA_DEFAULT = 1000
 
 
 @dataclass
@@ -148,7 +148,7 @@ def cellunit_shop(
     boss_facts: dict[RoadUnit, FactUnit] = None,
 ) -> CellUnit:
     if quota is None:
-        quota = CELL_NODE_QUOTA_DEFAULT
+        quota = CELLNODE_QUOTA_DEFAULT
     if budadjust is None:
         budadjust = budunit_shop(deal_owner_name)
     reason_bases = budadjust.get_reason_bases() if budadjust else set()

--- a/src/f05_listen/hub_path.py
+++ b/src/f05_listen/hub_path.py
@@ -7,7 +7,6 @@ FISC_OTE1_AGG_JSON_FILENAME = "fisc_ote1_agg.json"
 FISC_AGENDA_FULL_LISTING_FILENAME = "agenda_full_listing.csv"
 DEALUNIT_FILENAME = "dealunit.json"
 CELLNODE_FILENAME = "cell_node.json"
-CELL_FOUND_FACTS_FILENAME = "found_facts.json"
 CELL_QUOTA_LEDGER_FILENAME = "quota_ledger.json"
 BUDPOINT_FILENAME = "budpoint.json"
 BUDEVENT_FILENAME = "bud.json"
@@ -133,20 +132,6 @@ def create_cell_quota_ledger_path(
         fisc_mstr_dir, fisc_title, owner_name, time_int, deal_ancestors
     )
     return create_path(timepoint_dir, "quota_ledger.json")
-
-
-def create_cell_found_facts_path(
-    fisc_mstr_dir: str,
-    fisc_title: TitleUnit,
-    owner_name: OwnerName,
-    time_int: int,
-    deal_ancestors: list[OwnerName] = None,
-):
-    """Returns path: fisc_mstr_dir\\fiscs\\fisc_title\\owners\\owner_name\\deals\n\\time_int\\ledger_owner1\\ledger_owner2\\ledger_owner3\\found_facts.json"""
-    timepoint_dir = create_cell_dir_path(
-        fisc_mstr_dir, fisc_title, owner_name, time_int, deal_ancestors
-    )
-    return create_path(timepoint_dir, "found_facts.json")
 
 
 def create_owner_event_dir_path(

--- a/src/f05_listen/hub_path.py
+++ b/src/f05_listen/hub_path.py
@@ -6,7 +6,7 @@ FISC_OTE1_AGG_CSV_FILENAME = "fisc_ote1_agg.csv"
 FISC_OTE1_AGG_JSON_FILENAME = "fisc_ote1_agg.json"
 FISC_AGENDA_FULL_LISTING_FILENAME = "agenda_full_listing.csv"
 DEALUNIT_FILENAME = "dealunit.json"
-CELLNODE_FILENAME = "cell_node.json"
+CELLNODE_FILENAME = "cell.json"
 BUDPOINT_FILENAME = "budpoint.json"
 BUDEVENT_FILENAME = "bud.json"
 EVENT_ALL_GIFT_FILENAME = "all_gift.json"
@@ -105,18 +105,18 @@ def create_cell_dir_path(
     return deal_celldepth_dir
 
 
-def create_cell_node_json_path(
+def create_cell_json_path(
     fisc_mstr_dir: str,
     fisc_title: TitleUnit,
     owner_name: OwnerName,
     time_int: int,
     deal_ancestors: list[OwnerName] = None,
 ):
-    """Returns path: fisc_mstr_dir\\fiscs\\fisc_title\\owners\\owner_name\\deals\n\\time_int\\ledger_owner1\\ledger_owner2\\ledger_owner3\\cell_node.json"""
+    """Returns path: fisc_mstr_dir\\fiscs\\fisc_title\\owners\\owner_name\\deals\n\\time_int\\ledger_owner1\\ledger_owner2\\ledger_owner3\\cell.json"""
     timepoint_dir = create_cell_dir_path(
         fisc_mstr_dir, fisc_title, owner_name, time_int, deal_ancestors
     )
-    return create_path(timepoint_dir, "cell_node.json")
+    return create_path(timepoint_dir, "cell.json")
 
 
 def create_owner_event_dir_path(

--- a/src/f05_listen/hub_path.py
+++ b/src/f05_listen/hub_path.py
@@ -7,7 +7,6 @@ FISC_OTE1_AGG_JSON_FILENAME = "fisc_ote1_agg.json"
 FISC_AGENDA_FULL_LISTING_FILENAME = "agenda_full_listing.csv"
 DEALUNIT_FILENAME = "dealunit.json"
 CELLNODE_FILENAME = "cell_node.json"
-CELL_QUOTA_LEDGER_FILENAME = "quota_ledger.json"
 BUDPOINT_FILENAME = "budpoint.json"
 BUDEVENT_FILENAME = "bud.json"
 EVENT_ALL_GIFT_FILENAME = "all_gift.json"
@@ -118,20 +117,6 @@ def create_cell_node_json_path(
         fisc_mstr_dir, fisc_title, owner_name, time_int, deal_ancestors
     )
     return create_path(timepoint_dir, "cell_node.json")
-
-
-def create_cell_quota_ledger_path(
-    fisc_mstr_dir: str,
-    fisc_title: TitleUnit,
-    owner_name: OwnerName,
-    time_int: int,
-    deal_ancestors: list[OwnerName] = None,
-):
-    """Returns path: fisc_mstr_dir\\fiscs\\fisc_title\\owners\\owner_name\\deals\n\\time_int\\ledger_owner1\\ledger_owner2\\ledger_owner3\\quota_ledger.json"""
-    timepoint_dir = create_cell_dir_path(
-        fisc_mstr_dir, fisc_title, owner_name, time_int, deal_ancestors
-    )
-    return create_path(timepoint_dir, "quota_ledger.json")
 
 
 def create_owner_event_dir_path(

--- a/src/f05_listen/hub_path.py
+++ b/src/f05_listen/hub_path.py
@@ -7,9 +7,8 @@ FISC_OTE1_AGG_JSON_FILENAME = "fisc_ote1_agg.json"
 FISC_AGENDA_FULL_LISTING_FILENAME = "agenda_full_listing.csv"
 DEALUNIT_FILENAME = "dealunit.json"
 CELLNODE_FILENAME = "cell_node.json"
-CELL_QUOTA_LEDGER_FILENAME = "quota_ledger.json"
-CELL_BUDEVENT_FACTS_FILENAME = "budevent_facts.json"
 CELL_FOUND_FACTS_FILENAME = "found_facts.json"
+CELL_QUOTA_LEDGER_FILENAME = "quota_ledger.json"
 BUDPOINT_FILENAME = "budpoint.json"
 BUDEVENT_FILENAME = "bud.json"
 EVENT_ALL_GIFT_FILENAME = "all_gift.json"
@@ -134,20 +133,6 @@ def create_cell_quota_ledger_path(
         fisc_mstr_dir, fisc_title, owner_name, time_int, deal_ancestors
     )
     return create_path(timepoint_dir, "quota_ledger.json")
-
-
-def create_cell_budevent_facts_path(
-    fisc_mstr_dir: str,
-    fisc_title: TitleUnit,
-    owner_name: OwnerName,
-    time_int: int,
-    deal_ancestors: list[OwnerName] = None,
-):
-    """Returns path: fisc_mstr_dir\\fiscs\\fisc_title\\owners\\owner_name\\deals\n\\time_int\\ledger_owner1\\ledger_owner2\\ledger_owner3\\budevent_facts.json"""
-    timepoint_dir = create_cell_dir_path(
-        fisc_mstr_dir, fisc_title, owner_name, time_int, deal_ancestors
-    )
-    return create_path(timepoint_dir, "budevent_facts.json")
 
 
 def create_cell_found_facts_path(

--- a/src/f05_listen/hub_tool.py
+++ b/src/f05_listen/hub_tool.py
@@ -22,6 +22,7 @@ from src.f05_listen.hub_path import (
     create_budpoint_path,
     create_budevent_path,
     create_owners_dir_path,
+    create_cell_dir_path,
     create_cell_node_json_path,
 )
 from os import listdir as os_listdir
@@ -57,13 +58,6 @@ def get_budevent_obj(
         fisc_mstr_dir, fisc_title, owner_name, event_int
     )
     return open_bud_file(budevent_json_path)
-
-
-def get_budevent_facts(
-    fisc_mstr_dir: str, fisc_title: TitleUnit, owner_name: OwnerName, event_int: int
-) -> dict[RoadUnit, dict[str,]]:
-    budevent = get_budevent_obj(fisc_mstr_dir, fisc_title, owner_name, event_int)
-    return get_bud_root_facts_dict(budevent) if budevent else {}
 
 
 def collect_owner_event_dir_sets(
@@ -145,7 +139,7 @@ def save_arbitrary_budevent(
     return x_budevent_path
 
 
-def save_cell_node_file(
+def cellunit_add_json_file(
     fisc_mstr_dir: str,
     fisc_title: str,
     time_owner_name: str,
@@ -156,15 +150,19 @@ def save_cell_node_file(
     celldepth: int = None,
     penny: int = None,
 ):
-    cellnode_path = create_cell_node_json_path(
+    cell_dir = create_cell_dir_path(
         fisc_mstr_dir, fisc_title, time_owner_name, time_int, deal_ancestors
     )
-    x_cellunit = cellunit_shop(
+    x_cell = cellunit_shop(
         time_owner_name, deal_ancestors, event_int, celldepth, penny, quota
     )
-    save_json(cellnode_path, None, x_cellunit.get_dict())
+    cellunit_save_to_dir(cell_dir, x_cell)
 
 
-def cellunit_get_from_json(dirpath: str) -> CellUnit:
+def cellunit_save_to_dir(dirpath: str, x_cell: CellUnit):
+    save_json(dirpath, CELLNODE_FILENAME, x_cell.get_dict())
+
+
+def cellunit_get_from_dir(dirpath: str) -> CellUnit:
     cell_node_json_path = create_path(dirpath, CELLNODE_FILENAME)
     return cellunit_get_from_dict(open_json(cell_node_json_path))

--- a/src/f05_listen/hub_tool.py
+++ b/src/f05_listen/hub_tool.py
@@ -59,13 +59,6 @@ def get_budevent_obj(
     return open_bud_file(budevent_json_path)
 
 
-def get_budevents_credit_ledger(
-    fisc_mstr_dir: str, fisc_title: TitleUnit, owner_name: OwnerName, event_int: int
-) -> dict[AcctName, RespectNum]:
-    budevent = get_budevent_obj(fisc_mstr_dir, fisc_title, owner_name, event_int)
-    return get_credit_ledger(budevent) if budevent else {}
-
-
 def get_budevent_facts(
     fisc_mstr_dir: str, fisc_title: TitleUnit, owner_name: OwnerName, event_int: int
 ) -> dict[RoadUnit, dict[str,]]:

--- a/src/f05_listen/hub_tool.py
+++ b/src/f05_listen/hub_tool.py
@@ -23,7 +23,7 @@ from src.f05_listen.hub_path import (
     create_budevent_path,
     create_owners_dir_path,
     create_cell_dir_path,
-    create_cell_node_json_path,
+    create_cell_json_path,
 )
 from os import listdir as os_listdir
 from os.path import exists as os_path_exists, isdir as os_path_isdir
@@ -164,5 +164,5 @@ def cellunit_save_to_dir(dirpath: str, x_cell: CellUnit):
 
 
 def cellunit_get_from_dir(dirpath: str) -> CellUnit:
-    cell_node_json_path = create_path(dirpath, CELLNODE_FILENAME)
-    return cellunit_get_from_dict(open_json(cell_node_json_path))
+    cell_json_path = create_path(dirpath, CELLNODE_FILENAME)
+    return cellunit_get_from_dict(open_json(cell_json_path))

--- a/src/f05_listen/test_cell/test_cell_.py
+++ b/src/f05_listen/test_cell/test_cell_.py
@@ -3,7 +3,7 @@ from src.f02_bud.bud import budunit_shop
 from src.f05_listen.cell import (
     CellUnit,
     cellunit_shop,
-    CELL_NODE_QUOTA_DEFAULT,
+    CELLNODE_QUOTA_DEFAULT,
     create_child_cellunits,
 )
 from src.f05_listen.examples.example_listen import (
@@ -15,9 +15,9 @@ from src.f05_listen.examples.example_listen import (
 from copy import deepcopy as copy_deepcopy
 
 
-def test_CELL_NODE_QUOTA_DEFAULT_value():
+def test_CELLNODE_QUOTA_DEFAULT_value():
     # ESTABLISH / WHEN / THEN
-    assert CELL_NODE_QUOTA_DEFAULT == 1000
+    assert CELLNODE_QUOTA_DEFAULT == 1000
 
 
 def test_CellUnit_Exists():
@@ -49,7 +49,7 @@ def test_cellunit_shop_ReturnsObj_Scenario0_WithoutParameters():
     assert not x_cellunit.event_int
     assert x_cellunit.celldepth == 0
     assert x_cellunit.penny == 1
-    assert x_cellunit.quota == CELL_NODE_QUOTA_DEFAULT
+    assert x_cellunit.quota == CELLNODE_QUOTA_DEFAULT
     assert x_cellunit.budadjust.get_dict() == budunit_shop(bob_str).get_dict()
     assert x_cellunit.budevent_facts == {}
     assert x_cellunit._reason_bases == set()

--- a/src/f05_listen/test_hubunit/test_hub_path_.py
+++ b/src/f05_listen/test_hubunit/test_hub_path_.py
@@ -26,7 +26,7 @@ from src.f05_listen.hub_path import (
     create_dealunit_json_path,
     create_budpoint_path,
     create_cell_dir_path,
-    create_cell_node_json_path,
+    create_cell_json_path,
     create_owner_event_dir_path,
     create_budevent_path,
     create_event_all_gift_path,
@@ -44,7 +44,7 @@ def test_hub_path_constants_are_values():
     assert FISC_OTE1_AGG_JSON_FILENAME == "fisc_ote1_agg.json"
     assert FISC_AGENDA_FULL_LISTING_FILENAME == "agenda_full_listing.csv"
     assert DEALUNIT_FILENAME == "dealunit.json"
-    assert CELLNODE_FILENAME == "cell_node.json"
+    assert CELLNODE_FILENAME == "cell.json"
     assert BUDPOINT_FILENAME == "budpoint.json"
     assert BUDEVENT_FILENAME == "bud.json"
     assert EVENT_ALL_GIFT_FILENAME == "all_gift.json"
@@ -222,13 +222,11 @@ def test_create_cell_dir_path_ReturnObj_Scenario0_No_deal_ancestors():
     tp7 = 7
 
     # WHEN
-    gen_cell_node_path = create_cell_dir_path(
-        x_fisc_mstr_dir, a23_str, sue_str, tp7, []
-    )
+    gen_cell_dir = create_cell_dir_path(x_fisc_mstr_dir, a23_str, sue_str, tp7, [])
 
     # THEN
     timepoint_dir = create_deal_dir_path(x_fisc_mstr_dir, a23_str, sue_str, tp7)
-    assert gen_cell_node_path == timepoint_dir
+    assert gen_cell_dir == timepoint_dir
 
 
 def test_create_cell_dir_path_ReturnObj_Scenario1_One_deal_ancestors():
@@ -241,14 +239,14 @@ def test_create_cell_dir_path_ReturnObj_Scenario1_One_deal_ancestors():
     x_deal_ancestors = [yao_str]
 
     # WHEN
-    gen_cell_node_path = create_cell_dir_path(
+    gen_cell_dir = create_cell_dir_path(
         x_fisc_mstr_dir, a23_str, sue_str, tp7, deal_ancestors=x_deal_ancestors
     )
 
     # THEN
     timepoint_dir = create_deal_dir_path(x_fisc_mstr_dir, a23_str, sue_str, tp7)
     tp_yao_dir = create_path(timepoint_dir, yao_str)
-    assert gen_cell_node_path == tp_yao_dir
+    assert gen_cell_dir == tp_yao_dir
 
 
 def test_create_cell_dir_path_ReturnObj_Scenario2_Three_deal_ancestors():
@@ -275,7 +273,7 @@ def test_create_cell_dir_path_ReturnObj_Scenario2_Three_deal_ancestors():
     assert gen_deal_celldepth_dir_path == expected_tp_yao_bob_zia_dir
 
 
-def test_create_cell_node_json_path_ReturnObj_Scenario0_Empty_deal_ancestors():
+def test_create_cell_json_path_ReturnObj_Scenario0_Empty_deal_ancestors():
     # ESTABLISH
     x_fisc_mstr_dir = get_listen_temp_env_dir()
     a23_str = "accord23"
@@ -283,7 +281,7 @@ def test_create_cell_node_json_path_ReturnObj_Scenario0_Empty_deal_ancestors():
     timepoint7 = 7
 
     # WHEN
-    gen_cell_node_path = create_cell_node_json_path(
+    gen_cell_json_path = create_cell_json_path(
         x_fisc_mstr_dir, a23_str, sue_str, timepoint7
     )
 
@@ -294,11 +292,11 @@ def test_create_cell_node_json_path_ReturnObj_Scenario0_Empty_deal_ancestors():
     sue_dir = create_path(owners_dir, sue_str)
     deals_dir = create_path(sue_dir, "deals")
     timepoint_dir = create_path(deals_dir, timepoint7)
-    expected_cell_node_path_dir = create_path(timepoint_dir, CELLNODE_FILENAME)
-    assert gen_cell_node_path == expected_cell_node_path_dir
+    expected_cell_json_path = create_path(timepoint_dir, CELLNODE_FILENAME)
+    assert gen_cell_json_path == expected_cell_json_path
 
 
-def test_create_cell_node_json_path_ReturnObj_Scenario1_Three_deal_ancestors():
+def test_create_cell_json_path_ReturnObj_Scenario1_Three_deal_ancestors():
     # ESTABLISH
     x_fisc_mstr_dir = get_listen_temp_env_dir()
     a23_str = "accord23"
@@ -309,7 +307,7 @@ def test_create_cell_node_json_path_ReturnObj_Scenario1_Three_deal_ancestors():
     deal_ancestors = [yao_str, bob_str]
 
     # WHEN
-    gen_cell_node_path = create_cell_node_json_path(
+    gen_cell_json_path = create_cell_json_path(
         x_fisc_mstr_dir, a23_str, sue_str, tp7, deal_ancestors=deal_ancestors
     )
 
@@ -317,8 +315,8 @@ def test_create_cell_node_json_path_ReturnObj_Scenario1_Three_deal_ancestors():
     timepoint_dir = create_deal_dir_path(x_fisc_mstr_dir, a23_str, sue_str, tp7)
     tp_yao_dir = create_path(timepoint_dir, yao_str)
     tp_yao_bob_dir = create_path(tp_yao_dir, bob_str)
-    expected_cell_node_path = create_path(tp_yao_bob_dir, CELLNODE_FILENAME)
-    assert gen_cell_node_path == expected_cell_node_path
+    expected_cell_json_path = create_path(tp_yao_bob_dir, CELLNODE_FILENAME)
+    assert gen_cell_json_path == expected_cell_json_path
 
 
 def test_create_owner_event_dir_path_ReturnObj():

--- a/src/f05_listen/test_hubunit/test_hub_path_.py
+++ b/src/f05_listen/test_hubunit/test_hub_path_.py
@@ -12,7 +12,6 @@ from src.f05_listen.hub_path import (
     FISC_AGENDA_FULL_LISTING_FILENAME,
     DEALUNIT_FILENAME,
     CELLNODE_FILENAME,
-    CELL_QUOTA_LEDGER_FILENAME,
     BUDPOINT_FILENAME,
     BUDEVENT_FILENAME,
     EVENT_ALL_GIFT_FILENAME,
@@ -28,7 +27,6 @@ from src.f05_listen.hub_path import (
     create_budpoint_path,
     create_cell_dir_path,
     create_cell_node_json_path,
-    create_cell_quota_ledger_path,
     create_owner_event_dir_path,
     create_budevent_path,
     create_event_all_gift_path,
@@ -47,7 +45,6 @@ def test_hub_path_constants_are_values():
     assert FISC_AGENDA_FULL_LISTING_FILENAME == "agenda_full_listing.csv"
     assert DEALUNIT_FILENAME == "dealunit.json"
     assert CELLNODE_FILENAME == "cell_node.json"
-    assert CELL_QUOTA_LEDGER_FILENAME == "quota_ledger.json"
     assert BUDPOINT_FILENAME == "budpoint.json"
     assert BUDEVENT_FILENAME == "bud.json"
     assert EVENT_ALL_GIFT_FILENAME == "all_gift.json"
@@ -322,31 +319,6 @@ def test_create_cell_node_json_path_ReturnObj_Scenario1_Three_deal_ancestors():
     tp_yao_bob_dir = create_path(tp_yao_dir, bob_str)
     expected_cell_node_path = create_path(tp_yao_bob_dir, CELLNODE_FILENAME)
     assert gen_cell_node_path == expected_cell_node_path
-
-
-def test_create_cell_quota_ledger_path_ReturnObj_Scenario1_Three_deal_ancestors():
-    # ESTABLISH
-    x_fisc_mstr_dir = get_listen_temp_env_dir()
-    a23_str = "accord23"
-    sue_str = "Sue"
-    tp7 = 7
-    yao_str = "Yao"
-    bob_str = "Bob"
-    deal_ancestors = [yao_str, bob_str]
-
-    # WHEN
-    gen_deal_quota_ledger_path = create_cell_quota_ledger_path(
-        x_fisc_mstr_dir, a23_str, sue_str, tp7, deal_ancestors=deal_ancestors
-    )
-
-    # THEN
-    timepoint_dir = create_deal_dir_path(x_fisc_mstr_dir, a23_str, sue_str, tp7)
-    tp_yao_dir = create_path(timepoint_dir, yao_str)
-    tp_yao_bob_dir = create_path(tp_yao_dir, bob_str)
-    expected_deal_quota_ledger_path = create_path(
-        tp_yao_bob_dir, CELL_QUOTA_LEDGER_FILENAME
-    )
-    assert gen_deal_quota_ledger_path == expected_deal_quota_ledger_path
 
 
 def test_create_owner_event_dir_path_ReturnObj():

--- a/src/f05_listen/test_hubunit/test_hub_path_.py
+++ b/src/f05_listen/test_hubunit/test_hub_path_.py
@@ -13,7 +13,6 @@ from src.f05_listen.hub_path import (
     DEALUNIT_FILENAME,
     CELLNODE_FILENAME,
     CELL_QUOTA_LEDGER_FILENAME,
-    CELL_BUDEVENT_FACTS_FILENAME,
     CELL_FOUND_FACTS_FILENAME,
     BUDPOINT_FILENAME,
     BUDEVENT_FILENAME,
@@ -31,7 +30,6 @@ from src.f05_listen.hub_path import (
     create_cell_dir_path,
     create_cell_node_json_path,
     create_cell_quota_ledger_path,
-    create_cell_budevent_facts_path,
     create_cell_found_facts_path,
     create_owner_event_dir_path,
     create_budevent_path,
@@ -51,9 +49,8 @@ def test_hub_path_constants_are_values():
     assert FISC_AGENDA_FULL_LISTING_FILENAME == "agenda_full_listing.csv"
     assert DEALUNIT_FILENAME == "dealunit.json"
     assert CELLNODE_FILENAME == "cell_node.json"
-    assert CELL_QUOTA_LEDGER_FILENAME == "quota_ledger.json"
-    assert CELL_BUDEVENT_FACTS_FILENAME == "budevent_facts.json"
     assert CELL_FOUND_FACTS_FILENAME == "found_facts.json"
+    assert CELL_QUOTA_LEDGER_FILENAME == "quota_ledger.json"
     assert BUDPOINT_FILENAME == "budpoint.json"
     assert BUDEVENT_FILENAME == "bud.json"
     assert EVENT_ALL_GIFT_FILENAME == "all_gift.json"
@@ -353,29 +350,6 @@ def test_create_cell_quota_ledger_path_ReturnObj_Scenario1_Three_deal_ancestors(
         tp_yao_bob_dir, CELL_QUOTA_LEDGER_FILENAME
     )
     assert gen_deal_quota_ledger_path == expected_deal_quota_ledger_path
-
-
-def test_create_cell_budevent_facts_path_ReturnObj_Scenario0_Three_deal_ancestors():
-    # ESTABLISH
-    x_fisc_mstr_dir = get_listen_temp_env_dir()
-    a23_str = "accord23"
-    sue_str = "Sue"
-    tp7 = 7
-    yao_str = "Yao"
-    bob_str = "Bob"
-    deal_ancestors = [yao_str, bob_str]
-
-    # WHEN
-    gen_deal_facts_path = create_cell_budevent_facts_path(
-        x_fisc_mstr_dir, a23_str, sue_str, tp7, deal_ancestors=deal_ancestors
-    )
-
-    # THEN
-    timepoint_dir = create_deal_dir_path(x_fisc_mstr_dir, a23_str, sue_str, tp7)
-    tp_yao_dir = create_path(timepoint_dir, yao_str)
-    tp_yao_bob_dir = create_path(tp_yao_dir, bob_str)
-    expected_deal_facts_path = create_path(tp_yao_bob_dir, CELL_BUDEVENT_FACTS_FILENAME)
-    assert gen_deal_facts_path == expected_deal_facts_path
 
 
 def test_create_cell_found_facts_path_ReturnObj_Scenario0_Three_deal_ancestors():

--- a/src/f05_listen/test_hubunit/test_hub_path_.py
+++ b/src/f05_listen/test_hubunit/test_hub_path_.py
@@ -13,7 +13,6 @@ from src.f05_listen.hub_path import (
     DEALUNIT_FILENAME,
     CELLNODE_FILENAME,
     CELL_QUOTA_LEDGER_FILENAME,
-    CELL_FOUND_FACTS_FILENAME,
     BUDPOINT_FILENAME,
     BUDEVENT_FILENAME,
     EVENT_ALL_GIFT_FILENAME,
@@ -30,7 +29,6 @@ from src.f05_listen.hub_path import (
     create_cell_dir_path,
     create_cell_node_json_path,
     create_cell_quota_ledger_path,
-    create_cell_found_facts_path,
     create_owner_event_dir_path,
     create_budevent_path,
     create_event_all_gift_path,
@@ -49,7 +47,6 @@ def test_hub_path_constants_are_values():
     assert FISC_AGENDA_FULL_LISTING_FILENAME == "agenda_full_listing.csv"
     assert DEALUNIT_FILENAME == "dealunit.json"
     assert CELLNODE_FILENAME == "cell_node.json"
-    assert CELL_FOUND_FACTS_FILENAME == "found_facts.json"
     assert CELL_QUOTA_LEDGER_FILENAME == "quota_ledger.json"
     assert BUDPOINT_FILENAME == "budpoint.json"
     assert BUDEVENT_FILENAME == "bud.json"
@@ -350,29 +347,6 @@ def test_create_cell_quota_ledger_path_ReturnObj_Scenario1_Three_deal_ancestors(
         tp_yao_bob_dir, CELL_QUOTA_LEDGER_FILENAME
     )
     assert gen_deal_quota_ledger_path == expected_deal_quota_ledger_path
-
-
-def test_create_cell_found_facts_path_ReturnObj_Scenario0_Three_deal_ancestors():
-    # ESTABLISH
-    x_fisc_mstr_dir = get_listen_temp_env_dir()
-    a23_str = "accord23"
-    sue_str = "Sue"
-    tp7 = 7
-    yao_str = "Yao"
-    bob_str = "Bob"
-    deal_ancestors = [yao_str, bob_str]
-
-    # WHEN
-    gen_deal_facts_path = create_cell_found_facts_path(
-        x_fisc_mstr_dir, a23_str, sue_str, tp7, deal_ancestors=deal_ancestors
-    )
-
-    # THEN
-    timepoint_dir = create_deal_dir_path(x_fisc_mstr_dir, a23_str, sue_str, tp7)
-    tp_yao_dir = create_path(timepoint_dir, yao_str)
-    tp_yao_bob_dir = create_path(tp_yao_dir, bob_str)
-    expected_deal_facts_path = create_path(tp_yao_bob_dir, CELL_FOUND_FACTS_FILENAME)
-    assert gen_deal_facts_path == expected_deal_facts_path
 
 
 def test_create_owner_event_dir_path_ReturnObj():

--- a/src/f05_listen/test_hubunit/test_hub_path_doc.py
+++ b/src/f05_listen/test_hubunit/test_hub_path_doc.py
@@ -11,7 +11,7 @@ from src.f05_listen.hub_path import (
     create_dealunit_json_path,
     create_budpoint_path,
     create_cell_dir_path,
-    create_cell_node_json_path,
+    create_cell_json_path,
     create_owner_event_dir_path,
     create_budevent_path,
     create_event_all_gift_path,
@@ -117,9 +117,9 @@ def test_create_cell_dir_path_HasDocString():
     assert LINUX_OS or inspect_getdoc(create_cell_dir_path) == doc_str
 
 
-def test_create_cell_node_json_path_HasDocString():
+def test_create_cell_json_path_HasDocString():
     # ESTABLISH
-    doc_str = create_cell_node_json_path(
+    doc_str = create_cell_json_path(
         fisc_mstr_dir="fisc_mstr_dir",
         fisc_title=fisc_title_str(),
         owner_name=owner_name_str(),
@@ -130,7 +130,7 @@ def test_create_cell_node_json_path_HasDocString():
     doc_str = f"Returns path: {doc_str}"
     print(f"{doc_str=}")
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_cell_node_json_path) == doc_str
+    assert LINUX_OS or inspect_getdoc(create_cell_json_path) == doc_str
 
 
 def test_create_dealunit_json_path_HasDocString():

--- a/src/f05_listen/test_hubunit/test_hub_path_doc.py
+++ b/src/f05_listen/test_hubunit/test_hub_path_doc.py
@@ -12,7 +12,6 @@ from src.f05_listen.hub_path import (
     create_budpoint_path,
     create_cell_dir_path,
     create_cell_node_json_path,
-    create_cell_quota_ledger_path,
     create_owner_event_dir_path,
     create_budevent_path,
     create_event_all_gift_path,
@@ -132,22 +131,6 @@ def test_create_cell_node_json_path_HasDocString():
     print(f"{doc_str=}")
     # WHEN / THEN
     assert LINUX_OS or inspect_getdoc(create_cell_node_json_path) == doc_str
-
-
-def test_create_cell_quota_ledger_path_HasDocString():
-    # ESTABLISH
-    doc_str = create_cell_quota_ledger_path(
-        fisc_mstr_dir="fisc_mstr_dir",
-        fisc_title=fisc_title_str(),
-        owner_name=owner_name_str(),
-        time_int=time_int_str(),
-        deal_ancestors=["ledger_owner1", "ledger_owner2", "ledger_owner3"],
-    )
-    doc_str = doc_str.replace("deals\\time_int", "deals\n\\time_int")
-    doc_str = f"Returns path: {doc_str}"
-    print(f"{doc_str=}")
-    # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_cell_quota_ledger_path) == doc_str
 
 
 def test_create_dealunit_json_path_HasDocString():

--- a/src/f05_listen/test_hubunit/test_hub_path_doc.py
+++ b/src/f05_listen/test_hubunit/test_hub_path_doc.py
@@ -13,7 +13,6 @@ from src.f05_listen.hub_path import (
     create_cell_dir_path,
     create_cell_node_json_path,
     create_cell_quota_ledger_path,
-    create_cell_found_facts_path,
     create_owner_event_dir_path,
     create_budevent_path,
     create_event_all_gift_path,
@@ -149,22 +148,6 @@ def test_create_cell_quota_ledger_path_HasDocString():
     print(f"{doc_str=}")
     # WHEN / THEN
     assert LINUX_OS or inspect_getdoc(create_cell_quota_ledger_path) == doc_str
-
-
-def test_create_cell_found_facts_path_HasDocString():
-    # ESTABLISH
-    doc_str = create_cell_found_facts_path(
-        fisc_mstr_dir="fisc_mstr_dir",
-        fisc_title=fisc_title_str(),
-        owner_name=owner_name_str(),
-        time_int=time_int_str(),
-        deal_ancestors=["ledger_owner1", "ledger_owner2", "ledger_owner3"],
-    )
-    doc_str = doc_str.replace("deals\\time_int", "deals\n\\time_int")
-    doc_str = f"Returns path: {doc_str}"
-    print(f"{doc_str=}")
-    # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_cell_found_facts_path) == doc_str
 
 
 def test_create_dealunit_json_path_HasDocString():

--- a/src/f05_listen/test_hubunit/test_hub_path_doc.py
+++ b/src/f05_listen/test_hubunit/test_hub_path_doc.py
@@ -13,7 +13,6 @@ from src.f05_listen.hub_path import (
     create_cell_dir_path,
     create_cell_node_json_path,
     create_cell_quota_ledger_path,
-    create_cell_budevent_facts_path,
     create_cell_found_facts_path,
     create_owner_event_dir_path,
     create_budevent_path,
@@ -150,22 +149,6 @@ def test_create_cell_quota_ledger_path_HasDocString():
     print(f"{doc_str=}")
     # WHEN / THEN
     assert LINUX_OS or inspect_getdoc(create_cell_quota_ledger_path) == doc_str
-
-
-def test_create_cell_budevent_facts_path_HasDocString():
-    # ESTABLISH
-    doc_str = create_cell_budevent_facts_path(
-        fisc_mstr_dir="fisc_mstr_dir",
-        fisc_title=fisc_title_str(),
-        owner_name=owner_name_str(),
-        time_int=time_int_str(),
-        deal_ancestors=["ledger_owner1", "ledger_owner2", "ledger_owner3"],
-    )
-    doc_str = doc_str.replace("deals\\time_int", "deals\n\\time_int")
-    doc_str = f"Returns path: {doc_str}"
-    print(f"{doc_str=}")
-    # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_cell_budevent_facts_path) == doc_str
 
 
 def test_create_cell_found_facts_path_HasDocString():

--- a/src/f05_listen/test_hubunit/test_hub_tool.py
+++ b/src/f05_listen/test_hubunit/test_hub_tool.py
@@ -24,7 +24,6 @@ from src.f05_listen.hub_tool import (
     save_bud_file,
     open_bud_file,
     get_timepoint_credit_ledger,
-    get_budevents_credit_ledger,
     get_owners_downhill_event_ints,
     collect_owner_event_dir_sets,
     get_budevent_obj,
@@ -202,46 +201,6 @@ def test_get_budevent_obj_ReturnsObj_Scenario1_FileExists(env_dir_setup_cleanup)
 
     # THEN
     assert gen_a3_budevent == sue_bud
-
-
-def test_get_budevents_credit_ledger_ReturnsObj_Scenario0_NoFile(
-    env_dir_setup_cleanup,
-):
-    # ESTABLISH
-    fisc_mstr_dir = get_listen_temp_env_dir()
-    a23_str = "accord"
-    sue_str = "Sue"
-    t3 = 3
-
-    # WHEN
-    gen_a3_credit_ledger = get_budevents_credit_ledger(
-        fisc_mstr_dir, a23_str, sue_str, t3
-    )
-
-    # THEN
-    assert gen_a3_credit_ledger == {}
-
-
-def test_get_budevents_credit_ledger_ReturnsObj_Scenario1_FileExists(
-    env_dir_setup_cleanup,
-):
-    # ESTABLISH
-    fisc_mstr_dir = get_listen_temp_env_dir()
-    a23_str = "accord"
-    sue_str = "Sue"
-    t3 = 3
-    t3_json_path = create_budevent_path(fisc_mstr_dir, a23_str, sue_str, t3)
-    a3_bud = get_budunit_3_acct()
-    save_bud_file(t3_json_path, None, a3_bud)
-
-    # WHEN
-    gen_a3_credit_ledger = get_budevents_credit_ledger(
-        fisc_mstr_dir, a23_str, sue_str, t3
-    )
-
-    # THEN
-    expected_a3_credit_ledger = {sue_str: 5, "Yao": 2, "Zia": 33}
-    assert gen_a3_credit_ledger == expected_a3_credit_ledger
 
 
 def test_get_budevent_facts_ReturnsObj_Scenario0_NoFile(env_dir_setup_cleanup):

--- a/src/f05_listen/test_hubunit/test_hub_tool.py
+++ b/src/f05_listen/test_hubunit/test_hub_tool.py
@@ -2,7 +2,7 @@ from src.f00_instrument.file import create_path, set_dir, open_json
 from src.f01_road.road import create_road
 from src.f02_bud.bud import budunit_shop
 from src.f04_gift.atom_config import base_str
-from src.f05_listen.cell import CELL_NODE_QUOTA_DEFAULT, cellunit_shop
+from src.f05_listen.cell import CELLNODE_QUOTA_DEFAULT, cellunit_shop
 from src.f05_listen.hub_path import (
     create_fisc_json_path,
     create_fisc_ote1_csv_path,
@@ -11,7 +11,7 @@ from src.f05_listen.hub_path import (
     create_owners_dir_path,
     create_deals_dir_path,
     create_cell_dir_path,
-    create_cell_node_json_path as node_path,
+    create_cell_json_path as node_path,
     create_deal_dir_path,
     create_budpoint_path,
     create_owner_event_dir_path,
@@ -382,13 +382,13 @@ def test_cellunit_add_json_file_SetsFile_Scenario0(env_dir_setup_cleanup):
     a23_str = "accord23"
     time7 = 777000
     sue_str = "Sue"
-    sue7_cellnode_path = node_path(fisc_mstr_dir, a23_str, sue_str, time7)
+    sue7_cell_path = node_path(fisc_mstr_dir, a23_str, sue_str, time7)
     event3 = 3
     das = []
     quota500 = 500
     celldepth4 = 4
     penny6 = 6
-    assert os_path_exists(sue7_cellnode_path) is False
+    assert os_path_exists(sue7_cell_path) is False
 
     # WHEN
     cellunit_add_json_file(
@@ -404,9 +404,9 @@ def test_cellunit_add_json_file_SetsFile_Scenario0(env_dir_setup_cleanup):
     )
 
     # THEN
-    print(f"{sue7_cellnode_path=}")
-    assert os_path_exists(sue7_cellnode_path)
-    generated_cell_dict = open_json(sue7_cellnode_path)
+    print(f"{sue7_cell_path=}")
+    assert os_path_exists(sue7_cell_path)
+    generated_cell_dict = open_json(sue7_cell_path)
     assert generated_cell_dict.get("ancestors") == das
     assert generated_cell_dict.get("event_int") == event3
     assert generated_cell_dict.get("celldepth") == celldepth4
@@ -425,9 +425,9 @@ def test_cellunit_add_json_file_SetsFile_Scenario1_ManyParametersEmpty(
     sue_str = "Sue"
     bob_str = "Bob"
     das = [bob_str, sue_str]
-    sue7_cellnode_path = node_path(fisc_mstr_dir, a23_str, sue_str, time7, das)
+    sue7_cell_path = node_path(fisc_mstr_dir, a23_str, sue_str, time7, das)
     event3 = 3
-    assert os_path_exists(sue7_cellnode_path) is False
+    assert os_path_exists(sue7_cell_path) is False
 
     # WHEN
     cellunit_add_json_file(
@@ -435,15 +435,15 @@ def test_cellunit_add_json_file_SetsFile_Scenario1_ManyParametersEmpty(
     )
 
     # THEN
-    print(f"{sue7_cellnode_path=}")
-    assert os_path_exists(sue7_cellnode_path)
-    generated_cell_dict = open_json(sue7_cellnode_path)
+    print(f"{sue7_cell_path=}")
+    assert os_path_exists(sue7_cell_path)
+    generated_cell_dict = open_json(sue7_cell_path)
     assert generated_cell_dict.get("ancestors") == das
     assert generated_cell_dict.get("event_int") == event3
     assert generated_cell_dict.get("celldepth") == 0
     assert generated_cell_dict.get("deal_owner_name") == sue_str
     assert generated_cell_dict.get("penny") == 1
-    assert generated_cell_dict.get("quota") == CELL_NODE_QUOTA_DEFAULT
+    assert generated_cell_dict.get("quota") == CELLNODE_QUOTA_DEFAULT
 
 
 def test_cellunit_get_from_dir_ReturnsObj_Scenario1_FileExists(env_dir_setup_cleanup):
@@ -454,9 +454,9 @@ def test_cellunit_get_from_dir_ReturnsObj_Scenario1_FileExists(env_dir_setup_cle
     sue_str = "Sue"
     bob_str = "Bob"
     das = [bob_str, sue_str]
-    sue7_cellnode_path = node_path(fisc_mstr_dir, a23_str, sue_str, time7, das)
+    sue7_cell_path = node_path(fisc_mstr_dir, a23_str, sue_str, time7, das)
     event3 = 3
-    assert os_path_exists(sue7_cellnode_path) is False
+    assert os_path_exists(sue7_cell_path) is False
     cellunit_add_json_file(
         fisc_mstr_dir, a23_str, sue_str, time7, event3, deal_ancestors=das
     )
@@ -480,15 +480,15 @@ def test_cellunit_save_to_dir_ReturnsObj_Scenario0(env_dir_setup_cleanup):
     sue_str = "Sue"
     bob_str = "Bob"
     das = [bob_str, sue_str]
-    sue7_cellnode_path = node_path(fisc_mstr_dir, a23_str, sue_str, time7, das)
+    sue7_cell_path = node_path(fisc_mstr_dir, a23_str, sue_str, time7, das)
     event3 = 3
     sue_cell = cellunit_shop(sue_str, ancestors=das, event_int=event3)
     cell_dir = create_cell_dir_path(fisc_mstr_dir, a23_str, sue_str, time7, das)
-    assert os_path_exists(sue7_cellnode_path) is False
+    assert os_path_exists(sue7_cell_path) is False
 
     # WHEN
     cellunit_save_to_dir(cell_dir, sue_cell)
 
     # THEN
-    assert os_path_exists(sue7_cellnode_path)
+    assert os_path_exists(sue7_cell_path)
     assert cellunit_get_from_dir(cell_dir) == sue_cell

--- a/src/f07_fisc/fisc_tool.py
+++ b/src/f07_fisc/fisc_tool.py
@@ -9,7 +9,6 @@ from src.f05_listen.cell import (
 )
 from src.f05_listen.hub_path import (
     CELLNODE_FILENAME,
-    CELL_BUDEVENT_FACTS_FILENAME,
     CELL_FOUND_FACTS_FILENAME,
     CELL_QUOTA_LEDGER_FILENAME,
     create_cell_node_json_path,
@@ -136,7 +135,7 @@ def uphill_cell_node_budevent_facts(fisc_mstr_dir: str, fisc_title: TitleUnit):
             budevent_facts_dirs = [
                 dirpath
                 for dirpath, dirnames, filenames in os_walk(deal_time_dir)
-                if CELL_BUDEVENT_FACTS_FILENAME in set(filenames)
+                if CELLNODE_FILENAME in set(filenames)
             ]
             quota_ledger_dirs = [
                 dirpath
@@ -151,11 +150,10 @@ def _create_found_facts(
 ):
     nodes_facts_dict = {}
     for dirpath in budevent_facts_dirs:
-        budevent_facts_path = create_path(dirpath, CELL_BUDEVENT_FACTS_FILENAME)
-        budevent_facts_dict = factunits_get_from_dict(open_json(budevent_facts_path))
+        x_cell = cellunit_get_from_dir(dirpath)
         deal_path = dirpath.replace(deal_time_dir, "")
         cell_owners_tuple = tuple(deal_path.split(os_sep)[1:])
-        nodes_facts_dict[cell_owners_tuple] = budevent_facts_dict
+        nodes_facts_dict[cell_owners_tuple] = x_cell.budevent_facts
 
     nodes_quotas_dict = {}
     for dirpath in quota_ledger_dirs:

--- a/src/f07_fisc/fisc_tool.py
+++ b/src/f07_fisc/fisc_tool.py
@@ -9,11 +9,9 @@ from src.f05_listen.cell import (
 )
 from src.f05_listen.hub_path import (
     CELLNODE_FILENAME,
-    CELL_FOUND_FACTS_FILENAME,
     CELL_QUOTA_LEDGER_FILENAME,
     create_cell_node_json_path,
     create_budevent_path,
-    create_cell_found_facts_path,
     create_cell_quota_ledger_path,
 )
 from src.f05_listen.hub_tool import (
@@ -169,7 +167,9 @@ def _create_found_facts(
         for node_addr, facts in nodes_wgt_facts.items()
     }
     for output_dir, output_facts_dict in output_dir_facts.items():
-        save_json(output_dir, CELL_FOUND_FACTS_FILENAME, output_facts_dict)
+        output_cell = cellunit_get_from_dir(output_dir)
+        output_cell.set_found_facts_from_dict(output_facts_dict)
+        cellunit_save_to_dir(output_dir, output_cell)
 
 
 def modify_deal_trees_create_boss_facts(fisc_mstr_dir: str, fisc_title: str):
@@ -193,8 +193,6 @@ def modify_deal_tree_create_boss_facts(
     cell_event_int = root_cell.event_int
     budevent = get_budevent_obj(fisc_mstr_dir, fisc_title, owner_name, cell_event_int)
     root_cell.load_budevent(budevent)
-    found_facts_path = create_path(deal_time_dir, CELL_FOUND_FACTS_FILENAME)
-    root_cell.set_found_facts_from_dict(open_json(found_facts_path))
     root_cell.set_boss_facts_from_other_facts()
     to_evaluate_cells = [root_cell]
     while to_evaluate_cells != []:

--- a/src/f07_fisc/fisc_tool.py
+++ b/src/f07_fisc/fisc_tool.py
@@ -14,7 +14,6 @@ from src.f05_listen.hub_path import (
     CELL_QUOTA_LEDGER_FILENAME,
     create_cell_node_json_path,
     create_budevent_path,
-    create_cell_budevent_facts_path,
     create_cell_found_facts_path,
     create_cell_quota_ledger_path,
 )
@@ -22,7 +21,6 @@ from src.f05_listen.hub_tool import (
     get_budevent_obj,
     get_budevent_facts,
     collect_owner_event_dir_sets,
-    get_budevents_credit_ledger,
     get_owners_downhill_event_ints,
     cellunit_get_from_json,
 )

--- a/src/f07_fisc/test_fisc_tool/test_deal_budadjusts.py
+++ b/src/f07_fisc/test_fisc_tool/test_deal_budadjusts.py
@@ -3,10 +3,7 @@ from src.f02_bud.group import awardlink_shop
 from src.f02_bud.bud import budunit_shop, BudUnit
 from src.f02_bud.bud_tool import get_acct_agenda_net_ledger
 from src.f04_gift.atom_config import base_str
-from src.f05_listen.hub_path import (
-    create_budevent_path,
-    create_cell_found_facts_path as found_facts_path,
-)
+from src.f05_listen.hub_path import create_budevent_path
 from src.f05_listen.hub_tool import cellunit_add_json_file, open_bud_file
 from src.f07_fisc.fisc_tool import modify_deal_trees_create_boss_facts
 from src.f07_fisc.examples.fisc_env import env_dir_setup_cleanup, get_test_fisc_mstr_dir
@@ -119,7 +116,6 @@ def get_yao_run_rain_fact_budunit_example() -> BudUnit:
 #     save_file(bob7_budevent_path, None, mop_budunit.get_json())
 #     # create found_facts files
 #     bob5_found_facts = {}
-#     bob5_found = found_facts_path(mstr_dir, a23_str, bob_str, tp5, das)
 #     save_json(bob5_found, None, bob5_found_facts)
 #     # create paths for budadjusts
 #     bob5_adjust_path = budadjust_path(mstr_dir, a23_str, bob_str, tp5, das)
@@ -162,7 +158,6 @@ def get_yao_run_rain_fact_budunit_example() -> BudUnit:
 #     save_file(bob7_budevent_path, None, mop_budunit.get_json())
 #     # create found_facts files
 #     bob5_found_facts = {}
-#     bob5_found = found_facts_path(mstr_dir, a23_str, bob_str, tp5, das)
 #     save_json(bob5_found, None, bob5_found_facts)
 #     # create paths for budadjusts
 #     bob5_adjust_path = budadjust_path(mstr_dir, a23_str, bob_str, tp5, das)
@@ -205,8 +200,6 @@ def get_yao_run_rain_fact_budunit_example() -> BudUnit:
 #     # create found_facts files
 #     bob5_found_facts = {}
 #     bob5_yao_found_facts = {}
-#     bob5_found = found_facts_path(mstr_dir, a23_str, bob_str, tp5, das)
-#     bob5_yao_found = found_facts_path(mstr_dir, a23_str, bob_str, tp5, das_yao)
 #     save_json(bob5_found, None, bob5_found_facts)
 #     save_json(bob5_yao_found, None, bob5_yao_found_facts)
 #     # create paths for budadjusts, acct_agenda_adjust_ledgers
@@ -260,8 +253,6 @@ def get_yao_run_rain_fact_budunit_example() -> BudUnit:
 #     snow_road = yao_run_budunit.make_road(weather_road, "snowing")
 #     bob5_found_facts = {floor_road: {base_str(): floor_road, "pick": dirty_road}}
 #     bob5_yao_found_facts = {weather_road: {base_str(): weather_road, "pick": snow_road}}
-#     bob5_found = found_facts_path(mstr_dir, a23_str, bob_str, tp5, das)
-#     bob5_yao_found_path = found_facts_path(mstr_dir, a23_str, bob_str, tp5, das_yao)
 #     print(f"{bob5_yao_found_path=}")
 #     save_json(bob5_found, None, bob5_found_facts)
 #     save_json(bob5_yao_found_path, None, bob5_yao_found_facts)
@@ -354,8 +345,6 @@ def get_yao_run_rain_fact_budunit_example() -> BudUnit:
 #     snow_road = yao_run_budunit.make_road(weather_road, "snowing")
 #     bob5_found_facts = {floor_road: {base_str(): floor_road, "pick": dirty_road}}
 #     bob5_yao_found_facts = {weather_road: {base_str(): weather_road, "pick": snow_road}}
-#     bob5_found = found_facts_path(mstr_dir, a23_str, bob_str, tp5, das)
-#     bob5_yao_found_path = found_facts_path(mstr_dir, a23_str, bob_str, tp5, das_yao)
 #     print(f"{bob5_yao_found_path=}")
 #     save_json(bob5_found, None, bob5_found_facts)
 #     save_json(bob5_yao_found_path, None, bob5_yao_found_facts)

--- a/src/f07_fisc/test_fisc_tool/test_deal_budadjusts.py
+++ b/src/f07_fisc/test_fisc_tool/test_deal_budadjusts.py
@@ -7,7 +7,7 @@ from src.f05_listen.hub_path import (
     create_budevent_path,
     create_cell_found_facts_path as found_facts_path,
 )
-from src.f05_listen.hub_tool import save_cell_node_file, open_bud_file
+from src.f05_listen.hub_tool import cellunit_add_json_file, open_bud_file
 from src.f07_fisc.fisc_tool import modify_deal_trees_create_boss_facts
 from src.f07_fisc.examples.fisc_env import env_dir_setup_cleanup, get_test_fisc_mstr_dir
 from os.path import exists as os_path_exists
@@ -112,7 +112,7 @@ def get_yao_run_rain_fact_budunit_example() -> BudUnit:
 #     q3 = 3
 #     cd0 = 0
 #     # create cell_node files
-#     save_cell_node_file(mstr_dir, a23_str, bob_str, tp5, event7, das, q3, cd0)
+#     cellunit_add_json_file(mstr_dir, a23_str, bob_str, tp5, event7, das, q3, cd0)
 #     # create budevent files
 #     mop_budunit = get_bob_mop_without_reason_budunit_example()
 #     bob7_budevent_path = create_budevent_path(mstr_dir, a23_str, bob_str, event7)
@@ -155,7 +155,7 @@ def get_yao_run_rain_fact_budunit_example() -> BudUnit:
 #     das = []
 #     event7 = 7
 #     # create cell_node files
-#     save_cell_node_file(mstr_dir, a23_str, bob_str, tp5, event7, das)
+#     cellunit_add_json_file(mstr_dir, a23_str, bob_str, tp5, event7, das)
 #     # create budevent files
 #     mop_budunit = get_bob_mop_without_reason_budunit_example()
 #     bob7_budevent_path = create_budevent_path(mstr_dir, a23_str, bob_str, event7)
@@ -193,8 +193,8 @@ def get_yao_run_rain_fact_budunit_example() -> BudUnit:
 #     das_yao = [yao_str]
 #     event7 = 7
 #     # create cell_node files
-#     save_cell_node_file(mstr_dir, a23_str, bob_str, tp5, event7, das)
-#     save_cell_node_file(mstr_dir, a23_str, bob_str, tp5, event7, das_yao)
+#     cellunit_add_json_file(mstr_dir, a23_str, bob_str, tp5, event7, das)
+#     cellunit_add_json_file(mstr_dir, a23_str, bob_str, tp5, event7, das_yao)
 #     # create budevent files
 #     mop_budunit = get_bob_mop_with_reason_budunit_example()
 #     sport_budunit = get_yao_run_with_reason_budunit_example()
@@ -243,8 +243,8 @@ def get_yao_run_rain_fact_budunit_example() -> BudUnit:
 #     das_yao = [yao_str]
 #     event7 = 7
 #     # create cell_node files
-#     save_cell_node_file(mstr_dir, a23_str, bob_str, tp5, event7, das)
-#     save_cell_node_file(mstr_dir, a23_str, bob_str, tp5, event7, das_yao)
+#     cellunit_add_json_file(mstr_dir, a23_str, bob_str, tp5, event7, das)
+#     cellunit_add_json_file(mstr_dir, a23_str, bob_str, tp5, event7, das_yao)
 #     # create budevent files
 #     bob_mop_budunit = get_bob_mop_fact_clean_budunit_example()
 #     yao_run_budunit = get_yao_run_rain_fact_budunit_example()
@@ -340,8 +340,8 @@ def get_yao_run_rain_fact_budunit_example() -> BudUnit:
 #     quota700 = 70088
 #     quota900 = 900
 #     # create cell_node files
-#     save_cell_node_file(mstr_dir, a23_str, bob_str, tp5, event7, das, quota700)
-#     save_cell_node_file(mstr_dir, a23_str, bob_str, tp5, event7, das_yao, quota900)
+#     cellunit_add_json_file(mstr_dir, a23_str, bob_str, tp5, event7, das, quota700)
+#     cellunit_add_json_file(mstr_dir, a23_str, bob_str, tp5, event7, das_yao, quota900)
 #     # create budevent files
 #     bob_mop_budunit
 #     yao_run_budunit = get_yao_run_rain_fact_budunit_example()

--- a/src/f07_fisc/test_fisc_tool/test_deal_budadjusts.py
+++ b/src/f07_fisc/test_fisc_tool/test_deal_budadjusts.py
@@ -93,7 +93,7 @@ def get_yao_run_rain_fact_budunit_example() -> BudUnit:
     return yao_bud
 
 
-# # create a world with, cell_node.json, found facts and bud events
+# # create a world with, cell.json, found facts and bud events
 # # for every found_fact change budevent to that fact
 # # create agenda (different than if found_fact was not applied)
 # def test_modify_deal_tree_create_boss_facts_Scenario0_SetsFilesRootBossFactsCreatedWithBudEventFactsOnly(
@@ -108,7 +108,7 @@ def get_yao_run_rain_fact_budunit_example() -> BudUnit:
 #     event7 = 7
 #     q3 = 3
 #     cd0 = 0
-#     # create cell_node files
+#     # create cell files
 #     cellunit_add_json_file(mstr_dir, a23_str, bob_str, tp5, event7, das, q3, cd0)
 #     # create budevent files
 #     mop_budunit = get_bob_mop_without_reason_budunit_example()
@@ -150,7 +150,7 @@ def get_yao_run_rain_fact_budunit_example() -> BudUnit:
 #     bob_str = "Bob"
 #     das = []
 #     event7 = 7
-#     # create cell_node files
+#     # create cell files
 #     cellunit_add_json_file(mstr_dir, a23_str, bob_str, tp5, event7, das)
 #     # create budevent files
 #     mop_budunit = get_bob_mop_without_reason_budunit_example()
@@ -187,7 +187,7 @@ def get_yao_run_rain_fact_budunit_example() -> BudUnit:
 #     das = []
 #     das_yao = [yao_str]
 #     event7 = 7
-#     # create cell_node files
+#     # create cell files
 #     cellunit_add_json_file(mstr_dir, a23_str, bob_str, tp5, event7, das)
 #     cellunit_add_json_file(mstr_dir, a23_str, bob_str, tp5, event7, das_yao)
 #     # create budevent files
@@ -235,7 +235,7 @@ def get_yao_run_rain_fact_budunit_example() -> BudUnit:
 #     das = []
 #     das_yao = [yao_str]
 #     event7 = 7
-#     # create cell_node files
+#     # create cell files
 #     cellunit_add_json_file(mstr_dir, a23_str, bob_str, tp5, event7, das)
 #     cellunit_add_json_file(mstr_dir, a23_str, bob_str, tp5, event7, das_yao)
 #     # create budevent files
@@ -330,7 +330,7 @@ def get_yao_run_rain_fact_budunit_example() -> BudUnit:
 #     event7 = 7
 #     quota700 = 70088
 #     quota900 = 900
-#     # create cell_node files
+#     # create cell files
 #     cellunit_add_json_file(mstr_dir, a23_str, bob_str, tp5, event7, das, quota700)
 #     cellunit_add_json_file(mstr_dir, a23_str, bob_str, tp5, event7, das_yao, quota900)
 #     # create budevent files

--- a/src/f07_fisc/test_fisc_tool/test_deal_budevent_facts.py
+++ b/src/f07_fisc/test_fisc_tool/test_deal_budevent_facts.py
@@ -3,7 +3,6 @@ from src.f01_road.road import create_road
 from src.f04_gift.atom_config import base_str
 from src.f05_listen.hub_path import (
     create_cell_node_json_path,
-    create_cell_budevent_facts_path as bude_facts_path,
     create_budevent_path,
 )
 from src.f05_listen.hub_tool import (

--- a/src/f07_fisc/test_fisc_tool/test_deal_budevent_facts.py
+++ b/src/f07_fisc/test_fisc_tool/test_deal_budevent_facts.py
@@ -2,7 +2,7 @@ from src.f00_instrument.file import open_json
 from src.f01_road.road import create_road
 from src.f04_gift.atom_config import base_str
 from src.f05_listen.hub_path import (
-    create_cell_node_json_path,
+    create_cell_json_path,
     create_budevent_path,
 )
 from src.f05_listen.hub_tool import (
@@ -11,13 +11,13 @@ from src.f05_listen.hub_tool import (
     cellunit_get_from_dir,
     cellunit_save_to_dir,
 )
-from src.f07_fisc.fisc_tool import create_all_cell_node_facts_files
+from src.f07_fisc.fisc_tool import load_cells_budevent
 from src.f07_fisc.examples.example_fiscs import example_casa_clean_factunit
 from src.f07_fisc.examples.fisc_env import env_dir_setup_cleanup, get_test_fisc_mstr_dir
 from os.path import exists as os_path_exists
 
 
-def test_create_all_cell_node_facts_files_SetsFiles_Scenario0_NoFacts(
+def test_load_cells_budevent_SetsFiles_Scenario0_NoFacts(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -30,18 +30,18 @@ def test_create_all_cell_node_facts_files_SetsFiles_Scenario0_NoFacts(
     bob3_budevent_path = create_budevent_path(fisc_mstr_dir, a23_str, bob_str, event300)
     print(f"{bob3_budevent_path=}")
     cellunit_add_json_file(fisc_mstr_dir, a23_str, bob_str, time5, event300, [])
-    bob5_cell_path = create_cell_node_json_path(fisc_mstr_dir, a23_str, bob_str, time5)
+    bob5_cell_path = create_cell_json_path(fisc_mstr_dir, a23_str, bob_str, time5)
     assert open_json(bob5_cell_path).get("budevent_facts") == {}
 
     # WHEN
-    create_all_cell_node_facts_files(fisc_mstr_dir, a23_str)
+    load_cells_budevent(fisc_mstr_dir, a23_str)
 
     # THEN
     assert os_path_exists(bob5_cell_path)
     assert open_json(bob5_cell_path).get("budevent_facts") == {}
 
 
-def test_create_all_cell_node_facts_files_SetsFiles_Scenario1_WithFacts(
+def test_load_cells_budevent_SetsFiles_Scenario1_WithFacts(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -56,18 +56,18 @@ def test_create_all_cell_node_facts_files_SetsFiles_Scenario1_WithFacts(
     bob3_budevent_path = create_budevent_path(fisc_mstr_dir, a23_str, bob_str, event300)
     print(f"{bob3_budevent_path=}")
     cellunit_add_json_file(fisc_mstr_dir, a23_str, bob_str, time5, event300, [])
-    bob5_cell_path = create_cell_node_json_path(fisc_mstr_dir, a23_str, bob_str, time5)
+    bob5_cell_path = create_cell_json_path(fisc_mstr_dir, a23_str, bob_str, time5)
     assert open_json(bob5_cell_path).get("budevent_facts") == {}
 
     # WHEN
-    create_all_cell_node_facts_files(fisc_mstr_dir, a23_str)
+    load_cells_budevent(fisc_mstr_dir, a23_str)
 
     # THEN
     expected_budevent_facts = {clean_fact.base: clean_fact.get_dict()}
     assert open_json(bob5_cell_path).get("budevent_facts") == expected_budevent_facts
 
 
-def test_create_all_cell_node_facts_files_SetsFiles_Scenario2_WithFacts_NotAtRoot(
+def test_load_cells_budevent_SetsFiles_Scenario2_WithFacts_NotAtRoot(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -82,13 +82,11 @@ def test_create_all_cell_node_facts_files_SetsFiles_Scenario2_WithFacts_NotAtRoo
     yao_str = "Yao"
     das = [yao_str, bob_str]
     cellunit_add_json_file(fisc_mstr_dir, a23_str, bob_str, time5, event300, das)
-    bob5_cell_path = create_cell_node_json_path(
-        fisc_mstr_dir, a23_str, bob_str, time5, das
-    )
+    bob5_cell_path = create_cell_json_path(fisc_mstr_dir, a23_str, bob_str, time5, das)
     assert open_json(bob5_cell_path).get("budevent_facts") == {}
 
     # WHEN
-    create_all_cell_node_facts_files(fisc_mstr_dir, a23_str)
+    load_cells_budevent(fisc_mstr_dir, a23_str)
 
     # THEN
     expected_budevent_facts = {clean_fact.base: clean_fact.get_dict()}

--- a/src/f07_fisc/test_fisc_tool/test_deal_budevent_facts.py
+++ b/src/f07_fisc/test_fisc_tool/test_deal_budevent_facts.py
@@ -2,10 +2,16 @@ from src.f00_instrument.file import open_json
 from src.f01_road.road import create_road
 from src.f04_gift.atom_config import base_str
 from src.f05_listen.hub_path import (
+    create_cell_node_json_path,
     create_cell_budevent_facts_path as bude_facts_path,
     create_budevent_path,
 )
-from src.f05_listen.hub_tool import save_arbitrary_budevent, save_cell_node_file
+from src.f05_listen.hub_tool import (
+    save_arbitrary_budevent,
+    cellunit_add_json_file,
+    cellunit_get_from_dir,
+    cellunit_save_to_dir,
+)
 from src.f07_fisc.fisc_tool import create_all_cell_node_facts_files
 from src.f07_fisc.examples.example_fiscs import example_casa_clean_factunit
 from src.f07_fisc.examples.fisc_env import env_dir_setup_cleanup, get_test_fisc_mstr_dir
@@ -24,17 +30,16 @@ def test_create_all_cell_node_facts_files_SetsFiles_Scenario0_NoFacts(
     save_arbitrary_budevent(fisc_mstr_dir, a23_str, bob_str, event300)
     bob3_budevent_path = create_budevent_path(fisc_mstr_dir, a23_str, bob_str, event300)
     print(f"{bob3_budevent_path=}")
-    save_cell_node_file(fisc_mstr_dir, a23_str, bob_str, time5, event300, [])
-    bob_t5_facts_path = bude_facts_path(fisc_mstr_dir, a23_str, bob_str, time5)
-    # print(f" {bob_t5_facts_path=}")
-    assert os_path_exists(bob_t5_facts_path) is False
+    cellunit_add_json_file(fisc_mstr_dir, a23_str, bob_str, time5, event300, [])
+    bob5_cell_path = create_cell_node_json_path(fisc_mstr_dir, a23_str, bob_str, time5)
+    assert open_json(bob5_cell_path).get("budevent_facts") == {}
 
     # WHEN
     create_all_cell_node_facts_files(fisc_mstr_dir, a23_str)
 
     # THEN
-    assert os_path_exists(bob_t5_facts_path)
-    assert open_json(bob_t5_facts_path) == {}
+    assert os_path_exists(bob5_cell_path)
+    assert open_json(bob5_cell_path).get("budevent_facts") == {}
 
 
 def test_create_all_cell_node_facts_files_SetsFiles_Scenario1_WithFacts(
@@ -51,17 +56,16 @@ def test_create_all_cell_node_facts_files_SetsFiles_Scenario1_WithFacts(
     save_arbitrary_budevent(fisc_mstr_dir, a23_str, bob_str, event300, facts=x_facts)
     bob3_budevent_path = create_budevent_path(fisc_mstr_dir, a23_str, bob_str, event300)
     print(f"{bob3_budevent_path=}")
-    save_cell_node_file(fisc_mstr_dir, a23_str, bob_str, time5, event300, [])
-    bob_t5_facts_path = bude_facts_path(fisc_mstr_dir, a23_str, bob_str, time5)
-    # print(f" {bob_t5_facts_path=}")
-    assert os_path_exists(bob_t5_facts_path) is False
+    cellunit_add_json_file(fisc_mstr_dir, a23_str, bob_str, time5, event300, [])
+    bob5_cell_path = create_cell_node_json_path(fisc_mstr_dir, a23_str, bob_str, time5)
+    assert open_json(bob5_cell_path).get("budevent_facts") == {}
 
     # WHEN
     create_all_cell_node_facts_files(fisc_mstr_dir, a23_str)
 
     # THEN
-    assert os_path_exists(bob_t5_facts_path)
-    assert open_json(bob_t5_facts_path) == {clean_fact.base: clean_fact.get_dict()}
+    expected_budevent_facts = {clean_fact.base: clean_fact.get_dict()}
+    assert open_json(bob5_cell_path).get("budevent_facts") == expected_budevent_facts
 
 
 def test_create_all_cell_node_facts_files_SetsFiles_Scenario2_WithFacts_NotAtRoot(
@@ -73,21 +77,20 @@ def test_create_all_cell_node_facts_files_SetsFiles_Scenario2_WithFacts_NotAtRoo
     a23_str = "accord23"
     event300 = 300
     time5 = 5
-    casa_road = create_road(a23_str, "casa")
-    clean_road = create_road(casa_road, "clean")
-    x_facts = [(casa_road, clean_road, None, None)]
+    clean_fact = example_casa_clean_factunit()
+    x_facts = [(clean_fact.base, clean_fact.pick, None, None)]
     save_arbitrary_budevent(fisc_mstr_dir, a23_str, bob_str, event300, facts=x_facts)
     yao_str = "Yao"
     das = [yao_str, bob_str]
-    save_cell_node_file(fisc_mstr_dir, a23_str, bob_str, time5, event300, das)
-    bob_t5_facts_path = bude_facts_path(fisc_mstr_dir, a23_str, bob_str, time5, das)
-    print(f" {bob_t5_facts_path=}")
-    assert os_path_exists(bob_t5_facts_path) is False
+    cellunit_add_json_file(fisc_mstr_dir, a23_str, bob_str, time5, event300, das)
+    bob5_cell_path = create_cell_node_json_path(
+        fisc_mstr_dir, a23_str, bob_str, time5, das
+    )
+    assert open_json(bob5_cell_path).get("budevent_facts") == {}
 
     # WHEN
     create_all_cell_node_facts_files(fisc_mstr_dir, a23_str)
 
     # THEN
-    assert os_path_exists(bob_t5_facts_path)
-    facts_dict = open_json(bob_t5_facts_path)
-    assert facts_dict == {casa_road: {base_str(): casa_road, "pick": clean_road}}
+    expected_budevent_facts = {clean_fact.base: clean_fact.get_dict()}
+    assert open_json(bob5_cell_path).get("budevent_facts") == expected_budevent_facts

--- a/src/f07_fisc/test_fisc_tool/test_deal_facts.py
+++ b/src/f07_fisc/test_fisc_tool/test_deal_facts.py
@@ -1,12 +1,15 @@
 from src.f00_instrument.file import open_json, save_json
 from src.f01_road.road import create_road
 from src.f04_gift.atom_config import base_str
+from src.f05_listen.cell import cellunit_shop
 from src.f05_listen.hub_path import (
-    create_cell_budevent_facts_path as bude_facts_path,
+    create_cell_dir_path as cell_dir,
     create_cell_found_facts_path as found_facts_path,
     create_cell_quota_ledger_path as quota_path,
 )
+from src.f05_listen.hub_tool import cellunit_get_from_dir, cellunit_save_to_dir
 from src.f07_fisc.fisc_tool import uphill_cell_node_budevent_facts
+from src.f07_fisc.examples.example_fiscs import example_casa_clean_factunit
 from src.f07_fisc.examples.fisc_env import env_dir_setup_cleanup, get_test_fisc_mstr_dir
 from os.path import exists as os_path_exists
 
@@ -20,10 +23,10 @@ def test_uphill_cell_node_budevent_facts_Scenario0_RootOnly_NoFacts(
     a23_str = "accord23"
     time5 = 5
     das = []
-    bob_t5_be_facts_path = bude_facts_path(fisc_mstr_dir, a23_str, bob_str, time5, das)
+    bob_t5_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, time5, das)
     bob_t5_be_quota_path = quota_path(fisc_mstr_dir, a23_str, bob_str, time5, das)
-    be_facts_dict = {}
-    save_json(bob_t5_be_facts_path, None, be_facts_dict)
+    bob_t5_cell = cellunit_shop(bob_str, budevent_facts={})
+    cellunit_save_to_dir(bob_t5_dir, bob_t5_cell)
     save_json(bob_t5_be_quota_path, None, {})
     bob_t5_found_path = found_facts_path(fisc_mstr_dir, a23_str, bob_str, time5, das)
     assert os_path_exists(bob_t5_found_path) is False
@@ -49,15 +52,15 @@ def test_uphill_cell_node_budevent_facts_Scenario1_ChildNode_NoFacts(
     das = []
     das_y = [yao_str]
     das_ys = [yao_str, sue_str]
-    bob_t5_bef_path = bude_facts_path(mstr_dir, a23_str, bob_str, time5, das)
-    bob_t5_yao_bef_path = bude_facts_path(mstr_dir, a23_str, bob_str, time5, das_y)
-    bob_t5_yao_sue_bef_path = bude_facts_path(mstr_dir, a23_str, bob_str, time5, das_ys)
+    bob_t5_dir = cell_dir(mstr_dir, a23_str, bob_str, time5, das)
+    bob_t5_yao_dir = cell_dir(mstr_dir, a23_str, bob_str, time5, das_y)
+    bob_t5_yao_sue_dir = cell_dir(mstr_dir, a23_str, bob_str, time5, das_ys)
     bob_t5_quota_path = quota_path(mstr_dir, a23_str, bob_str, time5, das)
     bob_t5_yao_quota_path = quota_path(mstr_dir, a23_str, bob_str, time5, das_y)
     bob_t5_yao_sue_quota_path = quota_path(mstr_dir, a23_str, bob_str, time5, das_ys)
-    save_json(bob_t5_bef_path, None, {})
-    save_json(bob_t5_yao_bef_path, None, {})
-    save_json(bob_t5_yao_sue_bef_path, None, {})
+    cellunit_save_to_dir(bob_t5_dir, cellunit_shop(bob_str, das))
+    cellunit_save_to_dir(bob_t5_yao_dir, cellunit_shop(bob_str, das_y))
+    cellunit_save_to_dir(bob_t5_yao_sue_dir, cellunit_shop(bob_str, das_ys))
     save_json(bob_t5_quota_path, None, {})
     save_json(bob_t5_yao_quota_path, None, {})
     save_json(bob_t5_yao_sue_quota_path, None, {})
@@ -86,19 +89,29 @@ def test_uphill_cell_node_budevent_facts_Scenario2_ChildNodeWithOneFactIsAssigne
     clean_road = create_road(casa_road, "clean")
     bob_t5_be_facts = {}
     bob_t5_yao_be_facts = {}
-    bob_t5_yao_sue_be_facts = {casa_road: {base_str(): casa_road, "pick": clean_road}}
+    # bob_t5_yao_sue_be_facts = {casa_road: {base_str(): casa_road, "pick": clean_road}}
+    clean_fact = example_casa_clean_factunit()
+    bob_t5_yao_sue_be_facts = {clean_fact.base: clean_fact}
     das = []
     das_y = [yao_str]
     das_ys = [yao_str, sue_str]
-    bob_t5_bef_path = bude_facts_path(mstr_dir, a23_str, bob_str, time5, das)
-    bob_t5_yao_bef_path = bude_facts_path(mstr_dir, a23_str, bob_str, time5, das_y)
-    bob_t5_yao_sue_bef_path = bude_facts_path(mstr_dir, a23_str, bob_str, time5, das_ys)
+    bob_t5_dir = cell_dir(mstr_dir, a23_str, bob_str, time5, das)
+    bob_t5_yao_dir = cell_dir(mstr_dir, a23_str, bob_str, time5, das_y)
+    bob_t5_yao_sue_dir = cell_dir(mstr_dir, a23_str, bob_str, time5, das_ys)
     bob_t5_quota_path = quota_path(mstr_dir, a23_str, bob_str, time5, das)
     bob_t5_yao_quota_path = quota_path(mstr_dir, a23_str, bob_str, time5, das_y)
     bob_t5_yao_sue_quota_path = quota_path(mstr_dir, a23_str, bob_str, time5, das_ys)
-    save_json(bob_t5_bef_path, None, bob_t5_be_facts)
-    save_json(bob_t5_yao_bef_path, None, bob_t5_yao_be_facts)
-    save_json(bob_t5_yao_sue_bef_path, None, bob_t5_yao_sue_be_facts)
+    bob_t5_cell = cellunit_shop(bob_str, das, budevent_facts=bob_t5_be_facts)
+    bob_t5_yao_cell = cellunit_shop(bob_str, das_y, budevent_facts=bob_t5_yao_be_facts)
+    bob_t5_yao_sue_cell = cellunit_shop(
+        bob_str, das_ys, budevent_facts=bob_t5_yao_sue_be_facts
+    )
+    cellunit_save_to_dir(bob_t5_dir, bob_t5_cell)
+    cellunit_save_to_dir(bob_t5_yao_dir, bob_t5_yao_cell)
+    cellunit_save_to_dir(bob_t5_yao_sue_dir, bob_t5_yao_sue_cell)
+    # save_json(bob_t5_dir, None, bob_t5_be_facts)
+    # save_json(bob_t5_yao_dir, None, bob_t5_yao_be_facts)
+    # save_json(bob_t5_yao_sue_dir, None, bob_t5_yao_sue_be_facts)
     save_json(bob_t5_quota_path, None, {yao_str: 1})
     save_json(bob_t5_yao_quota_path, None, {sue_str: 1})
     save_json(bob_t5_yao_sue_quota_path, None, {bob_str: 1})
@@ -116,6 +129,7 @@ def test_uphill_cell_node_budevent_facts_Scenario2_ChildNodeWithOneFactIsAssigne
     assert os_path_exists(bob_t5_found)
     assert os_path_exists(bob_t5_yao_found)
     assert os_path_exists(bob_t5_yao_sue_found)
-    assert open_json(bob_t5_found) == bob_t5_yao_sue_be_facts
-    assert open_json(bob_t5_yao_found) == bob_t5_yao_sue_be_facts
-    assert open_json(bob_t5_yao_sue_found) == bob_t5_yao_sue_be_facts
+    expected_found_facts = {clean_fact.base: clean_fact.get_dict()}
+    assert open_json(bob_t5_found) == expected_found_facts
+    assert open_json(bob_t5_yao_found) == expected_found_facts
+    assert open_json(bob_t5_yao_sue_found) == expected_found_facts

--- a/src/f07_fisc/test_fisc_tool/test_deal_facts.py
+++ b/src/f07_fisc/test_fisc_tool/test_deal_facts.py
@@ -5,13 +5,13 @@ from src.f04_gift.atom_config import base_str
 from src.f05_listen.cell import cellunit_shop
 from src.f05_listen.hub_path import create_cell_dir_path as cell_dir
 from src.f05_listen.hub_tool import cellunit_get_from_dir, cellunit_save_to_dir
-from src.f07_fisc.fisc_tool import uphill_cell_node_budevent_facts
+from src.f07_fisc.fisc_tool import set_deal_trees_found_facts
 from src.f07_fisc.examples.example_fiscs import example_casa_clean_factunit
 from src.f07_fisc.examples.fisc_env import env_dir_setup_cleanup, get_test_fisc_mstr_dir
 from os.path import exists as os_path_exists
 
 
-def test_uphill_cell_node_budevent_facts_Scenario0_RootOnly_NoFacts(
+def test_set_deal_trees_found_facts_Scenario0_RootOnly_NoFacts(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -27,13 +27,13 @@ def test_uphill_cell_node_budevent_facts_Scenario0_RootOnly_NoFacts(
     assert cellunit_get_from_dir(bob5_dir).found_facts == {}
 
     # WHEN
-    uphill_cell_node_budevent_facts(fisc_mstr_dir, a23_str)
+    set_deal_trees_found_facts(fisc_mstr_dir, a23_str)
 
     # THEN
     assert cellunit_get_from_dir(bob5_dir).found_facts == {}
 
 
-def test_uphill_cell_node_budevent_facts_Scenario1_ChildNode_NoFacts(
+def test_set_deal_trees_found_facts_Scenario1_ChildNode_NoFacts(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -58,13 +58,13 @@ def test_uphill_cell_node_budevent_facts_Scenario1_ChildNode_NoFacts(
     assert cellunit_get_from_dir(bob5_dir).found_facts == {}
 
     # WHEN
-    uphill_cell_node_budevent_facts(mstr_dir, a23_str)
+    set_deal_trees_found_facts(mstr_dir, a23_str)
 
     # THEN
     assert cellunit_get_from_dir(bob5_dir).found_facts == {}
 
 
-def test_uphill_cell_node_budevent_facts_Scenario2_ChildNodeWithOneFactIsAssignedToAncestors(
+def test_set_deal_trees_found_facts_Scenario2_ChildNodeWithOneFactIsAssignedToAncestors(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -109,7 +109,7 @@ def test_uphill_cell_node_budevent_facts_Scenario2_ChildNodeWithOneFactIsAssigne
     assert cellunit_get_from_dir(bob5_yao_sue_dir).found_facts == {}
 
     # WHEN
-    uphill_cell_node_budevent_facts(mstr_dir, a23_str)
+    set_deal_trees_found_facts(mstr_dir, a23_str)
 
     # THEN
     assert cellunit_get_from_dir(bob5_dir).found_facts == clean_facts

--- a/src/f07_fisc/test_fisc_tool/test_deal_facts.py
+++ b/src/f07_fisc/test_fisc_tool/test_deal_facts.py
@@ -4,7 +4,6 @@ from src.f04_gift.atom_config import base_str
 from src.f05_listen.cell import cellunit_shop
 from src.f05_listen.hub_path import (
     create_cell_dir_path as cell_dir,
-    create_cell_found_facts_path as found_facts_path,
     create_cell_quota_ledger_path as quota_path,
 )
 from src.f05_listen.hub_tool import cellunit_get_from_dir, cellunit_save_to_dir
@@ -28,15 +27,13 @@ def test_uphill_cell_node_budevent_facts_Scenario0_RootOnly_NoFacts(
     bob_t5_cell = cellunit_shop(bob_str, budevent_facts={})
     cellunit_save_to_dir(bob_t5_dir, bob_t5_cell)
     save_json(bob_t5_be_quota_path, None, {})
-    bob_t5_found_path = found_facts_path(fisc_mstr_dir, a23_str, bob_str, time5, das)
-    assert os_path_exists(bob_t5_found_path) is False
+    assert cellunit_get_from_dir(bob_t5_dir).found_facts == {}
 
     # WHEN
     uphill_cell_node_budevent_facts(fisc_mstr_dir, a23_str)
 
     # THEN
-    assert os_path_exists(bob_t5_found_path)
-    assert open_json(bob_t5_found_path) == {}
+    assert cellunit_get_from_dir(bob_t5_dir).found_facts == {}
 
 
 def test_uphill_cell_node_budevent_facts_Scenario1_ChildNode_NoFacts(
@@ -64,15 +61,13 @@ def test_uphill_cell_node_budevent_facts_Scenario1_ChildNode_NoFacts(
     save_json(bob_t5_quota_path, None, {})
     save_json(bob_t5_yao_quota_path, None, {})
     save_json(bob_t5_yao_sue_quota_path, None, {})
-    bob_t5_found_path = found_facts_path(mstr_dir, a23_str, bob_str, time5, das)
-    assert os_path_exists(bob_t5_found_path) is False
+    assert cellunit_get_from_dir(bob_t5_dir).found_facts == {}
 
     # WHEN
     uphill_cell_node_budevent_facts(mstr_dir, a23_str)
 
     # THEN
-    assert os_path_exists(bob_t5_found_path)
-    assert open_json(bob_t5_found_path) == {}
+    assert cellunit_get_from_dir(bob_t5_dir).found_facts == {}
 
 
 def test_uphill_cell_node_budevent_facts_Scenario2_ChildNodeWithOneFactIsAssignedToAncestors(
@@ -109,27 +104,18 @@ def test_uphill_cell_node_budevent_facts_Scenario2_ChildNodeWithOneFactIsAssigne
     cellunit_save_to_dir(bob_t5_dir, bob_t5_cell)
     cellunit_save_to_dir(bob_t5_yao_dir, bob_t5_yao_cell)
     cellunit_save_to_dir(bob_t5_yao_sue_dir, bob_t5_yao_sue_cell)
-    # save_json(bob_t5_dir, None, bob_t5_be_facts)
-    # save_json(bob_t5_yao_dir, None, bob_t5_yao_be_facts)
-    # save_json(bob_t5_yao_sue_dir, None, bob_t5_yao_sue_be_facts)
     save_json(bob_t5_quota_path, None, {yao_str: 1})
     save_json(bob_t5_yao_quota_path, None, {sue_str: 1})
     save_json(bob_t5_yao_sue_quota_path, None, {bob_str: 1})
-    bob_t5_found = found_facts_path(mstr_dir, a23_str, bob_str, time5, das)
-    bob_t5_yao_found = found_facts_path(mstr_dir, a23_str, bob_str, time5, das_y)
-    bob_t5_yao_sue_found = found_facts_path(mstr_dir, a23_str, bob_str, time5, das_ys)
-    assert os_path_exists(bob_t5_found) is False
-    assert os_path_exists(bob_t5_yao_found) is False
-    assert os_path_exists(bob_t5_yao_sue_found) is False
+    assert cellunit_get_from_dir(bob_t5_dir).found_facts == {}
+    assert cellunit_get_from_dir(bob_t5_yao_dir).found_facts == {}
+    assert cellunit_get_from_dir(bob_t5_yao_sue_dir).found_facts == {}
 
     # WHEN
     uphill_cell_node_budevent_facts(mstr_dir, a23_str)
 
     # THEN
-    assert os_path_exists(bob_t5_found)
-    assert os_path_exists(bob_t5_yao_found)
-    assert os_path_exists(bob_t5_yao_sue_found)
-    expected_found_facts = {clean_fact.base: clean_fact.get_dict()}
-    assert open_json(bob_t5_found) == expected_found_facts
-    assert open_json(bob_t5_yao_found) == expected_found_facts
-    assert open_json(bob_t5_yao_sue_found) == expected_found_facts
+    expected_found_facts = {clean_fact.base: clean_fact}
+    assert cellunit_get_from_dir(bob_t5_dir).found_facts == expected_found_facts
+    assert cellunit_get_from_dir(bob_t5_yao_dir).found_facts == expected_found_facts
+    assert cellunit_get_from_dir(bob_t5_yao_sue_dir).found_facts == expected_found_facts

--- a/src/f07_fisc/test_fisc_tool/test_deal_facts.py
+++ b/src/f07_fisc/test_fisc_tool/test_deal_facts.py
@@ -1,11 +1,9 @@
 from src.f00_instrument.file import open_json, save_json
 from src.f01_road.road import create_road
+from src.f02_bud.bud import budunit_shop
 from src.f04_gift.atom_config import base_str
 from src.f05_listen.cell import cellunit_shop
-from src.f05_listen.hub_path import (
-    create_cell_dir_path as cell_dir,
-    create_cell_quota_ledger_path as quota_path,
-)
+from src.f05_listen.hub_path import create_cell_dir_path as cell_dir
 from src.f05_listen.hub_tool import cellunit_get_from_dir, cellunit_save_to_dir
 from src.f07_fisc.fisc_tool import uphill_cell_node_budevent_facts
 from src.f07_fisc.examples.example_fiscs import example_casa_clean_factunit
@@ -22,18 +20,17 @@ def test_uphill_cell_node_budevent_facts_Scenario0_RootOnly_NoFacts(
     a23_str = "accord23"
     time5 = 5
     das = []
-    bob_t5_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, time5, das)
-    bob_t5_be_quota_path = quota_path(fisc_mstr_dir, a23_str, bob_str, time5, das)
-    bob_t5_cell = cellunit_shop(bob_str, budevent_facts={})
-    cellunit_save_to_dir(bob_t5_dir, bob_t5_cell)
-    save_json(bob_t5_be_quota_path, None, {})
-    assert cellunit_get_from_dir(bob_t5_dir).found_facts == {}
+    bob5_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, time5, das)
+    bob5_cell = cellunit_shop(bob_str, budevent_facts={})
+    cellunit_save_to_dir(bob5_dir, bob5_cell)
+    assert bob5_cell.get_budevents_quota_ledger() == {}
+    assert cellunit_get_from_dir(bob5_dir).found_facts == {}
 
     # WHEN
     uphill_cell_node_budevent_facts(fisc_mstr_dir, a23_str)
 
     # THEN
-    assert cellunit_get_from_dir(bob_t5_dir).found_facts == {}
+    assert cellunit_get_from_dir(bob5_dir).found_facts == {}
 
 
 def test_uphill_cell_node_budevent_facts_Scenario1_ChildNode_NoFacts(
@@ -49,25 +46,22 @@ def test_uphill_cell_node_budevent_facts_Scenario1_ChildNode_NoFacts(
     das = []
     das_y = [yao_str]
     das_ys = [yao_str, sue_str]
-    bob_t5_dir = cell_dir(mstr_dir, a23_str, bob_str, time5, das)
-    bob_t5_yao_dir = cell_dir(mstr_dir, a23_str, bob_str, time5, das_y)
-    bob_t5_yao_sue_dir = cell_dir(mstr_dir, a23_str, bob_str, time5, das_ys)
-    bob_t5_quota_path = quota_path(mstr_dir, a23_str, bob_str, time5, das)
-    bob_t5_yao_quota_path = quota_path(mstr_dir, a23_str, bob_str, time5, das_y)
-    bob_t5_yao_sue_quota_path = quota_path(mstr_dir, a23_str, bob_str, time5, das_ys)
-    cellunit_save_to_dir(bob_t5_dir, cellunit_shop(bob_str, das))
-    cellunit_save_to_dir(bob_t5_yao_dir, cellunit_shop(bob_str, das_y))
-    cellunit_save_to_dir(bob_t5_yao_sue_dir, cellunit_shop(bob_str, das_ys))
-    save_json(bob_t5_quota_path, None, {})
-    save_json(bob_t5_yao_quota_path, None, {})
-    save_json(bob_t5_yao_sue_quota_path, None, {})
-    assert cellunit_get_from_dir(bob_t5_dir).found_facts == {}
+    bob5_dir = cell_dir(mstr_dir, a23_str, bob_str, time5, das)
+    bob5_yao_dir = cell_dir(mstr_dir, a23_str, bob_str, time5, das_y)
+    bob5_yao_sue_dir = cell_dir(mstr_dir, a23_str, bob_str, time5, das_ys)
+    cellunit_save_to_dir(bob5_dir, cellunit_shop(bob_str, das))
+    cellunit_save_to_dir(bob5_yao_dir, cellunit_shop(bob_str, das_y))
+    cellunit_save_to_dir(bob5_yao_sue_dir, cellunit_shop(bob_str, das_ys))
+    cellunit_get_from_dir(bob5_dir).get_budevents_quota_ledger() == {}
+    cellunit_get_from_dir(bob5_yao_dir).get_budevents_quota_ledger() == {}
+    cellunit_get_from_dir(bob5_yao_sue_dir).get_budevents_quota_ledger() == {}
+    assert cellunit_get_from_dir(bob5_dir).found_facts == {}
 
     # WHEN
     uphill_cell_node_budevent_facts(mstr_dir, a23_str)
 
     # THEN
-    assert cellunit_get_from_dir(bob_t5_dir).found_facts == {}
+    assert cellunit_get_from_dir(bob5_dir).found_facts == {}
 
 
 def test_uphill_cell_node_budevent_facts_Scenario2_ChildNodeWithOneFactIsAssignedToAncestors(
@@ -80,42 +74,44 @@ def test_uphill_cell_node_budevent_facts_Scenario2_ChildNodeWithOneFactIsAssigne
     sue_str = "Sue"
     a23_str = "accord23"
     time5 = 5
-    casa_road = create_road(a23_str, "casa")
-    clean_road = create_road(casa_road, "clean")
-    bob_t5_be_facts = {}
-    bob_t5_yao_be_facts = {}
-    # bob_t5_yao_sue_be_facts = {casa_road: {base_str(): casa_road, "pick": clean_road}}
     clean_fact = example_casa_clean_factunit()
-    bob_t5_yao_sue_be_facts = {clean_fact.base: clean_fact}
     das = []
     das_y = [yao_str]
     das_ys = [yao_str, sue_str]
-    bob_t5_dir = cell_dir(mstr_dir, a23_str, bob_str, time5, das)
-    bob_t5_yao_dir = cell_dir(mstr_dir, a23_str, bob_str, time5, das_y)
-    bob_t5_yao_sue_dir = cell_dir(mstr_dir, a23_str, bob_str, time5, das_ys)
-    bob_t5_quota_path = quota_path(mstr_dir, a23_str, bob_str, time5, das)
-    bob_t5_yao_quota_path = quota_path(mstr_dir, a23_str, bob_str, time5, das_y)
-    bob_t5_yao_sue_quota_path = quota_path(mstr_dir, a23_str, bob_str, time5, das_ys)
-    bob_t5_cell = cellunit_shop(bob_str, das, budevent_facts=bob_t5_be_facts)
-    bob_t5_yao_cell = cellunit_shop(bob_str, das_y, budevent_facts=bob_t5_yao_be_facts)
-    bob_t5_yao_sue_cell = cellunit_shop(
-        bob_str, das_ys, budevent_facts=bob_t5_yao_sue_be_facts
+    bob5_dir = cell_dir(mstr_dir, a23_str, bob_str, time5, das)
+    bob5_yao_dir = cell_dir(mstr_dir, a23_str, bob_str, time5, das_y)
+    bob5_yao_sue_dir = cell_dir(mstr_dir, a23_str, bob_str, time5, das_ys)
+    bob5_budevent = budunit_shop(bob_str, a23_str)
+    bob5_yao_budevent = budunit_shop(yao_str, a23_str)
+    bob5_yao_sue_budevent = budunit_shop(sue_str, a23_str)
+    bob5_budevent.add_acctunit(yao_str)
+    bob5_yao_budevent.add_acctunit(sue_str)
+    bob5_yao_sue_budevent.add_acctunit(bob_str)
+    bob5_yao_sue_budevent.add_item(clean_fact.pick, 1)
+    bob5_yao_sue_budevent.add_fact(clean_fact.base, clean_fact.pick)
+    bob5_cell = cellunit_shop(bob_str, das, budadjust=bob5_budevent)
+    bob5_yao_cell = cellunit_shop(bob_str, das_y, budadjust=bob5_yao_budevent)
+    clean_facts = {clean_fact.base: clean_fact}
+    bob5_yao_sue_cell = cellunit_shop(
+        bob_str, das_ys, budadjust=bob5_yao_sue_budevent, budevent_facts=clean_facts
     )
-    cellunit_save_to_dir(bob_t5_dir, bob_t5_cell)
-    cellunit_save_to_dir(bob_t5_yao_dir, bob_t5_yao_cell)
-    cellunit_save_to_dir(bob_t5_yao_sue_dir, bob_t5_yao_sue_cell)
-    save_json(bob_t5_quota_path, None, {yao_str: 1})
-    save_json(bob_t5_yao_quota_path, None, {sue_str: 1})
-    save_json(bob_t5_yao_sue_quota_path, None, {bob_str: 1})
-    assert cellunit_get_from_dir(bob_t5_dir).found_facts == {}
-    assert cellunit_get_from_dir(bob_t5_yao_dir).found_facts == {}
-    assert cellunit_get_from_dir(bob_t5_yao_sue_dir).found_facts == {}
+    assert bob5_cell.get_budevents_quota_ledger() == {yao_str: 1000}
+    assert bob5_yao_cell.get_budevents_quota_ledger() == {sue_str: 1000}
+    assert bob5_yao_sue_cell.get_budevents_quota_ledger() == {bob_str: 1000}
+    assert bob5_cell.budevent_facts == {}
+    assert bob5_yao_cell.budevent_facts == {}
+    assert bob5_yao_sue_cell.budevent_facts == clean_facts
+    cellunit_save_to_dir(bob5_dir, bob5_cell)
+    cellunit_save_to_dir(bob5_yao_dir, bob5_yao_cell)
+    cellunit_save_to_dir(bob5_yao_sue_dir, bob5_yao_sue_cell)
+    assert cellunit_get_from_dir(bob5_dir).found_facts == {}
+    assert cellunit_get_from_dir(bob5_yao_dir).found_facts == {}
+    assert cellunit_get_from_dir(bob5_yao_sue_dir).found_facts == {}
 
     # WHEN
     uphill_cell_node_budevent_facts(mstr_dir, a23_str)
 
     # THEN
-    expected_found_facts = {clean_fact.base: clean_fact}
-    assert cellunit_get_from_dir(bob_t5_dir).found_facts == expected_found_facts
-    assert cellunit_get_from_dir(bob_t5_yao_dir).found_facts == expected_found_facts
-    assert cellunit_get_from_dir(bob_t5_yao_sue_dir).found_facts == expected_found_facts
+    assert cellunit_get_from_dir(bob5_dir).found_facts == clean_facts
+    assert cellunit_get_from_dir(bob5_yao_dir).found_facts == clean_facts
+    assert cellunit_get_from_dir(bob5_yao_sue_dir).found_facts == clean_facts

--- a/src/f07_fisc/test_fisc_z_deal_trees/test_fisc_create_deal_tree.py
+++ b/src/f07_fisc/test_fisc_z_deal_trees/test_fisc_create_deal_tree.py
@@ -1,12 +1,16 @@
-from src.f00_instrument.file import open_json, save_json, count_dirs_files, create_path
+from src.f00_instrument.file import open_json, save_json, create_path
 from src.f01_road.deal import owner_name_str, quota_str, celldepth_str
 from src.f04_gift.atom_config import event_int_str, penny_str
+from src.f05_listen.cell import cellunit_shop
 from src.f05_listen.hub_path import (
-    create_cell_dir_path as node_dir,
+    create_cell_dir_path as cell_dir,
     create_cell_node_json_path as node_path,
-    create_cell_quota_ledger_path as quota_path,
 )
-from src.f05_listen.hub_tool import save_arbitrary_budevent as save_budevent
+from src.f05_listen.hub_tool import (
+    save_arbitrary_budevent as save_budevent,
+    cellunit_save_to_dir,
+    cellunit_get_from_dir,
+)
 from src.f07_fisc.fisc_tool import create_deal_tree
 from src.f07_fisc.examples.fisc_env import env_dir_setup_cleanup, get_test_fisc_mstr_dir
 from os.path import exists as os_path_exists
@@ -19,15 +23,15 @@ def test_create_deal_tree_Scenaro0_timepoint_Empty(env_dir_setup_cleanup):
     bob_str = "Bob"
     tp37 = 37
 
-    a23_bob_tp37_path = node_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [])
+    a23_bob_tp37_path = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [])
     print(f"{a23_bob_tp37_path=}")
-    assert count_dirs_files(a23_bob_tp37_path) == 0
+    assert os_path_exists(a23_bob_tp37_path) is False
 
     # WHEN
     create_deal_tree(fisc_mstr_dir, a23_str, bob_str, tp37)
 
     # THEN
-    assert count_dirs_files(a23_bob_tp37_path) == 0
+    assert os_path_exists(a23_bob_tp37_path) is False
 
 
 def test_create_deal_tree_Scenaro1_LedgerDepth0(env_dir_setup_cleanup):
@@ -40,29 +44,19 @@ def test_create_deal_tree_Scenaro1_LedgerDepth0(env_dir_setup_cleanup):
     deal1_quota = 450
     deal1_celldepth = 0
     event56 = 56
-    cell_node = {
-        "ancestors": [],
-        celldepth_str(): deal1_celldepth,
-        "deal_owner_name": bob_str,
-        event_int_str(): event56,
-        quota_str(): deal1_quota,
-    }
-    a23_bob_root_cell_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37)
-    save_json(a23_bob_root_cell_path, None, cell_node)
+    x_cell = cellunit_shop(bob_str, [], event56, deal1_celldepth, quota=deal1_quota)
+    bob37_root_cell_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [])
+    cellunit_save_to_dir(bob37_root_cell_dir, x_cell)
     save_budevent(fisc_mstr_dir, a23_str, bob_str, event56, [[yao_str], [bob_str]])
-
-    bob_tp37_quota_ledger_path = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37)
-    bob_tp37_dir = node_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [])
-    assert os_path_exists(bob_tp37_quota_ledger_path) is False
-    assert count_dirs_files(bob_tp37_dir) == 1
+    assert cellunit_get_from_dir(bob37_root_cell_dir).get_budevents_quota_ledger() == {}
 
     # WHEN
     create_deal_tree(fisc_mstr_dir, a23_str, bob_str, tp37)
 
     # THEN
-    assert os_path_exists(bob_tp37_quota_ledger_path)
-    assert open_json(bob_tp37_quota_ledger_path) == {"Bob": 225, yao_str: 225}
-    assert count_dirs_files(bob_tp37_dir) == 2
+    bob37_root_cell = cellunit_get_from_dir(bob37_root_cell_dir)
+    generated_bob37_quota_ledger = bob37_root_cell.get_budevents_quota_ledger()
+    assert generated_bob37_quota_ledger == {"Bob": 225, yao_str: 225}
 
 
 def test_create_deal_tree_Scenaro2_LedgerDepth1(env_dir_setup_cleanup):
@@ -73,24 +67,12 @@ def test_create_deal_tree_Scenaro2_LedgerDepth1(env_dir_setup_cleanup):
     yao_str = "Yao"
     zia_str = "Zia"
     tp37 = 37  # timepoint
-    deal1_quota = 450
-    deal1_celldepth = 1
+    x_quota = 450
+    x_celldepth = 1
     event56 = 56
-    cell_node = {
-        "ancestors": [bob_str],
-        event_int_str(): event56,
-        celldepth_str(): deal1_celldepth,
-        "deal_owner_name": bob_str,
-        penny_str(): 1,
-        quota_str(): deal1_quota,
-    }
-    a23_bob_ledger_state_path = node_path(
-        fisc_mstr_dir=fisc_mstr_dir,
-        fisc_title=a23_str,
-        owner_name=bob_str,
-        time_int=tp37,
-    )
-    save_json(a23_bob_ledger_state_path, None, cell_node)
+    x_cell = cellunit_shop(bob_str, [], event56, x_celldepth, quota=x_quota)
+    bob37_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [])
+    cellunit_save_to_dir(bob37_dir, x_cell)
     bob_accts = [[yao_str], [bob_str], [zia_str]]
     yao_accts = [[zia_str]]
     zia_accts = [[bob_str], [yao_str]]
@@ -100,68 +82,66 @@ def test_create_deal_tree_Scenaro2_LedgerDepth1(env_dir_setup_cleanup):
     assert os_path_exists(bob_e56_path)
     assert os_path_exists(yao_e56_path)
     assert os_path_exists(zia_e56_path)
-    tp37_dir = node_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [])
-    bob_tp37_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [])
-    bob_tp37_bob_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
-    bob_tp37_yao_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
-    bob_tp37_zia_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [zia_str])
-    tp37_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37)
-    tp37_bob_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
-    tp37_yao_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
-    tp37_zia_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37, [zia_str])
-    assert os_path_exists(bob_tp37_node_path)
-    assert os_path_exists(bob_tp37_bob_node_path) is False
-    assert os_path_exists(bob_tp37_yao_node_path) is False
-    assert os_path_exists(bob_tp37_zia_node_path) is False
-    assert os_path_exists(tp37_quota) is False
-    assert os_path_exists(tp37_bob_quota) is False
-    assert os_path_exists(tp37_yao_quota) is False
-    assert os_path_exists(tp37_zia_quota) is False
-    assert count_dirs_files(tp37_dir) == 1
+    bob37_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [])
+    bob37_bob_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
+    bob37_yao_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
+    bob37_zia_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [zia_str])
+    assert os_path_exists(bob37_node_path)
+    assert os_path_exists(bob37_bob_node_path) is False
+    assert os_path_exists(bob37_yao_node_path) is False
+    assert os_path_exists(bob37_zia_node_path) is False
+    assert cellunit_get_from_dir(bob37_dir).get_budevents_quota_ledger() == {}
 
     # WHEN
     create_deal_tree(fisc_mstr_dir, a23_str, bob_str, tp37)
 
     # THEN
-    assert os_path_exists(tp37_quota)
-    assert open_json(tp37_quota) == {bob_str: 150, yao_str: 150, zia_str: 150}
-    print(f"{bob_tp37_bob_node_path=}")
-    print(f"{bob_tp37_yao_node_path=}")
-    print(f"{bob_tp37_zia_node_path=}")
-    assert os_path_exists(bob_tp37_node_path)
-    assert os_path_exists(bob_tp37_bob_node_path)
-    assert os_path_exists(bob_tp37_yao_node_path)
-    assert os_path_exists(bob_tp37_zia_node_path)
-    assert os_path_exists(tp37_quota)
-    assert os_path_exists(tp37_bob_quota)
-    assert os_path_exists(tp37_yao_quota)
-    assert os_path_exists(tp37_zia_quota)
-    assert count_dirs_files(tp37_dir) == 11
-    bob_tp37_bob_dict = open_json(bob_tp37_bob_node_path)
-    assert bob_tp37_bob_dict.get("ancestors") == [bob_str, bob_str]
-    assert bob_tp37_bob_dict.get("event_int") == 56
-    assert bob_tp37_bob_dict.get("celldepth") == 0
-    assert bob_tp37_bob_dict.get("deal_owner_name") == bob_str
-    assert bob_tp37_bob_dict.get("penny") == 1
-    assert bob_tp37_bob_dict.get("quota") == 150
-    bob_tp37_yao_dict = open_json(bob_tp37_yao_node_path)
-    assert bob_tp37_yao_dict.get("ancestors") == [bob_str, yao_str]
-    assert bob_tp37_yao_dict.get("event_int") == 56
-    assert bob_tp37_yao_dict.get("celldepth") == 0
-    assert bob_tp37_yao_dict.get("deal_owner_name") == bob_str
-    assert bob_tp37_yao_dict.get("penny") == 1
-    assert bob_tp37_yao_dict.get("quota") == 150
-    bob_tp37_zia_dict = open_json(bob_tp37_zia_node_path)
-    assert bob_tp37_zia_dict.get("ancestors") == [bob_str, zia_str]
-    assert bob_tp37_zia_dict.get("event_int") == 56
-    assert bob_tp37_zia_dict.get("celldepth") == 0
-    assert bob_tp37_zia_dict.get("deal_owner_name") == bob_str
-    assert bob_tp37_zia_dict.get("penny") == 1
-    assert bob_tp37_zia_dict.get("quota") == 150
-    assert open_json(tp37_quota) == {bob_str: 150, yao_str: 150, zia_str: 150}
-    assert open_json(tp37_bob_quota) == {bob_str: 50, yao_str: 50, zia_str: 50}
-    assert open_json(tp37_yao_quota) == {zia_str: 150}
-    assert open_json(tp37_zia_quota) == {bob_str: 75, yao_str: 75}
+    print(f"{bob37_bob_node_path=}")
+    print(f"{bob37_yao_node_path=}")
+    print(f"{bob37_zia_node_path=}")
+    assert os_path_exists(bob37_node_path)
+    assert os_path_exists(bob37_bob_node_path)
+    assert os_path_exists(bob37_yao_node_path)
+    assert os_path_exists(bob37_zia_node_path)
+    bob37_bob_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
+    bob37_yao_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
+    bob37_zia_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [zia_str])
+    bob37_cell = cellunit_get_from_dir(bob37_dir)
+    bob37_bob_cell = cellunit_get_from_dir(bob37_bob_dir)
+    bob37_yao_cell = cellunit_get_from_dir(bob37_yao_dir)
+    bob37_zia_cell = cellunit_get_from_dir(bob37_zia_dir)
+    assert bob37_cell.ancestors == []
+    assert bob37_cell.event_int == 56
+    assert bob37_cell.celldepth == 1
+    assert bob37_cell.deal_owner_name == bob_str
+    assert bob37_cell.penny == 1
+    assert bob37_cell.quota == 450
+    assert bob37_bob_cell.ancestors == [bob_str]
+    assert bob37_bob_cell.event_int == 56
+    assert bob37_bob_cell.celldepth == 0
+    assert bob37_bob_cell.deal_owner_name == bob_str
+    assert bob37_bob_cell.penny == 1
+    assert bob37_bob_cell.quota == 150
+    assert bob37_yao_cell.ancestors == [yao_str]
+    assert bob37_yao_cell.event_int == 56
+    assert bob37_yao_cell.celldepth == 0
+    assert bob37_yao_cell.deal_owner_name == bob_str
+    assert bob37_yao_cell.penny == 1
+    assert bob37_yao_cell.quota == 150
+    assert bob37_zia_cell.ancestors == [zia_str]
+    assert bob37_zia_cell.event_int == 56
+    assert bob37_zia_cell.celldepth == 0
+    assert bob37_zia_cell.deal_owner_name == bob_str
+    assert bob37_zia_cell.penny == 1
+    assert bob37_zia_cell.quota == 150
+    gen_bob37_quota_ledger = bob37_cell.get_budevents_quota_ledger()
+    gen_bob37_bob_quota_ledger = bob37_bob_cell.get_budevents_quota_ledger()
+    gen_bob37_yao_quota_ledger = bob37_yao_cell.get_budevents_quota_ledger()
+    gen_bob37_zia_quota_ledger = bob37_zia_cell.get_budevents_quota_ledger()
+    assert gen_bob37_quota_ledger == {bob_str: 150, yao_str: 150, zia_str: 150}
+    assert gen_bob37_bob_quota_ledger == {bob_str: 50, yao_str: 50, zia_str: 50}
+    assert gen_bob37_yao_quota_ledger == {zia_str: 150}
+    assert gen_bob37_zia_quota_ledger == {bob_str: 75, yao_str: 75}
 
 
 def test_create_deal_tree_Scenaro3_LedgerDepth1_MostRecentEvent(env_dir_setup_cleanup):
@@ -172,26 +152,14 @@ def test_create_deal_tree_Scenaro3_LedgerDepth1_MostRecentEvent(env_dir_setup_cl
     yao_str = "Yao"
     zia_str = "Zia"
     tp37 = 37  # timepoint
-    deal1_quota = 450
-    deal1_celldepth = 1
+    x_quota = 450
+    x_celldepth = 1
     event33 = 33
     event44 = 44
     event55 = 55
-    cell_node = {
-        "ancestors": [bob_str],
-        event_int_str(): event55,
-        celldepth_str(): deal1_celldepth,
-        "deal_owner_name": bob_str,
-        penny_str(): 1,
-        quota_str(): deal1_quota,
-    }
-    a23_bob_ledger_state_path = node_path(
-        fisc_mstr_dir=fisc_mstr_dir,
-        fisc_title=a23_str,
-        owner_name=bob_str,
-        time_int=tp37,
-    )
-    save_json(a23_bob_ledger_state_path, None, cell_node)
+    x_cell = cellunit_shop(bob_str, [], event55, x_celldepth, quota=x_quota)
+    bob37_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [])
+    cellunit_save_to_dir(bob37_dir, x_cell)
     bob_accts = [[yao_str], [bob_str], [zia_str]]
     yao_accts = [[zia_str]]
     zia_accts = [[bob_str], [yao_str]]
@@ -202,68 +170,65 @@ def test_create_deal_tree_Scenaro3_LedgerDepth1_MostRecentEvent(env_dir_setup_cl
     assert os_path_exists(bob_e55_path)
     assert os_path_exists(yao_e44_path)
     assert os_path_exists(zia_e33_path)
-    tp37_dir = node_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [])
-    tp37_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [])
-    tp37_bob_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
-    tp37_yao_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
-    tp37_zia_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [zia_str])
-    tp37_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37)
-    tp37_bob_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
-    tp37_yao_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
-    tp37_zia_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37, [zia_str])
-    assert os_path_exists(tp37_node_path)
-    assert os_path_exists(tp37_bob_node_path) is False
-    assert os_path_exists(tp37_yao_node_path) is False
-    assert os_path_exists(tp37_zia_node_path) is False
-    assert os_path_exists(tp37_quota) is False
-    assert os_path_exists(tp37_bob_quota) is False
-    assert os_path_exists(tp37_yao_quota) is False
-    assert os_path_exists(tp37_zia_quota) is False
-    assert count_dirs_files(tp37_dir) == 1
+    bob37_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [])
+    bob37_bob_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
+    bob37_yao_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
+    bob37_zia_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [zia_str])
+    assert os_path_exists(bob37_node_path)
+    assert os_path_exists(bob37_bob_node_path) is False
+    assert os_path_exists(bob37_yao_node_path) is False
+    assert os_path_exists(bob37_zia_node_path) is False
 
     # WHEN
     create_deal_tree(fisc_mstr_dir, a23_str, bob_str, tp37)
 
     # THEN
-    assert os_path_exists(tp37_quota)
-    assert open_json(tp37_quota) == {bob_str: 150, yao_str: 150, zia_str: 150}
-    print(f"{tp37_bob_node_path=}")
-    print(f"{tp37_yao_node_path=}")
-    print(f"{tp37_zia_node_path=}")
-    assert os_path_exists(tp37_node_path)
-    assert os_path_exists(tp37_bob_node_path)
-    assert os_path_exists(tp37_yao_node_path)
-    assert os_path_exists(tp37_zia_node_path)
-    assert os_path_exists(tp37_quota)
-    assert os_path_exists(tp37_bob_quota)
-    assert os_path_exists(tp37_yao_quota)
-    assert os_path_exists(tp37_zia_quota)
-    assert count_dirs_files(tp37_dir) == 11
-    bob_tp37_bob_dict = open_json(tp37_bob_node_path)
-    assert bob_tp37_bob_dict.get("ancestors") == [bob_str, bob_str]
-    assert bob_tp37_bob_dict.get("event_int") == 55
-    assert bob_tp37_bob_dict.get("celldepth") == 0
-    assert bob_tp37_bob_dict.get("deal_owner_name") == bob_str
-    assert bob_tp37_bob_dict.get("penny") == 1
-    assert bob_tp37_bob_dict.get("quota") == 150
-    bob_tp37_yao_dict = open_json(tp37_yao_node_path)
-    assert bob_tp37_yao_dict.get("ancestors") == [bob_str, yao_str]
-    assert bob_tp37_yao_dict.get("event_int") == 44
-    assert bob_tp37_yao_dict.get("celldepth") == 0
-    assert bob_tp37_yao_dict.get("deal_owner_name") == bob_str
-    assert bob_tp37_yao_dict.get("penny") == 1
-    assert bob_tp37_yao_dict.get("quota") == 150
-    bob_tp37_zia_dict = open_json(tp37_zia_node_path)
-    assert bob_tp37_zia_dict.get("ancestors") == [bob_str, zia_str]
-    assert bob_tp37_zia_dict.get("event_int") == 33
-    assert bob_tp37_zia_dict.get("celldepth") == 0
-    assert bob_tp37_zia_dict.get("deal_owner_name") == bob_str
-    assert bob_tp37_zia_dict.get("penny") == 1
-    assert bob_tp37_zia_dict.get("quota") == 150
-    assert open_json(tp37_quota) == {bob_str: 150, yao_str: 150, zia_str: 150}
-    assert open_json(tp37_bob_quota) == {bob_str: 50, yao_str: 50, zia_str: 50}
-    assert open_json(tp37_yao_quota) == {zia_str: 150}
-    assert open_json(tp37_zia_quota) == {bob_str: 75, yao_str: 75}
+    print(f"{bob37_bob_node_path=}")
+    print(f"{bob37_yao_node_path=}")
+    print(f"{bob37_zia_node_path=}")
+    assert os_path_exists(bob37_node_path)
+    assert os_path_exists(bob37_bob_node_path)
+    assert os_path_exists(bob37_yao_node_path)
+    assert os_path_exists(bob37_zia_node_path)
+    bob37_bob_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
+    bob37_yao_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
+    bob37_zia_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [zia_str])
+    bob37_cell = cellunit_get_from_dir(bob37_dir)
+    bob37_bob_cell = cellunit_get_from_dir(bob37_bob_dir)
+    bob37_yao_cell = cellunit_get_from_dir(bob37_yao_dir)
+    bob37_zia_cell = cellunit_get_from_dir(bob37_zia_dir)
+    assert bob37_cell.ancestors == []
+    assert bob37_cell.event_int == 55
+    assert bob37_cell.celldepth == 1
+    assert bob37_cell.deal_owner_name == bob_str
+    assert bob37_cell.penny == 1
+    assert bob37_cell.quota == 450
+    assert bob37_bob_cell.ancestors == [bob_str]
+    assert bob37_bob_cell.event_int == 55
+    assert bob37_bob_cell.celldepth == 0
+    assert bob37_bob_cell.deal_owner_name == bob_str
+    assert bob37_bob_cell.penny == 1
+    assert bob37_bob_cell.quota == 150
+    assert bob37_yao_cell.ancestors == [yao_str]
+    assert bob37_yao_cell.event_int == 44
+    assert bob37_yao_cell.celldepth == 0
+    assert bob37_yao_cell.deal_owner_name == bob_str
+    assert bob37_yao_cell.penny == 1
+    assert bob37_yao_cell.quota == 150
+    assert bob37_zia_cell.ancestors == [zia_str]
+    assert bob37_zia_cell.event_int == 33
+    assert bob37_zia_cell.celldepth == 0
+    assert bob37_zia_cell.deal_owner_name == bob_str
+    assert bob37_zia_cell.penny == 1
+    assert bob37_zia_cell.quota == 150
+    gen_bob37_quota_ledger = bob37_cell.get_budevents_quota_ledger()
+    gen_bob37_bob_quota_ledger = bob37_bob_cell.get_budevents_quota_ledger()
+    gen_bob37_yao_quota_ledger = bob37_yao_cell.get_budevents_quota_ledger()
+    gen_bob37_zia_quota_ledger = bob37_zia_cell.get_budevents_quota_ledger()
+    assert gen_bob37_quota_ledger == {bob_str: 150, yao_str: 150, zia_str: 150}
+    assert gen_bob37_bob_quota_ledger == {bob_str: 50, yao_str: 50, zia_str: 50}
+    assert gen_bob37_yao_quota_ledger == {zia_str: 150}
+    assert gen_bob37_zia_quota_ledger == {bob_str: 75, yao_str: 75}
 
 
 def test_create_deal_tree_Scenaro4_LedgerDepth1_OneOwnerHasNoPast_budevent(
@@ -276,27 +241,15 @@ def test_create_deal_tree_Scenaro4_LedgerDepth1_OneOwnerHasNoPast_budevent(
     yao_str = "Yao"
     zia_str = "Zia"
     tp37 = 37  # timepoint
-    deal1_quota = 450
-    deal1_celldepth = 1
+    x_quota = 450
+    x_celldepth = 1
     event33 = 33
     event44 = 44
     event55 = 55
     event66 = 66
-    cell_node = {
-        "ancestors": [bob_str],
-        event_int_str(): event55,
-        celldepth_str(): deal1_celldepth,
-        "deal_owner_name": bob_str,
-        penny_str(): 1,
-        quota_str(): deal1_quota,
-    }
-    a23_bob_ledger_state_path = node_path(
-        fisc_mstr_dir=fisc_mstr_dir,
-        fisc_title=a23_str,
-        owner_name=bob_str,
-        time_int=tp37,
-    )
-    save_json(a23_bob_ledger_state_path, None, cell_node)
+    x_cell = cellunit_shop(bob_str, [], event55, x_celldepth, quota=x_quota)
+    bob37_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [])
+    cellunit_save_to_dir(bob37_dir, x_cell)
     bob_accts = [[yao_str], [bob_str], [zia_str]]
     yao_accts = [[zia_str]]
     zia_accts = [[bob_str], [yao_str]]
@@ -307,60 +260,50 @@ def test_create_deal_tree_Scenaro4_LedgerDepth1_OneOwnerHasNoPast_budevent(
     assert os_path_exists(bob_e55_path)
     assert os_path_exists(yao_e44_path)
     assert os_path_exists(zia_e66_path)
-    tp37_dir = node_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [])
-    tp37_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [])
-    tp37_bob_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
-    tp37_yao_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
-    tp37_zia_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [zia_str])
-    tp37_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37)
-    tp37_bob_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
-    tp37_yao_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
-    tp37_zia_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37, [zia_str])
-    assert os_path_exists(tp37_node_path)
-    assert os_path_exists(tp37_bob_node_path) is False
-    assert os_path_exists(tp37_yao_node_path) is False
-    assert os_path_exists(tp37_zia_node_path) is False
-    assert os_path_exists(tp37_quota) is False
-    assert os_path_exists(tp37_bob_quota) is False
-    assert os_path_exists(tp37_yao_quota) is False
-    assert os_path_exists(tp37_zia_quota) is False
-    assert count_dirs_files(tp37_dir) == 1
+    bob37_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [])
+    bob37_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [])
+    bob37_bob_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
+    bob37_yao_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
+    bob37_zia_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [zia_str])
+    assert os_path_exists(bob37_node_path)
+    assert os_path_exists(bob37_bob_node_path) is False
+    assert os_path_exists(bob37_yao_node_path) is False
+    assert os_path_exists(bob37_zia_node_path) is False
 
     # WHEN
     create_deal_tree(fisc_mstr_dir, a23_str, bob_str, tp37)
 
     # THEN
-    assert os_path_exists(tp37_quota)
-    assert open_json(tp37_quota) == {bob_str: 150, yao_str: 150, zia_str: 150}
-    print(f"{tp37_bob_node_path=}")
-    print(f"{tp37_yao_node_path=}")
-    print(f"{tp37_zia_node_path=}")
-    assert os_path_exists(tp37_node_path)
-    assert os_path_exists(tp37_bob_node_path)
-    assert os_path_exists(tp37_yao_node_path)
-    assert os_path_exists(tp37_zia_node_path) is False
-    assert os_path_exists(tp37_quota)
-    assert os_path_exists(tp37_bob_quota)
-    assert os_path_exists(tp37_yao_quota)
-    assert os_path_exists(tp37_zia_quota) is False
-    assert count_dirs_files(tp37_dir) == 8
-    bob_tp37_bob_dict = open_json(tp37_bob_node_path)
-    assert bob_tp37_bob_dict.get("ancestors") == [bob_str, bob_str]
-    assert bob_tp37_bob_dict.get("event_int") == 55
-    assert bob_tp37_bob_dict.get("celldepth") == 0
-    assert bob_tp37_bob_dict.get("deal_owner_name") == bob_str
-    assert bob_tp37_bob_dict.get("penny") == 1
-    assert bob_tp37_bob_dict.get("quota") == 150
-    bob_tp37_yao_dict = open_json(tp37_yao_node_path)
-    assert bob_tp37_yao_dict.get("ancestors") == [bob_str, yao_str]
-    assert bob_tp37_yao_dict.get("event_int") == 44
-    assert bob_tp37_yao_dict.get("celldepth") == 0
-    assert bob_tp37_yao_dict.get("deal_owner_name") == bob_str
-    assert bob_tp37_yao_dict.get("penny") == 1
-    assert bob_tp37_yao_dict.get("quota") == 150
-    assert open_json(tp37_quota) == {bob_str: 150, yao_str: 150, zia_str: 150}
-    assert open_json(tp37_bob_quota) == {bob_str: 50, yao_str: 50, zia_str: 50}
-    assert open_json(tp37_yao_quota) == {zia_str: 150}
+    print(f"{bob37_bob_node_path=}")
+    print(f"{bob37_yao_node_path=}")
+    print(f"{bob37_zia_node_path=}")
+    assert os_path_exists(bob37_node_path)
+    assert os_path_exists(bob37_bob_node_path)
+    assert os_path_exists(bob37_yao_node_path)
+    assert os_path_exists(bob37_zia_node_path) is False
+    bob37_bob_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
+    bob37_yao_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
+    bob37_cell = cellunit_get_from_dir(bob37_dir)
+    bob37_bob_cell = cellunit_get_from_dir(bob37_bob_dir)
+    bob37_yao_cell = cellunit_get_from_dir(bob37_yao_dir)
+    assert bob37_bob_cell.ancestors == [bob_str]
+    assert bob37_bob_cell.event_int == 55
+    assert bob37_bob_cell.celldepth == 0
+    assert bob37_bob_cell.deal_owner_name == bob_str
+    assert bob37_bob_cell.penny == 1
+    assert bob37_bob_cell.quota == 150
+    assert bob37_yao_cell.ancestors == [yao_str]
+    assert bob37_yao_cell.event_int == 44
+    assert bob37_yao_cell.celldepth == 0
+    assert bob37_yao_cell.deal_owner_name == bob_str
+    assert bob37_yao_cell.penny == 1
+    assert bob37_yao_cell.quota == 150
+    gen_bob37_quota_ledger = bob37_cell.get_budevents_quota_ledger()
+    gen_bob37_bob_quota_ledger = bob37_bob_cell.get_budevents_quota_ledger()
+    gen_bob37_yao_quota_ledger = bob37_yao_cell.get_budevents_quota_ledger()
+    assert gen_bob37_quota_ledger == {bob_str: 150, yao_str: 150, zia_str: 150}
+    assert gen_bob37_bob_quota_ledger == {bob_str: 50, yao_str: 50, zia_str: 50}
+    assert gen_bob37_yao_quota_ledger == {zia_str: 150}
 
 
 def test_create_deal_tree_Scenaro5_LedgerDepth1_ZeroQuotaDoesNotGetCreated(
@@ -373,26 +316,14 @@ def test_create_deal_tree_Scenaro5_LedgerDepth1_ZeroQuotaDoesNotGetCreated(
     yao_str = "Yao"
     zia_str = "Zia"
     tp37 = 37  # timepoint
-    deal1_quota = 2
-    deal1_celldepth = 1
+    x_quota = 2
+    x_celldepth = 1
     event33 = 33
     event44 = 44
     event55 = 55
-    cell_node = {
-        "ancestors": [bob_str],
-        event_int_str(): event55,
-        celldepth_str(): deal1_celldepth,
-        "deal_owner_name": bob_str,
-        penny_str(): 1,
-        quota_str(): deal1_quota,
-    }
-    a23_bob_ledger_state_path = node_path(
-        fisc_mstr_dir=fisc_mstr_dir,
-        fisc_title=a23_str,
-        owner_name=bob_str,
-        time_int=tp37,
-    )
-    save_json(a23_bob_ledger_state_path, None, cell_node)
+    x_cell = cellunit_shop(bob_str, [], event55, x_celldepth, quota=x_quota)
+    bob37_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [])
+    cellunit_save_to_dir(bob37_dir, x_cell)
     bob_accts = [[yao_str], [bob_str], [zia_str]]
     yao_accts = [[zia_str]]
     zia_accts = [[bob_str], [yao_str]]
@@ -403,43 +334,36 @@ def test_create_deal_tree_Scenaro5_LedgerDepth1_ZeroQuotaDoesNotGetCreated(
     assert os_path_exists(bob_e55_path)
     assert os_path_exists(yao_e44_path)
     assert os_path_exists(zia_e33_path)
-    tp37_dir = node_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [])
-    tp37_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [])
-    tp37_bob_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
-    tp37_yao_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
-    tp37_zia_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [zia_str])
-    tp37_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37)
-    tp37_bob_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
-    tp37_yao_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
-    tp37_zia_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37, [zia_str])
-    assert os_path_exists(tp37_node_path)
-    assert os_path_exists(tp37_bob_node_path) is False
-    assert os_path_exists(tp37_yao_node_path) is False
-    assert os_path_exists(tp37_zia_node_path) is False
-    assert os_path_exists(tp37_quota) is False
-    assert os_path_exists(tp37_bob_quota) is False
-    assert os_path_exists(tp37_yao_quota) is False
-    assert os_path_exists(tp37_zia_quota) is False
-    assert count_dirs_files(tp37_dir) == 1
+    bob37_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [])
+    bob37_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [])
+    bob37_bob_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
+    bob37_yao_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
+    bob37_zia_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [zia_str])
+    assert os_path_exists(bob37_node_path)
+    assert os_path_exists(bob37_bob_node_path) is False
+    assert os_path_exists(bob37_yao_node_path) is False
+    assert os_path_exists(bob37_zia_node_path) is False
 
     # WHEN
     create_deal_tree(fisc_mstr_dir, a23_str, bob_str, tp37)
 
     # THEN
-    assert os_path_exists(tp37_quota)
-    assert open_json(tp37_quota) == {bob_str: 0, yao_str: 1, zia_str: 1}
-    print(f"{tp37_bob_node_path=}")
-    print(f"{tp37_yao_node_path=}")
-    print(f"{tp37_zia_node_path=}")
-    assert os_path_exists(tp37_node_path)
-    assert os_path_exists(tp37_bob_node_path) is False
-    assert os_path_exists(tp37_yao_node_path)
-    assert os_path_exists(tp37_zia_node_path)
-    assert os_path_exists(tp37_quota)
-    assert os_path_exists(tp37_bob_quota) is False
-    assert os_path_exists(tp37_yao_quota)
-    assert os_path_exists(tp37_zia_quota)
-    assert count_dirs_files(tp37_dir) == 8
-    assert open_json(tp37_quota) == {bob_str: 0, yao_str: 1, zia_str: 1}
-    assert open_json(tp37_yao_quota) == {zia_str: 1}
-    assert open_json(tp37_zia_quota) == {bob_str: 1, yao_str: 0}
+    print(f"{bob37_bob_node_path=}")
+    print(f"{bob37_yao_node_path=}")
+    print(f"{bob37_zia_node_path=}")
+    assert os_path_exists(bob37_node_path)
+    assert os_path_exists(bob37_bob_node_path) is False
+    assert os_path_exists(bob37_yao_node_path)
+    assert os_path_exists(bob37_zia_node_path)
+    bob37_bob_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
+    bob37_yao_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
+    bob37_zia_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [zia_str])
+    bob37_cell = cellunit_get_from_dir(bob37_dir)
+    bob37_yao_cell = cellunit_get_from_dir(bob37_yao_dir)
+    bob37_zia_cell = cellunit_get_from_dir(bob37_zia_dir)
+    gen_bob37_quota_ledger = bob37_cell.get_budevents_quota_ledger()
+    gen_bob37_yao_quota_ledger = bob37_yao_cell.get_budevents_quota_ledger()
+    gen_bob37_zia_quota_ledger = bob37_zia_cell.get_budevents_quota_ledger()
+    assert gen_bob37_quota_ledger == {bob_str: 0, yao_str: 1, zia_str: 1}
+    assert gen_bob37_yao_quota_ledger == {zia_str: 1}
+    assert gen_bob37_zia_quota_ledger == {bob_str: 1, yao_str: 0}

--- a/src/f07_fisc/test_fisc_z_deal_trees/test_fisc_create_deal_tree.py
+++ b/src/f07_fisc/test_fisc_z_deal_trees/test_fisc_create_deal_tree.py
@@ -4,7 +4,7 @@ from src.f04_gift.atom_config import event_int_str, penny_str
 from src.f05_listen.cell import cellunit_shop
 from src.f05_listen.hub_path import (
     create_cell_dir_path as cell_dir,
-    create_cell_node_json_path as node_path,
+    create_cell_json_path as node_path,
 )
 from src.f05_listen.hub_tool import (
     save_arbitrary_budevent as save_budevent,

--- a/src/f10_etl/transformers.py
+++ b/src/f10_etl/transformers.py
@@ -39,7 +39,7 @@ from src.f07_fisc.fisc import (
 )
 from src.f07_fisc.fisc_tool import (
     create_fisc_owners_deal_trees,
-    uphill_cell_node_budevent_facts,
+    set_deal_trees_found_facts,
     modify_deal_trees_create_boss_facts,
 )
 from src.f07_fisc.fisc_config import get_fisc_dimens
@@ -900,7 +900,7 @@ def etl_fisc_ote1_agg_csvs2jsons(fisc_mstr_dir: str):
         save_json(json_path, None, x_dict)
 
 
-def etl_create_root_cell_nodes(fisc_mstr_dir: str):
+def etl_create_deals_root_cells(fisc_mstr_dir: str):
     fiscs_dir = create_path(fisc_mstr_dir, "fiscs")
     for fisc_title in get_level1_dirs(fiscs_dir):
         fisc_dir = create_path(fiscs_dir, fisc_title)
@@ -908,7 +908,7 @@ def etl_create_root_cell_nodes(fisc_mstr_dir: str):
         if os_path_exists(ote1_json_path):
             ote1_dict = open_json(ote1_json_path)
             x_fiscunit = fiscunit_get_from_standard(fisc_mstr_dir, fisc_title)
-            x_fiscunit.create_root_cell_nodes(ote1_dict)
+            x_fiscunit.create_deals_root_cells(ote1_dict)
 
 
 def etl_create_fisc_deal_trees(fisc_mstr_dir: str):
@@ -917,10 +917,10 @@ def etl_create_fisc_deal_trees(fisc_mstr_dir: str):
         create_fisc_owners_deal_trees(fisc_mstr_dir, fisc_title)
 
 
-def etl_uphill_cell_node_budevent_facts(fisc_mstr_dir: str):
+def etl_set_deal_trees_found_facts(fisc_mstr_dir: str):
     fiscs_dir = create_path(fisc_mstr_dir, "fiscs")
     for fisc_title in get_level1_dirs(fiscs_dir):
-        uphill_cell_node_budevent_facts(fisc_mstr_dir, fisc_title)
+        set_deal_trees_found_facts(fisc_mstr_dir, fisc_title)
 
 
 def etl_modify_deal_trees_with_boss_facts(fisc_mstr_dir: str):

--- a/src/f11_world/test_08_create_balances/test_world_etl08_00_create_root_deal_nodes.py
+++ b/src/f11_world/test_08_create_balances/test_world_etl08_00_create_root_deal_nodes.py
@@ -9,7 +9,7 @@ from src.f04_gift.atom_config import event_int_str, penny_str
 from src.f05_listen.hub_path import (
     create_fisc_json_path,
     create_owners_dir_path,
-    create_cell_node_json_path,
+    create_cell_json_path,
     create_fisc_ote1_json_path,
 )
 from src.f07_fisc.fisc import fiscunit_shop
@@ -18,7 +18,7 @@ from src.f11_world.examples.world_env import env_dir_setup_cleanup
 from os.path import exists as os_path_exists
 
 
-def test_WorldUnit_create_root_cell_nodes_Scenaro0_DealEmpty(
+def test_WorldUnit_create_deals_root_cells_Scenaro0_DealEmpty(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -33,13 +33,13 @@ def test_WorldUnit_create_root_cell_nodes_Scenaro0_DealEmpty(
     assert count_dirs_files(a23_owners_path) == 0
 
     # WHEN
-    fizz_world.create_root_cell_nodes()
+    fizz_world.create_deals_root_cells()
 
     # THEN
     assert count_dirs_files(a23_owners_path) == 0
 
 
-def test_WorldUnit_create_root_cell_nodes_Scenaro1_DealExists(
+def test_WorldUnit_create_deals_root_cells_Scenaro1_DealExists(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -67,26 +67,26 @@ def test_WorldUnit_create_root_cell_nodes_Scenaro1_DealExists(
     save_json(a23_ote1_json_path, None, a23_ote1_dict)
     assert os_path_exists(a23_ote1_json_path)
 
-    # timepoint37 cell_node path
-    tp37_cell_node_json_path = create_cell_node_json_path(
+    # timepoint37 cell path
+    tp37_cell_json_path = create_cell_json_path(
         fisc_mstr_dir, a23_str, bob_str, timepoint37
     )
-    assert os_path_exists(tp37_cell_node_json_path) is False
+    assert os_path_exists(tp37_cell_json_path) is False
 
     # WHEN
-    fizz_world.create_root_cell_nodes()
+    fizz_world.create_deals_root_cells()
 
     # THEN
-    assert os_path_exists(tp37_cell_node_json_path)
-    ledger_state_dict = open_json(tp37_cell_node_json_path)
+    assert os_path_exists(tp37_cell_json_path)
+    ledger_state_dict = open_json(tp37_cell_json_path)
     print(f"{ledger_state_dict=}")
     assert ledger_state_dict.get(celldepth_str()) == DEFAULT_celldepth
-    assert ledger_state_dict.get(owner_name_str()) == bob_str
+    assert ledger_state_dict.get("deal_owner_name") == bob_str
     assert ledger_state_dict.get(quota_str()) == deal1_quota
     assert ledger_state_dict.get(event_int_str()) == event3
 
 
-def test_WorldUnit_create_root_cell_nodes_Scenaro2_DealExistsButNoBudExistsInEventsPast(
+def test_WorldUnit_create_deals_root_cells_Scenaro2_DealExistsButNoBudExistsInEventsPast(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -114,26 +114,26 @@ def test_WorldUnit_create_root_cell_nodes_Scenaro2_DealExistsButNoBudExistsInEve
     print(f"{a23_ote1_json_path=}")
     save_json(a23_ote1_json_path, None, a23_ote1_dict)
     assert os_path_exists(a23_ote1_json_path)
-    tp37_cell_node_json_path = create_cell_node_json_path(
+    tp37_cell_json_path = create_cell_json_path(
         fisc_mstr_dir, a23_str, bob_str, timepoint37
     )
-    assert os_path_exists(tp37_cell_node_json_path) is False
+    assert os_path_exists(tp37_cell_json_path) is False
 
     # WHEN
-    fizz_world.create_root_cell_nodes()
+    fizz_world.create_deals_root_cells()
 
     # THEN
-    assert os_path_exists(tp37_cell_node_json_path)
-    ledger_state_dict = open_json(tp37_cell_node_json_path)
+    assert os_path_exists(tp37_cell_json_path)
+    ledger_state_dict = open_json(tp37_cell_json_path)
     print(f"{ledger_state_dict=}")
     assert ledger_state_dict.get("ancestors") == [bob_str]
     assert not ledger_state_dict.get(event_int_str())
     assert ledger_state_dict.get(celldepth_str()) == DEFAULT_celldepth
-    assert ledger_state_dict.get(owner_name_str()) == bob_str
+    assert ledger_state_dict.get("deal_owner_name") == bob_str
     assert ledger_state_dict.get(quota_str()) == deal1_quota
 
 
-def test_WorldUnit_create_root_cell_nodes_Scenaro3_DealExistsNotPerfectMatch_time_int_event_int(
+def test_WorldUnit_create_deals_root_cells_Scenaro3_DealExistsNotPerfectMatch_time_int_event_int(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -167,23 +167,23 @@ def test_WorldUnit_create_root_cell_nodes_Scenaro3_DealExistsNotPerfectMatch_tim
     save_json(a23_ote1_json_path, None, a23_ote1_dict)
     assert os_path_exists(a23_ote1_json_path)
 
-    # destination of cell_node json
-    tp37_cell_node_json_path = create_cell_node_json_path(
+    # destination of cell json
+    tp37_cell_json_path = create_cell_json_path(
         fisc_mstr_dir, a23_str, bob_str, timepoint37
     )
-    assert os_path_exists(tp37_cell_node_json_path) is False
+    assert os_path_exists(tp37_cell_json_path) is False
 
     # WHEN
-    fizz_world.create_root_cell_nodes()
+    fizz_world.create_deals_root_cells()
 
     # THEN
-    assert os_path_exists(tp37_cell_node_json_path)
-    ledger_state_dict = open_json(tp37_cell_node_json_path)
+    assert os_path_exists(tp37_cell_json_path)
+    ledger_state_dict = open_json(tp37_cell_json_path)
     assert ledger_state_dict.get("ancestors") == [bob_str]
     assert ledger_state_dict.get(event_int_str()) == event3
     assert ledger_state_dict.get(celldepth_str()) == deal1_celldepth
-    assert ledger_state_dict.get(owner_name_str()) == bob_str
+    assert ledger_state_dict.get("deal_owner_name") == bob_str
     assert ledger_state_dict.get(penny_str()) == a23_penny
     assert ledger_state_dict.get(quota_str()) == deal1_quota
     print(ledger_state_dict.get("ancestors"))
-    assert len(ledger_state_dict) == 6
+    assert len(ledger_state_dict) == 10

--- a/src/f11_world/test_08_create_balances/test_world_etl08_01_create_deal_trees.py
+++ b/src/f11_world/test_08_create_balances/test_world_etl08_01_create_deal_trees.py
@@ -4,7 +4,7 @@ from src.f04_gift.atom_config import event_int_str, penny_str
 from src.f05_listen.cell import cellunit_shop
 from src.f05_listen.hub_path import (
     create_cell_dir_path as cell_dir,
-    create_cell_node_json_path as node_path,
+    create_cell_json_path as node_path,
 )
 from src.f05_listen.hub_tool import (
     save_arbitrary_budevent as save_budevent,

--- a/src/f11_world/test_08_create_balances/test_world_etl08_01_create_deal_trees.py
+++ b/src/f11_world/test_08_create_balances/test_world_etl08_01_create_deal_trees.py
@@ -1,18 +1,22 @@
-from src.f00_instrument.file import open_json, save_json, count_dirs_files
+from src.f00_instrument.file import open_json, save_json, create_path
 from src.f01_road.deal import owner_name_str, quota_str, celldepth_str
 from src.f04_gift.atom_config import event_int_str, penny_str
+from src.f05_listen.cell import cellunit_shop
 from src.f05_listen.hub_path import (
-    create_cell_dir_path as node_dir,
+    create_cell_dir_path as cell_dir,
     create_cell_node_json_path as node_path,
-    create_cell_quota_ledger_path as quota_path,
 )
-from src.f05_listen.hub_tool import save_arbitrary_budevent as save_budevent
+from src.f05_listen.hub_tool import (
+    save_arbitrary_budevent as save_budevent,
+    cellunit_save_to_dir,
+    cellunit_get_from_dir,
+)
 from src.f11_world.world import worldunit_shop
 from src.f11_world.examples.world_env import env_dir_setup_cleanup
 from os.path import exists as os_path_exists
 
 
-def test_WorldUnit_create_fisc_deal_trees_Scenaro0_timepoint_Empty(
+def test_worldunit_create_fisc_deal_trees_Scenaro0_timepoint_Empty(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -22,20 +26,18 @@ def test_WorldUnit_create_fisc_deal_trees_Scenaro0_timepoint_Empty(
     bob_str = "Bob"
     tp37 = 37
 
-    a23_bob_tp37_path = node_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [])
+    a23_bob_tp37_path = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [])
     print(f"{a23_bob_tp37_path=}")
-    assert count_dirs_files(a23_bob_tp37_path) == 0
+    assert os_path_exists(a23_bob_tp37_path) is False
 
     # WHEN
     fizz_world.create_fisc_deal_trees()
 
     # THEN
-    assert count_dirs_files(a23_bob_tp37_path) == 0
+    assert os_path_exists(a23_bob_tp37_path) is False
 
 
-def test_WorldUnit_create_fisc_deal_trees_Scenaro1_LedgerDepth0(
-    env_dir_setup_cleanup,
-):
+def test_worldunit_create_fisc_deal_trees_Scenaro1_LedgerDepth0(env_dir_setup_cleanup):
     # ESTABLISH
     fizz_world = worldunit_shop("fizz")
     fisc_mstr_dir = fizz_world._fisc_mstr_dir
@@ -46,39 +48,22 @@ def test_WorldUnit_create_fisc_deal_trees_Scenaro1_LedgerDepth0(
     deal1_quota = 450
     deal1_celldepth = 0
     event56 = 56
-    cell_node = {
-        "ancestors": [],
-        celldepth_str(): deal1_celldepth,
-        "deal_owner_name": bob_str,
-        event_int_str(): event56,
-        quota_str(): deal1_quota,
-    }
-    a23_bob_ledger_state_path = node_path(
-        fisc_mstr_dir=fisc_mstr_dir,
-        fisc_title=a23_str,
-        owner_name=bob_str,
-        time_int=tp37,
-    )
-    save_json(a23_bob_ledger_state_path, None, cell_node)
+    x_cell = cellunit_shop(bob_str, [], event56, deal1_celldepth, quota=deal1_quota)
+    bob37_root_cell_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [])
+    cellunit_save_to_dir(bob37_root_cell_dir, x_cell)
     save_budevent(fisc_mstr_dir, a23_str, bob_str, event56, [[yao_str], [bob_str]])
-
-    bob_tp37_quota_ledger_path = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37)
-    bob_tp37_dir = node_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [])
-    assert os_path_exists(bob_tp37_quota_ledger_path) is False
-    assert count_dirs_files(bob_tp37_dir) == 1
+    assert cellunit_get_from_dir(bob37_root_cell_dir).get_budevents_quota_ledger() == {}
 
     # WHEN
     fizz_world.create_fisc_deal_trees()
 
     # THEN
-    assert os_path_exists(bob_tp37_quota_ledger_path)
-    assert open_json(bob_tp37_quota_ledger_path) == {"Bob": 225, "Yao": 225}
-    assert count_dirs_files(bob_tp37_dir) == 2
+    bob37_root_cell = cellunit_get_from_dir(bob37_root_cell_dir)
+    generated_bob37_quota_ledger = bob37_root_cell.get_budevents_quota_ledger()
+    assert generated_bob37_quota_ledger == {"Bob": 225, yao_str: 225}
 
 
-def test_WorldUnit_create_fisc_deal_trees_Scenaro2_LedgerDepth1(
-    env_dir_setup_cleanup,
-):
+def test_worldunit_create_fisc_deal_trees_Scenaro2_LedgerDepth1(env_dir_setup_cleanup):
     # ESTABLISH
     fizz_world = worldunit_shop("fizz")
     fisc_mstr_dir = fizz_world._fisc_mstr_dir
@@ -87,24 +72,12 @@ def test_WorldUnit_create_fisc_deal_trees_Scenaro2_LedgerDepth1(
     yao_str = "Yao"
     zia_str = "Zia"
     tp37 = 37  # timepoint
-    deal1_quota = 450
-    deal1_celldepth = 1
+    x_quota = 450
+    x_celldepth = 1
     event56 = 56
-    cell_node = {
-        "ancestors": [bob_str],
-        event_int_str(): event56,
-        celldepth_str(): deal1_celldepth,
-        owner_name_str(): bob_str,
-        penny_str(): 1,
-        quota_str(): deal1_quota,
-    }
-    a23_bob_ledger_state_path = node_path(
-        fisc_mstr_dir=fisc_mstr_dir,
-        fisc_title=a23_str,
-        owner_name=bob_str,
-        time_int=tp37,
-    )
-    save_json(a23_bob_ledger_state_path, None, cell_node)
+    x_cell = cellunit_shop(bob_str, [], event56, x_celldepth, quota=x_quota)
+    bob37_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [])
+    cellunit_save_to_dir(bob37_dir, x_cell)
     bob_accts = [[yao_str], [bob_str], [zia_str]]
     yao_accts = [[zia_str]]
     zia_accts = [[bob_str], [yao_str]]
@@ -114,71 +87,69 @@ def test_WorldUnit_create_fisc_deal_trees_Scenaro2_LedgerDepth1(
     assert os_path_exists(bob_e56_path)
     assert os_path_exists(yao_e56_path)
     assert os_path_exists(zia_e56_path)
-    tp37_dir = node_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [])
-    bob_tp37_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [])
-    bob_tp37_bob_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
-    bob_tp37_yao_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
-    bob_tp37_zia_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [zia_str])
-    tp37_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37)
-    tp37_bob_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
-    tp37_yao_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
-    tp37_zia_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37, [zia_str])
-    assert os_path_exists(bob_tp37_node_path)
-    assert os_path_exists(bob_tp37_bob_node_path) is False
-    assert os_path_exists(bob_tp37_yao_node_path) is False
-    assert os_path_exists(bob_tp37_zia_node_path) is False
-    assert os_path_exists(tp37_quota) is False
-    assert os_path_exists(tp37_bob_quota) is False
-    assert os_path_exists(tp37_yao_quota) is False
-    assert os_path_exists(tp37_zia_quota) is False
-    assert count_dirs_files(tp37_dir) == 1
+    bob37_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [])
+    bob37_bob_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
+    bob37_yao_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
+    bob37_zia_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [zia_str])
+    assert os_path_exists(bob37_node_path)
+    assert os_path_exists(bob37_bob_node_path) is False
+    assert os_path_exists(bob37_yao_node_path) is False
+    assert os_path_exists(bob37_zia_node_path) is False
+    assert cellunit_get_from_dir(bob37_dir).get_budevents_quota_ledger() == {}
 
     # WHEN
     fizz_world.create_fisc_deal_trees()
 
     # THEN
-    assert os_path_exists(tp37_quota)
-    assert open_json(tp37_quota) == {bob_str: 150, yao_str: 150, zia_str: 150}
-    print(f"{bob_tp37_bob_node_path=}")
-    print(f"{bob_tp37_yao_node_path=}")
-    print(f"{bob_tp37_zia_node_path=}")
-    assert os_path_exists(bob_tp37_node_path)
-    assert os_path_exists(bob_tp37_bob_node_path)
-    assert os_path_exists(bob_tp37_yao_node_path)
-    assert os_path_exists(bob_tp37_zia_node_path)
-    assert os_path_exists(tp37_quota)
-    assert os_path_exists(tp37_bob_quota)
-    assert os_path_exists(tp37_yao_quota)
-    assert os_path_exists(tp37_zia_quota)
-    assert count_dirs_files(tp37_dir) == 11
-    bob_tp37_bob_dict = open_json(bob_tp37_bob_node_path)
-    assert bob_tp37_bob_dict.get("ancestors") == [bob_str, bob_str]
-    assert bob_tp37_bob_dict.get("event_int") == 56
-    assert bob_tp37_bob_dict.get("celldepth") == 0
-    assert bob_tp37_bob_dict.get("deal_owner_name") == bob_str
-    assert bob_tp37_bob_dict.get("penny") == 1
-    assert bob_tp37_bob_dict.get("quota") == 150
-    bob_tp37_yao_dict = open_json(bob_tp37_yao_node_path)
-    assert bob_tp37_yao_dict.get("ancestors") == [bob_str, yao_str]
-    assert bob_tp37_yao_dict.get("event_int") == 56
-    assert bob_tp37_yao_dict.get("celldepth") == 0
-    assert bob_tp37_yao_dict.get("deal_owner_name") == bob_str
-    assert bob_tp37_yao_dict.get("penny") == 1
-    assert bob_tp37_yao_dict.get("quota") == 150
-    bob_tp37_zia_dict = open_json(bob_tp37_zia_node_path)
-    assert bob_tp37_zia_dict.get("ancestors") == [bob_str, zia_str]
-    assert bob_tp37_zia_dict.get("event_int") == 56
-    assert bob_tp37_zia_dict.get("celldepth") == 0
-    assert bob_tp37_zia_dict.get("deal_owner_name") == bob_str
-    assert bob_tp37_zia_dict.get("penny") == 1
-    assert bob_tp37_zia_dict.get("quota") == 150
-    assert open_json(tp37_quota) == {"Bob": 150, "Yao": 150, "Zia": 150}
-    assert open_json(tp37_bob_quota) == {"Bob": 50, "Yao": 50, "Zia": 50}
-    assert open_json(tp37_yao_quota) == {"Zia": 150}
-    assert open_json(tp37_zia_quota) == {"Bob": 75, "Yao": 75}
+    print(f"{bob37_bob_node_path=}")
+    print(f"{bob37_yao_node_path=}")
+    print(f"{bob37_zia_node_path=}")
+    assert os_path_exists(bob37_node_path)
+    assert os_path_exists(bob37_bob_node_path)
+    assert os_path_exists(bob37_yao_node_path)
+    assert os_path_exists(bob37_zia_node_path)
+    bob37_bob_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
+    bob37_yao_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
+    bob37_zia_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [zia_str])
+    bob37_cell = cellunit_get_from_dir(bob37_dir)
+    bob37_bob_cell = cellunit_get_from_dir(bob37_bob_dir)
+    bob37_yao_cell = cellunit_get_from_dir(bob37_yao_dir)
+    bob37_zia_cell = cellunit_get_from_dir(bob37_zia_dir)
+    assert bob37_cell.ancestors == []
+    assert bob37_cell.event_int == 56
+    assert bob37_cell.celldepth == 1
+    assert bob37_cell.deal_owner_name == bob_str
+    assert bob37_cell.penny == 1
+    assert bob37_cell.quota == 450
+    assert bob37_bob_cell.ancestors == [bob_str]
+    assert bob37_bob_cell.event_int == 56
+    assert bob37_bob_cell.celldepth == 0
+    assert bob37_bob_cell.deal_owner_name == bob_str
+    assert bob37_bob_cell.penny == 1
+    assert bob37_bob_cell.quota == 150
+    assert bob37_yao_cell.ancestors == [yao_str]
+    assert bob37_yao_cell.event_int == 56
+    assert bob37_yao_cell.celldepth == 0
+    assert bob37_yao_cell.deal_owner_name == bob_str
+    assert bob37_yao_cell.penny == 1
+    assert bob37_yao_cell.quota == 150
+    assert bob37_zia_cell.ancestors == [zia_str]
+    assert bob37_zia_cell.event_int == 56
+    assert bob37_zia_cell.celldepth == 0
+    assert bob37_zia_cell.deal_owner_name == bob_str
+    assert bob37_zia_cell.penny == 1
+    assert bob37_zia_cell.quota == 150
+    gen_bob37_quota_ledger = bob37_cell.get_budevents_quota_ledger()
+    gen_bob37_bob_quota_ledger = bob37_bob_cell.get_budevents_quota_ledger()
+    gen_bob37_yao_quota_ledger = bob37_yao_cell.get_budevents_quota_ledger()
+    gen_bob37_zia_quota_ledger = bob37_zia_cell.get_budevents_quota_ledger()
+    assert gen_bob37_quota_ledger == {bob_str: 150, yao_str: 150, zia_str: 150}
+    assert gen_bob37_bob_quota_ledger == {bob_str: 50, yao_str: 50, zia_str: 50}
+    assert gen_bob37_yao_quota_ledger == {zia_str: 150}
+    assert gen_bob37_zia_quota_ledger == {bob_str: 75, yao_str: 75}
 
 
-def test_WorldUnit_create_fisc_deal_trees_Scenaro3_LedgerDepth1_MostRecentEvent(
+def test_worldunit_create_fisc_deal_trees_Scenaro3_LedgerDepth1_MostRecentEvent(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -189,26 +160,14 @@ def test_WorldUnit_create_fisc_deal_trees_Scenaro3_LedgerDepth1_MostRecentEvent(
     yao_str = "Yao"
     zia_str = "Zia"
     tp37 = 37  # timepoint
-    deal1_quota = 450
-    deal1_celldepth = 1
+    x_quota = 450
+    x_celldepth = 1
     event33 = 33
     event44 = 44
     event55 = 55
-    cell_node = {
-        "ancestors": [bob_str],
-        event_int_str(): event55,
-        celldepth_str(): deal1_celldepth,
-        owner_name_str(): bob_str,
-        penny_str(): 1,
-        quota_str(): deal1_quota,
-    }
-    a23_bob_ledger_state_path = node_path(
-        fisc_mstr_dir=fisc_mstr_dir,
-        fisc_title=a23_str,
-        owner_name=bob_str,
-        time_int=tp37,
-    )
-    save_json(a23_bob_ledger_state_path, None, cell_node)
+    x_cell = cellunit_shop(bob_str, [], event55, x_celldepth, quota=x_quota)
+    bob37_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [])
+    cellunit_save_to_dir(bob37_dir, x_cell)
     bob_accts = [[yao_str], [bob_str], [zia_str]]
     yao_accts = [[zia_str]]
     zia_accts = [[bob_str], [yao_str]]
@@ -219,71 +178,68 @@ def test_WorldUnit_create_fisc_deal_trees_Scenaro3_LedgerDepth1_MostRecentEvent(
     assert os_path_exists(bob_e55_path)
     assert os_path_exists(yao_e44_path)
     assert os_path_exists(zia_e33_path)
-    tp37_dir = node_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [])
-    tp37_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [])
-    tp37_bob_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
-    tp37_yao_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
-    tp37_zia_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [zia_str])
-    tp37_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37)
-    tp37_bob_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
-    tp37_yao_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
-    tp37_zia_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37, [zia_str])
-    assert os_path_exists(tp37_node_path)
-    assert os_path_exists(tp37_bob_node_path) is False
-    assert os_path_exists(tp37_yao_node_path) is False
-    assert os_path_exists(tp37_zia_node_path) is False
-    assert os_path_exists(tp37_quota) is False
-    assert os_path_exists(tp37_bob_quota) is False
-    assert os_path_exists(tp37_yao_quota) is False
-    assert os_path_exists(tp37_zia_quota) is False
-    assert count_dirs_files(tp37_dir) == 1
+    bob37_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [])
+    bob37_bob_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
+    bob37_yao_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
+    bob37_zia_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [zia_str])
+    assert os_path_exists(bob37_node_path)
+    assert os_path_exists(bob37_bob_node_path) is False
+    assert os_path_exists(bob37_yao_node_path) is False
+    assert os_path_exists(bob37_zia_node_path) is False
 
     # WHEN
     fizz_world.create_fisc_deal_trees()
 
     # THEN
-    assert os_path_exists(tp37_quota)
-    assert open_json(tp37_quota) == {bob_str: 150, yao_str: 150, zia_str: 150}
-    print(f"{tp37_bob_node_path=}")
-    print(f"{tp37_yao_node_path=}")
-    print(f"{tp37_zia_node_path=}")
-    assert os_path_exists(tp37_node_path)
-    assert os_path_exists(tp37_bob_node_path)
-    assert os_path_exists(tp37_yao_node_path)
-    assert os_path_exists(tp37_zia_node_path)
-    assert os_path_exists(tp37_quota)
-    assert os_path_exists(tp37_bob_quota)
-    assert os_path_exists(tp37_yao_quota)
-    assert os_path_exists(tp37_zia_quota)
-    assert count_dirs_files(tp37_dir) == 11
-    bob_tp37_bob_dict = open_json(tp37_bob_node_path)
-    assert bob_tp37_bob_dict.get("ancestors") == [bob_str, bob_str]
-    assert bob_tp37_bob_dict.get("event_int") == 55
-    assert bob_tp37_bob_dict.get("celldepth") == 0
-    assert bob_tp37_bob_dict.get("deal_owner_name") == bob_str
-    assert bob_tp37_bob_dict.get("penny") == 1
-    assert bob_tp37_bob_dict.get("quota") == 150
-    bob_tp37_yao_dict = open_json(tp37_yao_node_path)
-    assert bob_tp37_yao_dict.get("ancestors") == [bob_str, yao_str]
-    assert bob_tp37_yao_dict.get("event_int") == 44
-    assert bob_tp37_yao_dict.get("celldepth") == 0
-    assert bob_tp37_yao_dict.get("deal_owner_name") == bob_str
-    assert bob_tp37_yao_dict.get("penny") == 1
-    assert bob_tp37_yao_dict.get("quota") == 150
-    bob_tp37_zia_dict = open_json(tp37_zia_node_path)
-    assert bob_tp37_zia_dict.get("ancestors") == [bob_str, zia_str]
-    assert bob_tp37_zia_dict.get("event_int") == 33
-    assert bob_tp37_zia_dict.get("celldepth") == 0
-    assert bob_tp37_zia_dict.get("deal_owner_name") == bob_str
-    assert bob_tp37_zia_dict.get("penny") == 1
-    assert bob_tp37_zia_dict.get("quota") == 150
-    assert open_json(tp37_quota) == {"Bob": 150, "Yao": 150, "Zia": 150}
-    assert open_json(tp37_bob_quota) == {"Bob": 50, "Yao": 50, "Zia": 50}
-    assert open_json(tp37_yao_quota) == {"Zia": 150}
-    assert open_json(tp37_zia_quota) == {"Bob": 75, "Yao": 75}
+    print(f"{bob37_bob_node_path=}")
+    print(f"{bob37_yao_node_path=}")
+    print(f"{bob37_zia_node_path=}")
+    assert os_path_exists(bob37_node_path)
+    assert os_path_exists(bob37_bob_node_path)
+    assert os_path_exists(bob37_yao_node_path)
+    assert os_path_exists(bob37_zia_node_path)
+    bob37_bob_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
+    bob37_yao_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
+    bob37_zia_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [zia_str])
+    bob37_cell = cellunit_get_from_dir(bob37_dir)
+    bob37_bob_cell = cellunit_get_from_dir(bob37_bob_dir)
+    bob37_yao_cell = cellunit_get_from_dir(bob37_yao_dir)
+    bob37_zia_cell = cellunit_get_from_dir(bob37_zia_dir)
+    assert bob37_cell.ancestors == []
+    assert bob37_cell.event_int == 55
+    assert bob37_cell.celldepth == 1
+    assert bob37_cell.deal_owner_name == bob_str
+    assert bob37_cell.penny == 1
+    assert bob37_cell.quota == 450
+    assert bob37_bob_cell.ancestors == [bob_str]
+    assert bob37_bob_cell.event_int == 55
+    assert bob37_bob_cell.celldepth == 0
+    assert bob37_bob_cell.deal_owner_name == bob_str
+    assert bob37_bob_cell.penny == 1
+    assert bob37_bob_cell.quota == 150
+    assert bob37_yao_cell.ancestors == [yao_str]
+    assert bob37_yao_cell.event_int == 44
+    assert bob37_yao_cell.celldepth == 0
+    assert bob37_yao_cell.deal_owner_name == bob_str
+    assert bob37_yao_cell.penny == 1
+    assert bob37_yao_cell.quota == 150
+    assert bob37_zia_cell.ancestors == [zia_str]
+    assert bob37_zia_cell.event_int == 33
+    assert bob37_zia_cell.celldepth == 0
+    assert bob37_zia_cell.deal_owner_name == bob_str
+    assert bob37_zia_cell.penny == 1
+    assert bob37_zia_cell.quota == 150
+    gen_bob37_quota_ledger = bob37_cell.get_budevents_quota_ledger()
+    gen_bob37_bob_quota_ledger = bob37_bob_cell.get_budevents_quota_ledger()
+    gen_bob37_yao_quota_ledger = bob37_yao_cell.get_budevents_quota_ledger()
+    gen_bob37_zia_quota_ledger = bob37_zia_cell.get_budevents_quota_ledger()
+    assert gen_bob37_quota_ledger == {bob_str: 150, yao_str: 150, zia_str: 150}
+    assert gen_bob37_bob_quota_ledger == {bob_str: 50, yao_str: 50, zia_str: 50}
+    assert gen_bob37_yao_quota_ledger == {zia_str: 150}
+    assert gen_bob37_zia_quota_ledger == {bob_str: 75, yao_str: 75}
 
 
-def test_WorldUnit_create_fisc_deal_trees_Scenaro4_LedgerDepth1_OneOwnerHasNoPast_budevent(
+def test_worldunit_create_fisc_deal_trees_Scenaro4_LedgerDepth1_OneOwnerHasNoPast_budevent(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -294,27 +250,15 @@ def test_WorldUnit_create_fisc_deal_trees_Scenaro4_LedgerDepth1_OneOwnerHasNoPas
     yao_str = "Yao"
     zia_str = "Zia"
     tp37 = 37  # timepoint
-    deal1_quota = 450
-    deal1_celldepth = 1
+    x_quota = 450
+    x_celldepth = 1
     event33 = 33
     event44 = 44
     event55 = 55
     event66 = 66
-    cell_node = {
-        "ancestors": [bob_str],
-        event_int_str(): event55,
-        celldepth_str(): deal1_celldepth,
-        owner_name_str(): bob_str,
-        penny_str(): 1,
-        quota_str(): deal1_quota,
-    }
-    a23_bob_ledger_state_path = node_path(
-        fisc_mstr_dir=fisc_mstr_dir,
-        fisc_title=a23_str,
-        owner_name=bob_str,
-        time_int=tp37,
-    )
-    save_json(a23_bob_ledger_state_path, None, cell_node)
+    x_cell = cellunit_shop(bob_str, [], event55, x_celldepth, quota=x_quota)
+    bob37_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [])
+    cellunit_save_to_dir(bob37_dir, x_cell)
     bob_accts = [[yao_str], [bob_str], [zia_str]]
     yao_accts = [[zia_str]]
     zia_accts = [[bob_str], [yao_str]]
@@ -325,63 +269,53 @@ def test_WorldUnit_create_fisc_deal_trees_Scenaro4_LedgerDepth1_OneOwnerHasNoPas
     assert os_path_exists(bob_e55_path)
     assert os_path_exists(yao_e44_path)
     assert os_path_exists(zia_e66_path)
-    tp37_dir = node_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [])
-    tp37_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [])
-    tp37_bob_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
-    tp37_yao_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
-    tp37_zia_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [zia_str])
-    tp37_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37)
-    tp37_bob_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
-    tp37_yao_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
-    tp37_zia_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37, [zia_str])
-    assert os_path_exists(tp37_node_path)
-    assert os_path_exists(tp37_bob_node_path) is False
-    assert os_path_exists(tp37_yao_node_path) is False
-    assert os_path_exists(tp37_zia_node_path) is False
-    assert os_path_exists(tp37_quota) is False
-    assert os_path_exists(tp37_bob_quota) is False
-    assert os_path_exists(tp37_yao_quota) is False
-    assert os_path_exists(tp37_zia_quota) is False
-    assert count_dirs_files(tp37_dir) == 1
+    bob37_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [])
+    bob37_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [])
+    bob37_bob_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
+    bob37_yao_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
+    bob37_zia_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [zia_str])
+    assert os_path_exists(bob37_node_path)
+    assert os_path_exists(bob37_bob_node_path) is False
+    assert os_path_exists(bob37_yao_node_path) is False
+    assert os_path_exists(bob37_zia_node_path) is False
 
     # WHEN
     fizz_world.create_fisc_deal_trees()
 
     # THEN
-    assert os_path_exists(tp37_quota)
-    assert open_json(tp37_quota) == {bob_str: 150, yao_str: 150, zia_str: 150}
-    print(f"{tp37_bob_node_path=}")
-    print(f"{tp37_yao_node_path=}")
-    print(f"{tp37_zia_node_path=}")
-    assert os_path_exists(tp37_node_path)
-    assert os_path_exists(tp37_bob_node_path)
-    assert os_path_exists(tp37_yao_node_path)
-    assert os_path_exists(tp37_zia_node_path) is False
-    assert os_path_exists(tp37_quota)
-    assert os_path_exists(tp37_bob_quota)
-    assert os_path_exists(tp37_yao_quota)
-    assert os_path_exists(tp37_zia_quota) is False
-    assert count_dirs_files(tp37_dir) == 8
-    bob_tp37_bob_dict = open_json(tp37_bob_node_path)
-    assert bob_tp37_bob_dict.get("ancestors") == [bob_str, bob_str]
-    assert bob_tp37_bob_dict.get("event_int") == 55
-    assert bob_tp37_bob_dict.get("celldepth") == 0
-    assert bob_tp37_bob_dict.get("deal_owner_name") == bob_str
-    assert bob_tp37_bob_dict.get("penny") == 1
-    assert bob_tp37_bob_dict.get("quota") == 150
-    bob_tp37_yao_dict = open_json(tp37_yao_node_path)
-    assert bob_tp37_yao_dict.get("ancestors") == [bob_str, yao_str]
-    assert bob_tp37_yao_dict.get("event_int") == 44
-    assert bob_tp37_yao_dict.get("celldepth") == 0
-    assert bob_tp37_yao_dict.get("deal_owner_name") == bob_str
-    assert bob_tp37_yao_dict.get("penny") == 1
-    assert bob_tp37_yao_dict.get("quota") == 150
-    assert open_json(tp37_quota) == {"Bob": 150, "Yao": 150, "Zia": 150}
-    assert open_json(tp37_bob_quota) == {"Bob": 50, "Yao": 50, "Zia": 50}
-    assert open_json(tp37_yao_quota) == {"Zia": 150}
+    print(f"{bob37_bob_node_path=}")
+    print(f"{bob37_yao_node_path=}")
+    print(f"{bob37_zia_node_path=}")
+    assert os_path_exists(bob37_node_path)
+    assert os_path_exists(bob37_bob_node_path)
+    assert os_path_exists(bob37_yao_node_path)
+    assert os_path_exists(bob37_zia_node_path) is False
+    bob37_bob_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
+    bob37_yao_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
+    bob37_cell = cellunit_get_from_dir(bob37_dir)
+    bob37_bob_cell = cellunit_get_from_dir(bob37_bob_dir)
+    bob37_yao_cell = cellunit_get_from_dir(bob37_yao_dir)
+    assert bob37_bob_cell.ancestors == [bob_str]
+    assert bob37_bob_cell.event_int == 55
+    assert bob37_bob_cell.celldepth == 0
+    assert bob37_bob_cell.deal_owner_name == bob_str
+    assert bob37_bob_cell.penny == 1
+    assert bob37_bob_cell.quota == 150
+    assert bob37_yao_cell.ancestors == [yao_str]
+    assert bob37_yao_cell.event_int == 44
+    assert bob37_yao_cell.celldepth == 0
+    assert bob37_yao_cell.deal_owner_name == bob_str
+    assert bob37_yao_cell.penny == 1
+    assert bob37_yao_cell.quota == 150
+    gen_bob37_quota_ledger = bob37_cell.get_budevents_quota_ledger()
+    gen_bob37_bob_quota_ledger = bob37_bob_cell.get_budevents_quota_ledger()
+    gen_bob37_yao_quota_ledger = bob37_yao_cell.get_budevents_quota_ledger()
+    assert gen_bob37_quota_ledger == {bob_str: 150, yao_str: 150, zia_str: 150}
+    assert gen_bob37_bob_quota_ledger == {bob_str: 50, yao_str: 50, zia_str: 50}
+    assert gen_bob37_yao_quota_ledger == {zia_str: 150}
 
 
-def test_WorldUnit_create_fisc_deal_trees_Scenaro5_LedgerDepth1_ZeroQuotaDoesNotGetCreated(
+def test_worldunit_create_fisc_deal_trees_Scenaro5_LedgerDepth1_ZeroQuotaDoesNotGetCreated(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -392,26 +326,14 @@ def test_WorldUnit_create_fisc_deal_trees_Scenaro5_LedgerDepth1_ZeroQuotaDoesNot
     yao_str = "Yao"
     zia_str = "Zia"
     tp37 = 37  # timepoint
-    deal1_quota = 2
-    deal1_celldepth = 1
+    x_quota = 2
+    x_celldepth = 1
     event33 = 33
     event44 = 44
     event55 = 55
-    cell_node = {
-        "ancestors": [bob_str],
-        event_int_str(): event55,
-        celldepth_str(): deal1_celldepth,
-        owner_name_str(): bob_str,
-        penny_str(): 1,
-        quota_str(): deal1_quota,
-    }
-    a23_bob_ledger_state_path = node_path(
-        fisc_mstr_dir=fisc_mstr_dir,
-        fisc_title=a23_str,
-        owner_name=bob_str,
-        time_int=tp37,
-    )
-    save_json(a23_bob_ledger_state_path, None, cell_node)
+    x_cell = cellunit_shop(bob_str, [], event55, x_celldepth, quota=x_quota)
+    bob37_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [])
+    cellunit_save_to_dir(bob37_dir, x_cell)
     bob_accts = [[yao_str], [bob_str], [zia_str]]
     yao_accts = [[zia_str]]
     zia_accts = [[bob_str], [yao_str]]
@@ -422,43 +344,36 @@ def test_WorldUnit_create_fisc_deal_trees_Scenaro5_LedgerDepth1_ZeroQuotaDoesNot
     assert os_path_exists(bob_e55_path)
     assert os_path_exists(yao_e44_path)
     assert os_path_exists(zia_e33_path)
-    tp37_dir = node_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [])
-    tp37_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [])
-    tp37_bob_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
-    tp37_yao_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
-    tp37_zia_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [zia_str])
-    tp37_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37)
-    tp37_bob_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
-    tp37_yao_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
-    tp37_zia_quota = quota_path(fisc_mstr_dir, a23_str, bob_str, tp37, [zia_str])
-    assert os_path_exists(tp37_node_path)
-    assert os_path_exists(tp37_bob_node_path) is False
-    assert os_path_exists(tp37_yao_node_path) is False
-    assert os_path_exists(tp37_zia_node_path) is False
-    assert os_path_exists(tp37_quota) is False
-    assert os_path_exists(tp37_bob_quota) is False
-    assert os_path_exists(tp37_yao_quota) is False
-    assert os_path_exists(tp37_zia_quota) is False
-    assert count_dirs_files(tp37_dir) == 1
+    bob37_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [])
+    bob37_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [])
+    bob37_bob_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
+    bob37_yao_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
+    bob37_zia_node_path = node_path(fisc_mstr_dir, a23_str, bob_str, tp37, [zia_str])
+    assert os_path_exists(bob37_node_path)
+    assert os_path_exists(bob37_bob_node_path) is False
+    assert os_path_exists(bob37_yao_node_path) is False
+    assert os_path_exists(bob37_zia_node_path) is False
 
     # WHEN
     fizz_world.create_fisc_deal_trees()
 
     # THEN
-    assert os_path_exists(tp37_quota)
-    assert open_json(tp37_quota) == {bob_str: 0, yao_str: 1, zia_str: 1}
-    print(f"{tp37_bob_node_path=}")
-    print(f"{tp37_yao_node_path=}")
-    print(f"{tp37_zia_node_path=}")
-    assert os_path_exists(tp37_node_path)
-    assert os_path_exists(tp37_bob_node_path) is False
-    assert os_path_exists(tp37_yao_node_path)
-    assert os_path_exists(tp37_zia_node_path)
-    assert os_path_exists(tp37_quota)
-    assert os_path_exists(tp37_bob_quota) is False
-    assert os_path_exists(tp37_yao_quota)
-    assert os_path_exists(tp37_zia_quota)
-    assert count_dirs_files(tp37_dir) == 8
-    assert open_json(tp37_quota) == {bob_str: 0, yao_str: 1, zia_str: 1}
-    assert open_json(tp37_yao_quota) == {"Zia": 1}
-    assert open_json(tp37_zia_quota) == {"Bob": 1, "Yao": 0}
+    print(f"{bob37_bob_node_path=}")
+    print(f"{bob37_yao_node_path=}")
+    print(f"{bob37_zia_node_path=}")
+    assert os_path_exists(bob37_node_path)
+    assert os_path_exists(bob37_bob_node_path) is False
+    assert os_path_exists(bob37_yao_node_path)
+    assert os_path_exists(bob37_zia_node_path)
+    bob37_bob_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [bob_str])
+    bob37_yao_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [yao_str])
+    bob37_zia_dir = cell_dir(fisc_mstr_dir, a23_str, bob_str, tp37, [zia_str])
+    bob37_cell = cellunit_get_from_dir(bob37_dir)
+    bob37_yao_cell = cellunit_get_from_dir(bob37_yao_dir)
+    bob37_zia_cell = cellunit_get_from_dir(bob37_zia_dir)
+    gen_bob37_quota_ledger = bob37_cell.get_budevents_quota_ledger()
+    gen_bob37_yao_quota_ledger = bob37_yao_cell.get_budevents_quota_ledger()
+    gen_bob37_zia_quota_ledger = bob37_zia_cell.get_budevents_quota_ledger()
+    assert gen_bob37_quota_ledger == {bob_str: 0, yao_str: 1, zia_str: 1}
+    assert gen_bob37_yao_quota_ledger == {zia_str: 1}
+    assert gen_bob37_zia_quota_ledger == {bob_str: 1, yao_str: 0}

--- a/src/f11_world/test_08_create_balances/test_world_etl08_02_create_uphill_facts.py
+++ b/src/f11_world/test_08_create_balances/test_world_etl08_02_create_uphill_facts.py
@@ -1,80 +1,20 @@
 from src.f00_instrument.file import open_json, save_json
 from src.f01_road.road import create_road
+from src.f02_bud.reason_item import factunit_shop
 from src.f04_gift.atom_config import base_str
+from src.f05_listen.cell import cellunit_shop
 from src.f05_listen.hub_path import (
-    create_cell_budevent_facts_path as bude_facts_path,
+    create_cell_dir_path as cell_dir,
     create_cell_found_facts_path as found_facts_path,
     create_cell_quota_ledger_path as quota_path,
 )
+from src.f05_listen.hub_tool import cellunit_save_to_dir
 from src.f11_world.world import worldunit_shop
 from src.f11_world.examples.world_env import env_dir_setup_cleanup, get_test_worlds_dir
 from os.path import exists as os_path_exists
 
 
-def test_uphill_cell_node_budevent_facts_Scenario0_RootOnly_NoFacts(
-    env_dir_setup_cleanup,
-):
-    # ESTABLISH
-    fizz_world = worldunit_shop("fizz")
-    fisc_mstr_dir = fizz_world._fisc_mstr_dir
-    a23_str = "accord23"
-    bob_str = "Bob"
-    time5 = 5
-    das = []
-    bob_t5_be_facts_path = bude_facts_path(fisc_mstr_dir, a23_str, bob_str, time5, das)
-    bob_t5_be_quota_path = quota_path(fisc_mstr_dir, a23_str, bob_str, time5, das)
-    be_facts_dict = {}
-    save_json(bob_t5_be_facts_path, None, be_facts_dict)
-    save_json(bob_t5_be_quota_path, None, {})
-    bob_t5_found_path = found_facts_path(fisc_mstr_dir, a23_str, bob_str, time5, das)
-    assert os_path_exists(bob_t5_found_path) is False
-
-    # WHEN
-    fizz_world.uphill_cell_node_budevent_facts()
-
-    # THEN
-    assert os_path_exists(bob_t5_found_path)
-    assert open_json(bob_t5_found_path) == {}
-
-
-def test_uphill_cell_node_budevent_facts_Scenario1_ChildNode_NoFacts(
-    env_dir_setup_cleanup,
-):
-    # ESTABLISH
-    fizz_world = worldunit_shop("fizz")
-    mstr_dir = fizz_world._fisc_mstr_dir
-    bob_str = "Bob"
-    yao_str = "Yao"
-    sue_str = "Sue"
-    a23_str = "accord23"
-    time5 = 5
-    das = []
-    das_y = [yao_str]
-    das_ys = [yao_str, sue_str]
-    bob_t5_bef_path = bude_facts_path(mstr_dir, a23_str, bob_str, time5, das)
-    bob_t5_yao_bef_path = bude_facts_path(mstr_dir, a23_str, bob_str, time5, das_y)
-    bob_t5_yao_sue_bef_path = bude_facts_path(mstr_dir, a23_str, bob_str, time5, das_ys)
-    bob_t5_quota_path = quota_path(mstr_dir, a23_str, bob_str, time5, das)
-    bob_t5_yao_quota_path = quota_path(mstr_dir, a23_str, bob_str, time5, das_y)
-    bob_t5_yao_sue_quota_path = quota_path(mstr_dir, a23_str, bob_str, time5, das_ys)
-    save_json(bob_t5_bef_path, None, {})
-    save_json(bob_t5_yao_bef_path, None, {})
-    save_json(bob_t5_yao_sue_bef_path, None, {})
-    save_json(bob_t5_quota_path, None, {})
-    save_json(bob_t5_yao_quota_path, None, {})
-    save_json(bob_t5_yao_sue_quota_path, None, {})
-    bob_t5_found_path = found_facts_path(mstr_dir, a23_str, bob_str, time5, das)
-    assert os_path_exists(bob_t5_found_path) is False
-
-    # WHEN
-    fizz_world.uphill_cell_node_budevent_facts()
-
-    # THEN
-    assert os_path_exists(bob_t5_found_path)
-    assert open_json(bob_t5_found_path) == {}
-
-
-def test_uphill_cell_node_budevent_facts_Scenario2_ChildNodeWithOneFactIsAssignedToAncestors(
+def test_uphill_cell_node_budevent_facts_ChildNodeWithOneFactIsAssignedToAncestors(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -89,19 +29,25 @@ def test_uphill_cell_node_budevent_facts_Scenario2_ChildNodeWithOneFactIsAssigne
     clean_road = create_road(casa_road, "clean")
     bob_t5_be_facts = {}
     bob_t5_yao_be_facts = {}
-    bob_t5_yao_sue_be_facts = {casa_road: {base_str(): casa_road, "pick": clean_road}}
+    clean_fact = factunit_shop(casa_road, clean_road)
+    bob_t5_yao_sue_be_facts = {clean_fact.base: clean_fact}
     das = []
     das_y = [yao_str]
     das_ys = [yao_str, sue_str]
-    bob_t5_bef_path = bude_facts_path(mstr_dir, a23_str, bob_str, time5, das)
-    bob_t5_yao_bef_path = bude_facts_path(mstr_dir, a23_str, bob_str, time5, das_y)
-    bob_t5_yao_sue_bef_path = bude_facts_path(mstr_dir, a23_str, bob_str, time5, das_ys)
+    bob_t5_dir = cell_dir(mstr_dir, a23_str, bob_str, time5, das)
+    bob_t5_yao_dir = cell_dir(mstr_dir, a23_str, bob_str, time5, das_y)
+    bob_t5_yao_sue_dir = cell_dir(mstr_dir, a23_str, bob_str, time5, das_ys)
     bob_t5_quota_path = quota_path(mstr_dir, a23_str, bob_str, time5, das)
     bob_t5_yao_quota_path = quota_path(mstr_dir, a23_str, bob_str, time5, das_y)
     bob_t5_yao_sue_quota_path = quota_path(mstr_dir, a23_str, bob_str, time5, das_ys)
-    save_json(bob_t5_bef_path, None, bob_t5_be_facts)
-    save_json(bob_t5_yao_bef_path, None, bob_t5_yao_be_facts)
-    save_json(bob_t5_yao_sue_bef_path, None, bob_t5_yao_sue_be_facts)
+    bob_t5_cell = cellunit_shop(bob_str, das, budevent_facts=bob_t5_be_facts)
+    bob_t5_yao_cell = cellunit_shop(bob_str, das_y, budevent_facts=bob_t5_yao_be_facts)
+    bob_t5_yao_sue_cell = cellunit_shop(
+        bob_str, das_ys, budevent_facts=bob_t5_yao_sue_be_facts
+    )
+    cellunit_save_to_dir(bob_t5_dir, bob_t5_cell)
+    cellunit_save_to_dir(bob_t5_yao_dir, bob_t5_yao_cell)
+    cellunit_save_to_dir(bob_t5_yao_sue_dir, bob_t5_yao_sue_cell)
     save_json(bob_t5_quota_path, None, {yao_str: 1})
     save_json(bob_t5_yao_quota_path, None, {sue_str: 1})
     save_json(bob_t5_yao_sue_quota_path, None, {bob_str: 1})
@@ -119,6 +65,7 @@ def test_uphill_cell_node_budevent_facts_Scenario2_ChildNodeWithOneFactIsAssigne
     assert os_path_exists(bob_t5_found)
     assert os_path_exists(bob_t5_yao_found)
     assert os_path_exists(bob_t5_yao_sue_found)
-    assert open_json(bob_t5_found) == bob_t5_yao_sue_be_facts
-    assert open_json(bob_t5_yao_found) == bob_t5_yao_sue_be_facts
-    assert open_json(bob_t5_yao_sue_found) == bob_t5_yao_sue_be_facts
+    expected_found_facts = {clean_fact.base: clean_fact.get_dict()}
+    assert open_json(bob_t5_found) == expected_found_facts
+    assert open_json(bob_t5_yao_found) == expected_found_facts
+    assert open_json(bob_t5_yao_sue_found) == expected_found_facts

--- a/src/f11_world/test_08_create_balances/test_world_etl08_02_create_uphill_facts.py
+++ b/src/f11_world/test_08_create_balances/test_world_etl08_02_create_uphill_facts.py
@@ -11,7 +11,7 @@ from src.f11_world.examples.world_env import env_dir_setup_cleanup, get_test_wor
 from os.path import exists as os_path_exists
 
 
-def test_uphill_cell_node_budevent_facts_ChildNodeWithOneFactIsAssignedToAncestors(
+def test_set_deal_trees_found_facts_ChildNodeWithOneFactIsAssignedToAncestors(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -59,7 +59,7 @@ def test_uphill_cell_node_budevent_facts_ChildNodeWithOneFactIsAssignedToAncesto
     assert cellunit_get_from_dir(bob5_yao_sue_dir).found_facts == {}
 
     # WHEN
-    fizz_world.uphill_cell_node_budevent_facts()
+    fizz_world.set_deal_trees_found_facts()
 
     # THEN
     assert cellunit_get_from_dir(bob5_dir).found_facts == clean_facts

--- a/src/f11_world/test_08_create_balances/test_world_etl08_02_create_uphill_facts.py
+++ b/src/f11_world/test_08_create_balances/test_world_etl08_02_create_uphill_facts.py
@@ -1,12 +1,10 @@
 from src.f00_instrument.file import open_json, save_json
 from src.f01_road.road import create_road
 from src.f02_bud.reason_item import factunit_shop
+from src.f02_bud.bud import budunit_shop
 from src.f04_gift.atom_config import base_str
 from src.f05_listen.cell import cellunit_shop
-from src.f05_listen.hub_path import (
-    create_cell_dir_path as cell_dir,
-    create_cell_quota_ledger_path as quota_path,
-)
+from src.f05_listen.hub_path import create_cell_dir_path as cell_dir
 from src.f05_listen.hub_tool import cellunit_save_to_dir, cellunit_get_from_dir
 from src.f11_world.world import worldunit_shop
 from src.f11_world.examples.world_env import env_dir_setup_cleanup, get_test_worlds_dir
@@ -26,39 +24,44 @@ def test_uphill_cell_node_budevent_facts_ChildNodeWithOneFactIsAssignedToAncesto
     time5 = 5
     casa_road = create_road(a23_str, "casa")
     clean_road = create_road(casa_road, "clean")
-    bob_t5_be_facts = {}
-    bob_t5_yao_be_facts = {}
     clean_fact = factunit_shop(casa_road, clean_road)
-    bob_t5_yao_sue_be_facts = {clean_fact.base: clean_fact}
     das = []
     das_y = [yao_str]
     das_ys = [yao_str, sue_str]
-    bob_t5_dir = cell_dir(mstr_dir, a23_str, bob_str, time5, das)
-    bob_t5_yao_dir = cell_dir(mstr_dir, a23_str, bob_str, time5, das_y)
-    bob_t5_yao_sue_dir = cell_dir(mstr_dir, a23_str, bob_str, time5, das_ys)
-    bob_t5_quota_path = quota_path(mstr_dir, a23_str, bob_str, time5, das)
-    bob_t5_yao_quota_path = quota_path(mstr_dir, a23_str, bob_str, time5, das_y)
-    bob_t5_yao_sue_quota_path = quota_path(mstr_dir, a23_str, bob_str, time5, das_ys)
-    bob_t5_cell = cellunit_shop(bob_str, das, budevent_facts=bob_t5_be_facts)
-    bob_t5_yao_cell = cellunit_shop(bob_str, das_y, budevent_facts=bob_t5_yao_be_facts)
-    bob_t5_yao_sue_cell = cellunit_shop(
-        bob_str, das_ys, budevent_facts=bob_t5_yao_sue_be_facts
+    bob5_dir = cell_dir(mstr_dir, a23_str, bob_str, time5, das)
+    bob5_yao_dir = cell_dir(mstr_dir, a23_str, bob_str, time5, das_y)
+    bob5_yao_sue_dir = cell_dir(mstr_dir, a23_str, bob_str, time5, das_ys)
+    bob5_budevent = budunit_shop(bob_str, a23_str)
+    bob5_yao_budevent = budunit_shop(yao_str, a23_str)
+    bob5_yao_sue_budevent = budunit_shop(sue_str, a23_str)
+    bob5_budevent.add_acctunit(yao_str)
+    bob5_yao_budevent.add_acctunit(sue_str)
+    bob5_yao_sue_budevent.add_acctunit(bob_str)
+    bob5_yao_sue_budevent.add_item(clean_fact.pick, 1)
+    bob5_yao_sue_budevent.add_fact(clean_fact.base, clean_fact.pick)
+    bob5_cell = cellunit_shop(bob_str, das, budadjust=bob5_budevent)
+    bob5_yao_cell = cellunit_shop(bob_str, das_y, budadjust=bob5_yao_budevent)
+    clean_facts = {clean_fact.base: clean_fact}
+    bob5_yao_sue_cell = cellunit_shop(
+        bob_str, das_ys, budadjust=bob5_yao_sue_budevent, budevent_facts=clean_facts
     )
-    cellunit_save_to_dir(bob_t5_dir, bob_t5_cell)
-    cellunit_save_to_dir(bob_t5_yao_dir, bob_t5_yao_cell)
-    cellunit_save_to_dir(bob_t5_yao_sue_dir, bob_t5_yao_sue_cell)
-    save_json(bob_t5_quota_path, None, {yao_str: 1})
-    save_json(bob_t5_yao_quota_path, None, {sue_str: 1})
-    save_json(bob_t5_yao_sue_quota_path, None, {bob_str: 1})
-    assert cellunit_get_from_dir(bob_t5_dir).found_facts == {}
-    assert cellunit_get_from_dir(bob_t5_yao_dir).found_facts == {}
-    assert cellunit_get_from_dir(bob_t5_yao_sue_dir).found_facts == {}
+    assert bob5_cell.get_budevents_quota_ledger() == {yao_str: 1000}
+    assert bob5_yao_cell.get_budevents_quota_ledger() == {sue_str: 1000}
+    assert bob5_yao_sue_cell.get_budevents_quota_ledger() == {bob_str: 1000}
+    assert bob5_cell.budevent_facts == {}
+    assert bob5_yao_cell.budevent_facts == {}
+    assert bob5_yao_sue_cell.budevent_facts == clean_facts
+    cellunit_save_to_dir(bob5_dir, bob5_cell)
+    cellunit_save_to_dir(bob5_yao_dir, bob5_yao_cell)
+    cellunit_save_to_dir(bob5_yao_sue_dir, bob5_yao_sue_cell)
+    assert cellunit_get_from_dir(bob5_dir).found_facts == {}
+    assert cellunit_get_from_dir(bob5_yao_dir).found_facts == {}
+    assert cellunit_get_from_dir(bob5_yao_sue_dir).found_facts == {}
 
     # WHEN
     fizz_world.uphill_cell_node_budevent_facts()
 
     # THEN
-    expected_found_facts = {clean_fact.base: clean_fact}
-    assert cellunit_get_from_dir(bob_t5_dir).found_facts == expected_found_facts
-    assert cellunit_get_from_dir(bob_t5_yao_dir).found_facts == expected_found_facts
-    assert cellunit_get_from_dir(bob_t5_yao_sue_dir).found_facts == expected_found_facts
+    assert cellunit_get_from_dir(bob5_dir).found_facts == clean_facts
+    assert cellunit_get_from_dir(bob5_yao_dir).found_facts == clean_facts
+    assert cellunit_get_from_dir(bob5_yao_sue_dir).found_facts == clean_facts

--- a/src/f11_world/test_08_create_balances/test_world_etl08_02_create_uphill_facts.py
+++ b/src/f11_world/test_08_create_balances/test_world_etl08_02_create_uphill_facts.py
@@ -5,10 +5,9 @@ from src.f04_gift.atom_config import base_str
 from src.f05_listen.cell import cellunit_shop
 from src.f05_listen.hub_path import (
     create_cell_dir_path as cell_dir,
-    create_cell_found_facts_path as found_facts_path,
     create_cell_quota_ledger_path as quota_path,
 )
-from src.f05_listen.hub_tool import cellunit_save_to_dir
+from src.f05_listen.hub_tool import cellunit_save_to_dir, cellunit_get_from_dir
 from src.f11_world.world import worldunit_shop
 from src.f11_world.examples.world_env import env_dir_setup_cleanup, get_test_worlds_dir
 from os.path import exists as os_path_exists
@@ -51,21 +50,15 @@ def test_uphill_cell_node_budevent_facts_ChildNodeWithOneFactIsAssignedToAncesto
     save_json(bob_t5_quota_path, None, {yao_str: 1})
     save_json(bob_t5_yao_quota_path, None, {sue_str: 1})
     save_json(bob_t5_yao_sue_quota_path, None, {bob_str: 1})
-    bob_t5_found = found_facts_path(mstr_dir, a23_str, bob_str, time5, das)
-    bob_t5_yao_found = found_facts_path(mstr_dir, a23_str, bob_str, time5, das_y)
-    bob_t5_yao_sue_found = found_facts_path(mstr_dir, a23_str, bob_str, time5, das_ys)
-    assert os_path_exists(bob_t5_found) is False
-    assert os_path_exists(bob_t5_yao_found) is False
-    assert os_path_exists(bob_t5_yao_sue_found) is False
+    assert cellunit_get_from_dir(bob_t5_dir).found_facts == {}
+    assert cellunit_get_from_dir(bob_t5_yao_dir).found_facts == {}
+    assert cellunit_get_from_dir(bob_t5_yao_sue_dir).found_facts == {}
 
     # WHEN
     fizz_world.uphill_cell_node_budevent_facts()
 
     # THEN
-    assert os_path_exists(bob_t5_found)
-    assert os_path_exists(bob_t5_yao_found)
-    assert os_path_exists(bob_t5_yao_sue_found)
-    expected_found_facts = {clean_fact.base: clean_fact.get_dict()}
-    assert open_json(bob_t5_found) == expected_found_facts
-    assert open_json(bob_t5_yao_found) == expected_found_facts
-    assert open_json(bob_t5_yao_sue_found) == expected_found_facts
+    expected_found_facts = {clean_fact.base: clean_fact}
+    assert cellunit_get_from_dir(bob_t5_dir).found_facts == expected_found_facts
+    assert cellunit_get_from_dir(bob_t5_yao_dir).found_facts == expected_found_facts
+    assert cellunit_get_from_dir(bob_t5_yao_sue_dir).found_facts == expected_found_facts

--- a/src/f11_world/test_08_create_balances/test_world_etl08_03_create_acct_adjust_ledgers.py
+++ b/src/f11_world/test_08_create_balances/test_world_etl08_03_create_acct_adjust_ledgers.py
@@ -1,7 +1,6 @@
 from src.f00_instrument.file import save_json, save_file
 from src.f05_listen.hub_path import (
     create_budevent_path,
-    create_cell_found_facts_path as found_facts_path,
 )
 from src.f05_listen.hub_tool import cellunit_add_json_file
 from src.f11_world.world import worldunit_shop
@@ -27,7 +26,6 @@ from os.path import exists as os_path_exists
 #     save_file(bob7_budevent_path, None, mop_budunit.get_json())
 #     # create found_facts files
 #     bob5_found_facts = {}
-#     bob5_found = found_facts_path(mstr_dir, a23_str, bob_str, tp5, das)
 #     save_json(bob5_found, None, bob5_found_facts)
 #     # create paths for budadjusts
 #     bob5_budadjust_path = budadjust_path(mstr_dir, a23_str, bob_str, tp5, das)

--- a/src/f11_world/test_08_create_balances/test_world_etl08_03_create_acct_adjust_ledgers.py
+++ b/src/f11_world/test_08_create_balances/test_world_etl08_03_create_acct_adjust_ledgers.py
@@ -18,7 +18,7 @@ from os.path import exists as os_path_exists
 #     bob_str = "Bob"
 #     das = []
 #     event7 = 7
-#     # create cell_node files
+#     # create cell files
 #     cellunit_add_json_file(mstr_dir, a23_str, bob_str, tp5, event7, das)
 #     mop_budunit = get_mop_with_reason_budunit_example()
 #     # create budevent files
@@ -43,7 +43,7 @@ from os.path import exists as os_path_exists
 #     assert os_path_exists(bob5_adjust_ledger_path)
 
 
-# create a world with, cell_node.json, found facts and bud events
+# create a world with, cell.json, found facts and bud events
 # for every found_fact change budevent to that fact
 # create agenda (different than if found_fact was not applied)
 # create a budevent such that changing facts changes agenda output

--- a/src/f11_world/test_08_create_balances/test_world_etl08_03_create_acct_adjust_ledgers.py
+++ b/src/f11_world/test_08_create_balances/test_world_etl08_03_create_acct_adjust_ledgers.py
@@ -3,7 +3,7 @@ from src.f05_listen.hub_path import (
     create_budevent_path,
     create_cell_found_facts_path as found_facts_path,
 )
-from src.f05_listen.hub_tool import save_cell_node_file
+from src.f05_listen.hub_tool import cellunit_add_json_file
 from src.f11_world.world import worldunit_shop
 from src.f11_world.examples.example_worlds import get_mop_with_reason_budunit_example
 from src.f11_world.examples.world_env import env_dir_setup_cleanup
@@ -20,7 +20,7 @@ from os.path import exists as os_path_exists
 #     das = []
 #     event7 = 7
 #     # create cell_node files
-#     save_cell_node_file(mstr_dir, a23_str, bob_str, tp5, event7, das)
+#     cellunit_add_json_file(mstr_dir, a23_str, bob_str, tp5, event7, das)
 #     mop_budunit = get_mop_with_reason_budunit_example()
 #     # create budevent files
 #     bob7_budevent_path = create_budevent_path(mstr_dir, a23_str, bob_str, event7)

--- a/src/f11_world/test_08_create_balances/test_world_etl08_04_create_deal_root_allots.py
+++ b/src/f11_world/test_08_create_balances/test_world_etl08_04_create_deal_root_allots.py
@@ -3,7 +3,7 @@ from src.f01_road.deal import quota_str
 from src.f05_listen.hub_path import (
     create_cell_node_json_path,
 )
-from src.f05_listen.hub_tool import save_cell_node_file
+from src.f05_listen.hub_tool import cellunit_add_json_file
 from src.f11_world.world import worldunit_shop
 from src.f11_world.examples.example_worlds import get_mop_with_reason_budunit_example
 from src.f11_world.examples.world_env import env_dir_setup_cleanup

--- a/src/f11_world/test_08_create_balances/test_world_etl08_04_create_deal_root_allots.py
+++ b/src/f11_world/test_08_create_balances/test_world_etl08_04_create_deal_root_allots.py
@@ -1,7 +1,7 @@
 from src.f00_instrument.file import open_json, save_json
 from src.f01_road.deal import quota_str
 from src.f05_listen.hub_path import (
-    create_cell_node_json_path,
+    create_cell_json_path,
 )
 from src.f05_listen.hub_tool import cellunit_add_json_file
 from src.f11_world.world import worldunit_shop
@@ -9,6 +9,6 @@ from src.f11_world.examples.example_worlds import get_mop_with_reason_budunit_ex
 from src.f11_world.examples.world_env import env_dir_setup_cleanup
 from os.path import exists as os_path_exists
 
-# set acct_adjust_ledgers in cell_node
+# set acct_adjust_ledgers in cell
 # run allot_nested_scale to get root allotment
 # save root allotment as json

--- a/src/f11_world/world.py
+++ b/src/f11_world/world.py
@@ -49,9 +49,9 @@ from src.f10_etl.transformers import (
     etl_fisc_agg_tables2fisc_ote1_agg,
     etl_fisc_table2fisc_ote1_agg_csvs,
     etl_fisc_ote1_agg_csvs2jsons,
-    etl_create_root_cell_nodes,
+    etl_create_deals_root_cells,
     etl_create_fisc_deal_trees,
-    etl_uphill_cell_node_budevent_facts,
+    etl_set_deal_trees_found_facts,
     etl_modify_deal_trees_with_boss_facts,
 )
 from dataclasses import dataclass
@@ -222,14 +222,14 @@ class WorldUnit:
     def fisc_ote1_agg_csvs2jsons(self):
         etl_fisc_ote1_agg_csvs2jsons(self._fisc_mstr_dir)
 
-    def create_root_cell_nodes(self):
-        etl_create_root_cell_nodes(self._fisc_mstr_dir)
+    def create_deals_root_cells(self):
+        etl_create_deals_root_cells(self._fisc_mstr_dir)
 
     def create_fisc_deal_trees(self):
         etl_create_fisc_deal_trees(self._fisc_mstr_dir)
 
-    def uphill_cell_node_budevent_facts(self):
-        etl_uphill_cell_node_budevent_facts(self._fisc_mstr_dir)
+    def set_deal_trees_found_facts(self):
+        etl_set_deal_trees_found_facts(self._fisc_mstr_dir)
 
     def modify_deal_trees_with_boss_facts(self):
         etl_modify_deal_trees_with_boss_facts(self._fisc_mstr_dir)


### PR DESCRIPTION
## Summary by Sourcery

Refactors the deal tree creation process to use cell directories instead of JSON files for storing cell data, improving data management and organization. It also updates the logic for assigning facts to ancestor nodes in the deal trees.

Enhancements:
- Refactor deal tree creation to use cell directories for data storage.
- Update logic for assigning facts to ancestor nodes.
- Rename functions and update tests to reflect changes in data storage and fact assignment.
- Remove redundant file existence checks and directory counting in tests.
- Update cell data handling to use cellunit_save_to_dir and cellunit_get_from_dir functions.
- Remove CELL_QUOTA_LEDGER_FILENAME, CELL_BUDEVENT_FACTS_FILENAME, and CELL_FOUND_FACTS_FILENAME constants.
- Remove create_cell_quota_ledger_path, create_cell_budevent_facts_path, and create_cell_found_facts_path functions.
- Rename create_cell_node_json_path to create_cell_json_path.
- Rename save_cell_node_file to cellunit_add_json_file.
- Rename cellunit_get_from_json to cellunit_get_from_dir.
- Rename etl_create_root_cell_nodes to etl_create_deals_root_cells.
- Rename etl_uphill_cell_node_budevent_facts to etl_set_deal_trees_found_facts.
- Rename uphill_cell_node_budevent_facts to set_deal_trees_found_facts.
- Rename create_root_cell_nodes to create_deals_root_cells.
- Rename create_and_save_root_cell_node to _create_deal_root_cell.
- Remove create_all_cell_node_facts_files and replace with load_cells_budevent.
- Remove CELL_NODE_QUOTA_DEFAULT constant and replace with CELLNODE_QUOTA_DEFAULT.
- Remove get_budevents_credit_ledger and get_budevent_facts functions.
- Remove test_uphill_cell_node_budevent_facts tests and replace with test_set_deal_trees_found_facts tests.
- Remove test_create_all_cell_node_facts_files tests and replace with test_load_cells_budevent tests.