### PR TITLE
175 enable documentation process

### DIFF
--- a/src/a17_idea_logic/_utils/str_a17.py
+++ b/src/a17_idea_logic/_utils/str_a17.py
@@ -54,13 +54,13 @@ def build_order_str() -> str:
     return "build_order"
 
 
-def yell_raw_str() -> str:
-    return "yell_raw"
+def brick_raw_str() -> str:
+    return "brick_raw"
 
 
-def yell_agg_str() -> str:
-    return "yell_agg"
+def brick_agg_str() -> str:
+    return "brick_agg"
 
 
-def yell_valid_str() -> str:
-    return "yell_valid"
+def brick_valid_str() -> str:
+    return "brick_valid"

--- a/src/a17_idea_logic/idea_csv_tool.py
+++ b/src/a17_idea_logic/idea_csv_tool.py
@@ -11,9 +11,9 @@ from src.a17_idea_logic.idea_config import (
 )
 
 
-def create_init_stance_idea_brick_csv_strs() -> dict[str, str]:
+def create_init_stance_idea_csv_strs() -> dict[str, str]:
     """Returns strings of csv headers with comma delimiter"""
-    stance_idea_bricks = [
+    stance_idea_numbers = [
         "br00000",
         "br00001",
         "br00002",
@@ -39,11 +39,11 @@ def create_init_stance_idea_brick_csv_strs() -> dict[str, str]:
     idea_format_headers = get_idea_format_headers()
 
     fisc_csv_strs = {}
-    for idea_brick in stance_idea_bricks:
-        idea_format_filename = get_idea_format_filename(idea_brick)
+    for idea_number in stance_idea_numbers:
+        idea_format_filename = get_idea_format_filename(idea_number)
         for idea_columns, idea_file_name in idea_format_headers.items():
             if idea_file_name == idea_format_filename:
-                fisc_csv_strs[idea_brick] = f"face_name,event_int,{idea_columns}\n"
+                fisc_csv_strs[idea_number] = f"face_name,event_int,{idea_columns}\n"
     return fisc_csv_strs
 
 

--- a/src/a17_idea_logic/idea_db_tool.py
+++ b/src/a17_idea_logic/idea_db_tool.py
@@ -103,7 +103,7 @@ def get_relevant_columns_dataframe(
     return src_df[relevant_cols_in_order]
 
 
-def get_yell_raw_grouping_with_all_values_equal_df(
+def get_brick_raw_grouping_with_all_values_equal_df(
     x_df: DataFrame, groupby_list: list, idea_number: str
 ) -> DataFrame:
     df_columns = set(x_df.columns)
@@ -113,9 +113,9 @@ def get_yell_raw_grouping_with_all_values_equal_df(
     if grouping_columns == []:
         return x_df
     with sqlite3_connect(":memory:") as conn:
-        x_df.to_sql("yell_raw", conn, index=False)
+        x_df.to_sql("brick_raw", conn, index=False)
         query_str = get_grouping_with_all_values_equal_sql_query(
-            x_table="yell_raw",
+            x_table="brick_raw",
             groupby_columns=grouping_columns,
             value_columns=value_columns,
         )

--- a/src/a17_idea_logic/test__idea_db_tool/test_pandas_tool_.py
+++ b/src/a17_idea_logic/test__idea_db_tool/test_pandas_tool_.py
@@ -21,12 +21,16 @@ from src.a17_idea_logic._utils.example_pandas import (
     get_ex02_atom_dataframe,
     get_ex02_atom_csv,
 )
-from src.a17_idea_logic._utils.str_a17 import yell_raw_str, yell_agg_str, yell_valid_str
+from src.a17_idea_logic._utils.str_a17 import (
+    brick_raw_str,
+    brick_agg_str,
+    brick_valid_str,
+)
 from src.a17_idea_logic.idea_db_tool import (
     save_dataframe_to_csv,
     get_ordered_csv,
     get_relevant_columns_dataframe,
-    get_yell_raw_grouping_with_all_values_equal_df,
+    get_brick_raw_grouping_with_all_values_equal_df,
 )
 from os.path import exists as os_path_exists
 from pandas import DataFrame
@@ -176,20 +180,20 @@ def test_get_relevant_columns_dataframe_ReturnsObj_Scenario4_ColumnOrderCorrect(
     assert relevant_dataframe.columns.to_list() == [acct_name_str(), group_label_str()]
 
 
-def test_yell_raw_str_ReturnsObj():
+def test_brick_raw_str_ReturnsObj():
     # ESTABLISH / WHEN / THEN
-    assert yell_raw_str() == "yell_raw"
-    assert yell_agg_str() == "yell_agg"
-    assert yell_valid_str() == "yell_valid"
+    assert brick_raw_str() == "brick_raw"
+    assert brick_agg_str() == "brick_agg"
+    assert brick_valid_str() == "brick_valid"
 
 
-def test_get_yell_raw_grouping_with_all_values_equal_df_ReturnsObj_Scenario0_EmptyDataframe():
+def test_get_brick_raw_grouping_with_all_values_equal_df_ReturnsObj_Scenario0_EmptyDataframe():
     # ESTABLISH
     df1 = DataFrame([[]], columns=[])
     groupby_list = [group_label_str(), acct_name_str()]
 
     # WHEN
-    groupby_dataframe = get_yell_raw_grouping_with_all_values_equal_df(
+    groupby_dataframe = get_brick_raw_grouping_with_all_values_equal_df(
         df1, groupby_list, idea_number="br00004"
     )
 
@@ -200,7 +204,7 @@ def test_get_yell_raw_grouping_with_all_values_equal_df_ReturnsObj_Scenario0_Emp
     assert groupby_dataframe.columns.to_list() == []
 
 
-def test_get_yell_raw_grouping_with_all_values_equal_df_ReturnsObj_Scenario1_GroupBySingleColumn():
+def test_get_brick_raw_grouping_with_all_values_equal_df_ReturnsObj_Scenario1_GroupBySingleColumn():
     # ESTABLISH
     df_columns = [group_label_str(), credor_respect_str()]
     before_df_values = [["AA0", "BB0"], ["AA0", "BB0"]]
@@ -208,7 +212,7 @@ def test_get_yell_raw_grouping_with_all_values_equal_df_ReturnsObj_Scenario1_Gro
     groupby_list = [group_label_str()]
 
     # WHEN
-    groupby_dataframe = get_yell_raw_grouping_with_all_values_equal_df(
+    groupby_dataframe = get_brick_raw_grouping_with_all_values_equal_df(
         df1, groupby_list, idea_number="br00004"
     )
     print(f"{groupby_dataframe=}")
@@ -223,7 +227,7 @@ def test_get_yell_raw_grouping_with_all_values_equal_df_ReturnsObj_Scenario1_Gro
     assert groupby_dataframe.to_csv() == after_df.to_csv()
 
 
-def test_get_yell_raw_grouping_with_all_values_equal_df_ReturnsObj_Scenario2_GroupByExtraColumns():
+def test_get_brick_raw_grouping_with_all_values_equal_df_ReturnsObj_Scenario2_GroupByExtraColumns():
     # ESTABLISH
     df_columns = [group_label_str(), credor_respect_str()]
     before_df_values = [["AA0", "BB0"], ["AA0", "BB0"]]
@@ -231,7 +235,7 @@ def test_get_yell_raw_grouping_with_all_values_equal_df_ReturnsObj_Scenario2_Gro
     groupby_list = [group_label_str(), acct_name_str()]
 
     # WHEN
-    groupby_dataframe = get_yell_raw_grouping_with_all_values_equal_df(
+    groupby_dataframe = get_brick_raw_grouping_with_all_values_equal_df(
         df1, groupby_list, idea_number="br00004"
     )
     print(f"{groupby_dataframe=}")
@@ -246,7 +250,7 @@ def test_get_yell_raw_grouping_with_all_values_equal_df_ReturnsObj_Scenario2_Gro
     assert groupby_dataframe.to_csv() == after_df.to_csv()
 
 
-def test_get_yell_raw_grouping_with_all_values_equal_df_ReturnsObj_Scenario3_GroupByExtraColumns():
+def test_get_brick_raw_grouping_with_all_values_equal_df_ReturnsObj_Scenario3_GroupByExtraColumns():
     # ESTABLISH
     df_columns = [group_label_str(), credor_respect_str(), "column3"]
     before_df_values = [["AA0", "BB0", "CC0"], ["AA0", "BB0", "CC0"]]
@@ -254,7 +258,7 @@ def test_get_yell_raw_grouping_with_all_values_equal_df_ReturnsObj_Scenario3_Gro
     groupby_list = [group_label_str(), acct_name_str(), credor_respect_str()]
 
     # WHEN
-    groupby_dataframe = get_yell_raw_grouping_with_all_values_equal_df(
+    groupby_dataframe = get_brick_raw_grouping_with_all_values_equal_df(
         df1, groupby_list, idea_number="br00004"
     )
     print(f"{groupby_dataframe=}")
@@ -269,7 +273,7 @@ def test_get_yell_raw_grouping_with_all_values_equal_df_ReturnsObj_Scenario3_Gro
     assert groupby_dataframe.to_csv() == after_df.to_csv()
 
 
-def test_get_yell_raw_grouping_with_all_values_equal_df_ReturnsObj_Scenario4_GroupByExtraColumns():
+def test_get_brick_raw_grouping_with_all_values_equal_df_ReturnsObj_Scenario4_GroupByExtraColumns():
     # ESTABLISH
     df_columns = [group_label_str(), credor_respect_str(), "column3"]
     before_df_values = [
@@ -281,7 +285,7 @@ def test_get_yell_raw_grouping_with_all_values_equal_df_ReturnsObj_Scenario4_Gro
     groupby_list = [group_label_str(), acct_name_str(), credor_respect_str()]
 
     # WHEN
-    groupby_dataframe = get_yell_raw_grouping_with_all_values_equal_df(
+    groupby_dataframe = get_brick_raw_grouping_with_all_values_equal_df(
         df1, groupby_list, idea_number="br00004"
     )
     print(f"{groupby_dataframe=}")

--- a/src/a17_idea_logic/test_z_fisc_build/test_idea_csv_tool.py
+++ b/src/a17_idea_logic/test_z_fisc_build/test_idea_csv_tool.py
@@ -13,7 +13,7 @@ from src.a16_pidgin_logic.pidgin import PidginUnit, pidginunit_shop
 from src.a17_idea_logic.idea_config import get_idea_format_filename
 from src.a17_idea_logic.idea import fisc_build_from_df
 from src.a17_idea_logic.idea_csv_tool import (
-    create_init_stance_idea_brick_csv_strs,
+    create_init_stance_idea_csv_strs,
     add_fiscunit_to_stance_csv_strs,
     add_fiscunits_to_stance_csv_strs,
     add_bud_to_br00020_csv,
@@ -61,14 +61,14 @@ from src.a17_idea_logic._utils.idea_df_examples import (
 from copy import deepcopy as copy_deepcopy
 
 
-def test_create_init_stance_idea_brick_csv_strs_ReturnsObj_Scenario0_EmptyFiscUnit(
+def test_create_init_stance_idea_csv_strs_ReturnsObj_Scenario0_EmptyFiscUnit(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
     csv_delimiter = ","
 
     # WHEN
-    x_ideabricks = create_init_stance_idea_brick_csv_strs()
+    x_ideas = create_init_stance_idea_csv_strs()
 
     # THEN
     expected_stance_csv_strs = {
@@ -118,30 +118,30 @@ def test_create_init_stance_idea_brick_csv_strs_ReturnsObj_Scenario0_EmptyFiscUn
     print(f"{expected_br00001_csv=}")
 
     face_event_str = "face_name,event_int,"
-    assert x_ideabricks.get("br00000") == f"{face_event_str}{expected_br00000_csv}"
-    assert x_ideabricks.get("br00001") == f"{face_event_str}{expected_br00001_csv}"
-    assert x_ideabricks.get("br00002") == f"{face_event_str}{expected_br00002_csv}"
-    assert x_ideabricks.get("br00003") == f"{face_event_str}{expected_br00003_csv}"
-    assert x_ideabricks.get("br00004") == f"{face_event_str}{expected_br00004_csv}"
-    assert x_ideabricks.get("br00005") == f"{face_event_str}{expected_br00005_csv}"
-    # assert x_ideabricks.get("br00006") == f"{face_event_str}{expected_br00006_csv}"
+    assert x_ideas.get("br00000") == f"{face_event_str}{expected_br00000_csv}"
+    assert x_ideas.get("br00001") == f"{face_event_str}{expected_br00001_csv}"
+    assert x_ideas.get("br00002") == f"{face_event_str}{expected_br00002_csv}"
+    assert x_ideas.get("br00003") == f"{face_event_str}{expected_br00003_csv}"
+    assert x_ideas.get("br00004") == f"{face_event_str}{expected_br00004_csv}"
+    assert x_ideas.get("br00005") == f"{face_event_str}{expected_br00005_csv}"
+    # assert x_ideas.get("br00006") == f"{face_event_str}{expected_br00006_csv}"
     print(f"{expected_br00020_csv=}")
-    print(x_ideabricks.get("br00020"))
-    assert x_ideabricks.get("br00020") == f"{face_event_str}{expected_br00020_csv}"
-    assert x_ideabricks.get("br00021") == f"{face_event_str}{expected_br00021_csv}"
-    assert x_ideabricks.get("br00022") == f"{face_event_str}{expected_br00022_csv}"
-    assert x_ideabricks.get("br00023") == f"{face_event_str}{expected_br00023_csv}"
-    assert x_ideabricks.get("br00024") == f"{face_event_str}{expected_br00024_csv}"
-    assert x_ideabricks.get("br00025") == f"{face_event_str}{expected_br00025_csv}"
-    assert x_ideabricks.get("br00026") == f"{face_event_str}{expected_br00026_csv}"
-    assert x_ideabricks.get("br00027") == f"{face_event_str}{expected_br00027_csv}"
-    assert x_ideabricks.get("br00028") == f"{face_event_str}{expected_br00028_csv}"
-    assert x_ideabricks.get("br00029") == f"{face_event_str}{expected_br00029_csv}"
-    assert x_ideabricks.get("br00042") == f"{face_event_str}{expected_br00042_csv}"
-    assert x_ideabricks.get("br00043") == f"{face_event_str}{expected_br00043_csv}"
-    assert x_ideabricks.get("br00044") == f"{face_event_str}{expected_br00044_csv}"
-    assert x_ideabricks.get("br00045") == f"{face_event_str}{expected_br00045_csv}"
-    assert len(x_ideabricks) == 20
+    print(x_ideas.get("br00020"))
+    assert x_ideas.get("br00020") == f"{face_event_str}{expected_br00020_csv}"
+    assert x_ideas.get("br00021") == f"{face_event_str}{expected_br00021_csv}"
+    assert x_ideas.get("br00022") == f"{face_event_str}{expected_br00022_csv}"
+    assert x_ideas.get("br00023") == f"{face_event_str}{expected_br00023_csv}"
+    assert x_ideas.get("br00024") == f"{face_event_str}{expected_br00024_csv}"
+    assert x_ideas.get("br00025") == f"{face_event_str}{expected_br00025_csv}"
+    assert x_ideas.get("br00026") == f"{face_event_str}{expected_br00026_csv}"
+    assert x_ideas.get("br00027") == f"{face_event_str}{expected_br00027_csv}"
+    assert x_ideas.get("br00028") == f"{face_event_str}{expected_br00028_csv}"
+    assert x_ideas.get("br00029") == f"{face_event_str}{expected_br00029_csv}"
+    assert x_ideas.get("br00042") == f"{face_event_str}{expected_br00042_csv}"
+    assert x_ideas.get("br00043") == f"{face_event_str}{expected_br00043_csv}"
+    assert x_ideas.get("br00044") == f"{face_event_str}{expected_br00044_csv}"
+    assert x_ideas.get("br00045") == f"{face_event_str}{expected_br00045_csv}"
+    assert len(x_ideas) == 20
 
 
 def test_add_fiscunit_to_stance_csv_strs_ReturnsObj_Scenario0_OneFiscUnit(
@@ -173,7 +173,7 @@ def test_add_fiscunit_to_stance_csv_strs_ReturnsObj_Scenario0_OneFiscUnit(
         x_fiscs_dir,
     )
     csv_delimiter = ","
-    x_csvs = create_init_stance_idea_brick_csv_strs()
+    x_csvs = create_init_stance_idea_csv_strs()
     br00_csv_header = x_csvs.get("br00000")
     br01_csv_header = x_csvs.get("br00001")
     br02_csv_header = x_csvs.get("br00002")
@@ -243,10 +243,10 @@ def test_add_fiscunits_to_stance_csv_strs_ReturnsObj_Scenario1_TwoFiscUnits(
         x_fiscs_dir,
     )
     csv_delimiter = ","
-    x_ideabricks = create_init_stance_idea_brick_csv_strs()
+    x_ideas = create_init_stance_idea_csv_strs()
 
     # WHEN
-    add_fiscunits_to_stance_csv_strs(x_fiscunits, x_ideabricks, csv_delimiter)
+    add_fiscunits_to_stance_csv_strs(x_fiscunits, x_ideas, csv_delimiter)
 
     # THEN
     expected_br00000_csv = get_ordered_csv(get_ex2_br00000_df())
@@ -274,13 +274,13 @@ def test_add_fiscunits_to_stance_csv_strs_ReturnsObj_Scenario1_TwoFiscUnits(
     expected_br00004_csv = expected_br00004_csv.replace("jeffy45", ",,jeffy45")
     expected_br00005_csv = expected_br00005_csv.replace("jeffy45", ",,jeffy45")
 
-    assert len(x_ideabricks) == 20
-    generated_br00000_csv = x_ideabricks.get("br00000")
-    generated_br00001_csv = x_ideabricks.get("br00001")
-    generated_br00002_csv = x_ideabricks.get("br00002")
-    generated_br00003_csv = x_ideabricks.get("br00003")
-    generated_br00004_csv = x_ideabricks.get("br00004")
-    generated_br00005_csv = x_ideabricks.get("br00005")
+    assert len(x_ideas) == 20
+    generated_br00000_csv = x_ideas.get("br00000")
+    generated_br00001_csv = x_ideas.get("br00001")
+    generated_br00002_csv = x_ideas.get("br00002")
+    generated_br00003_csv = x_ideas.get("br00003")
+    generated_br00004_csv = x_ideas.get("br00004")
+    generated_br00005_csv = x_ideas.get("br00005")
     # print(f" {expected_br00000_csv=}")
     # print(f"{generated_br00000_csv=}")
     assert generated_br00000_csv == expected_br00000_csv
@@ -294,7 +294,7 @@ def test_add_fiscunits_to_stance_csv_strs_ReturnsObj_Scenario1_TwoFiscUnits(
 def test_add_bud_to_br00020_csv_ReturnsObj():
     # ESTABLISH
     csv_delimiter = ","
-    x_ideabricks = create_init_stance_idea_brick_csv_strs()
+    x_ideas = create_init_stance_idea_csv_strs()
     bob_str = "Bob"
     yao_str = "Yao"
     a23_str = "accord23"
@@ -304,7 +304,7 @@ def test_add_bud_to_br00020_csv_ReturnsObj():
     run_credit = 33
     run_debtit = 55
     bob_bud.get_acct(yao_str).add_membership(run_str, run_credit, run_debtit)
-    csv_header = x_ideabricks.get("br00020")
+    csv_header = x_ideas.get("br00020")
 
     # WHEN
     x_csv = add_bud_to_br00020_csv(csv_header, bob_bud, csv_delimiter)
@@ -322,7 +322,7 @@ def test_add_bud_to_br00020_csv_ReturnsObj():
 def test_add_bud_to_br00021_csv_ReturnsObj():
     # ESTABLISH
     csv_delimiter = ","
-    x_ideabricks = create_init_stance_idea_brick_csv_strs()
+    x_ideas = create_init_stance_idea_csv_strs()
     bob_str = "Bob"
     yao_str = "Yao"
     yao_credit = 33
@@ -330,7 +330,7 @@ def test_add_bud_to_br00021_csv_ReturnsObj():
     a23_str = "accord23"
     bob_bud = budunit_shop(bob_str, a23_str)
     bob_bud.add_acctunit(yao_str, yao_credit, yao_debtit)
-    csv_header = x_ideabricks.get("br00021")
+    csv_header = x_ideas.get("br00021")
 
     # WHEN
     x_csv = add_bud_to_br00021_csv(csv_header, bob_bud, csv_delimiter)
@@ -343,7 +343,7 @@ def test_add_bud_to_br00021_csv_ReturnsObj():
 def test_add_bud_to_br00022_csv_ReturnsObj():
     # ESTABLISH
     csv_delimiter = ","
-    x_ideabricks = create_init_stance_idea_brick_csv_strs()
+    x_ideas = create_init_stance_idea_csv_strs()
     bob_str = "Bob"
     a23_str = "accord23"
     bob_bud = budunit_shop(bob_str, a23_str)
@@ -354,7 +354,7 @@ def test_add_bud_to_br00022_csv_ReturnsObj():
     casa_awardlink = awardlink_shop(yao_str, yao_give_force, yao_take_force)
     bob_bud.add_item(casa_road)
     bob_bud.edit_item_attr(casa_road, awardlink=casa_awardlink)
-    csv_header = x_ideabricks.get("br00022")
+    csv_header = x_ideas.get("br00022")
     print(f"{csv_header=}")
 
     # WHEN
@@ -369,7 +369,7 @@ def test_add_bud_to_br00022_csv_ReturnsObj():
 def test_add_bud_to_br00023_csv_ReturnsObj():
     # ESTABLISH
     csv_delimiter = ","
-    x_ideabricks = create_init_stance_idea_brick_csv_strs()
+    x_ideas = create_init_stance_idea_csv_strs()
     bob_str = "Bob"
     a23_str = "accord23"
     bob_bud = budunit_shop(bob_str, a23_str)
@@ -380,7 +380,7 @@ def test_add_bud_to_br00023_csv_ReturnsObj():
     bob_bud.add_item(casa_road)
     bob_bud.add_item(clean_road)
     bob_bud.add_fact(casa_road, clean_road, clean_fopen, clean_fnigh)
-    csv_header = x_ideabricks.get("br00023")
+    csv_header = x_ideas.get("br00023")
     print(f"{csv_header=}")
 
     # WHEN
@@ -394,7 +394,7 @@ def test_add_bud_to_br00023_csv_ReturnsObj():
 def test_add_bud_to_br00024_csv_ReturnsObj():
     # ESTABLISH
     csv_delimiter = ","
-    x_ideabricks = create_init_stance_idea_brick_csv_strs()
+    x_ideas = create_init_stance_idea_csv_strs()
     bob_str = "Bob"
     a23_str = "accord23"
     bob_bud = budunit_shop(bob_str, a23_str)
@@ -403,7 +403,7 @@ def test_add_bud_to_br00024_csv_ReturnsObj():
     casa_item = bob_bud.get_item_obj(casa_road)
     cleaners_str = "cleaners"
     casa_item.teamunit.set_teamlink(cleaners_str)
-    csv_header = x_ideabricks.get("br00024")
+    csv_header = x_ideas.get("br00024")
     print(f"{csv_header=}")
 
     # WHEN
@@ -418,7 +418,7 @@ def test_add_bud_to_br00024_csv_ReturnsObj():
 def test_add_bud_to_br00025_csv_ReturnsObj():
     # ESTABLISH
     csv_delimiter = ","
-    x_ideabricks = create_init_stance_idea_brick_csv_strs()
+    x_ideas = create_init_stance_idea_csv_strs()
     bob_str = "Bob"
     a23_str = "accord23"
     bob_bud = budunit_shop(bob_str, a23_str)
@@ -427,7 +427,7 @@ def test_add_bud_to_br00025_csv_ReturnsObj():
     casa_item = bob_bud.get_item_obj(casa_road)
     cleaners_str = "cleaners"
     casa_item.healerlink.set_healer_name(cleaners_str)
-    csv_header = x_ideabricks.get("br00025")
+    csv_header = x_ideas.get("br00025")
     print(f"{csv_header=}")
 
     # WHEN
@@ -442,7 +442,7 @@ def test_add_bud_to_br00025_csv_ReturnsObj():
 def test_add_bud_to_br00026_csv_ReturnsObj():
     # ESTABLISH
     csv_delimiter = ","
-    x_ideabricks = create_init_stance_idea_brick_csv_strs()
+    x_ideas = create_init_stance_idea_csv_strs()
     bob_str = "Bob"
     a23_str = "accord23"
     bob_bud = budunit_shop(bob_str, a23_str)
@@ -463,7 +463,7 @@ def test_add_bud_to_br00026_csv_ReturnsObj():
         reason_premise_nigh=clean_premise_nigh,
         reason_premise_divisor=clean_premise_divisor,
     )
-    csv_header = x_ideabricks.get("br00026")
+    csv_header = x_ideas.get("br00026")
     print(f"{csv_header=}")
 
     # WHEN
@@ -478,7 +478,7 @@ def test_add_bud_to_br00026_csv_ReturnsObj():
 def test_add_bud_to_br00027_csv_ReturnsObj():
     # ESTABLISH
     csv_delimiter = ","
-    x_ideabricks = create_init_stance_idea_brick_csv_strs()
+    x_ideas = create_init_stance_idea_csv_strs()
     bob_str = "Bob"
     a23_str = "accord23"
     bob_bud = budunit_shop(bob_str, a23_str)
@@ -491,7 +491,7 @@ def test_add_bud_to_br00027_csv_ReturnsObj():
         reason_base=casa_road,
         reason_base_item_active_requisite=True,
     )
-    csv_header = x_ideabricks.get("br00027")
+    csv_header = x_ideas.get("br00027")
     print(f"{csv_header=}")
 
     # WHEN
@@ -506,7 +506,7 @@ def test_add_bud_to_br00027_csv_ReturnsObj():
 def test_add_bud_to_br00028_csv_ReturnsObj():
     # ESTABLISH
     csv_delimiter = ","
-    x_ideabricks = create_init_stance_idea_brick_csv_strs()
+    x_ideas = create_init_stance_idea_csv_strs()
     bob_str = "Bob"
     a23_str = "accord23"
     bob_bud = budunit_shop(bob_str, a23_str)
@@ -539,7 +539,7 @@ def test_add_bud_to_br00028_csv_ReturnsObj():
         pledge=casa_pledge,
         problem_bool=casa_problem_bool,
     )
-    csv_header = x_ideabricks.get("br00028")
+    csv_header = x_ideas.get("br00028")
     print(f"{csv_header=}")
 
     # WHEN
@@ -560,7 +560,7 @@ def test_add_bud_to_br00028_csv_ReturnsObj():
 def test_add_bud_to_br00029_csv_ReturnsObj():
     # ESTABLISH
     csv_delimiter = ","
-    x_ideabricks = create_init_stance_idea_brick_csv_strs()
+    x_ideas = create_init_stance_idea_csv_strs()
     bob_str = "Bob"
     a23_str = "accord23"
     bob_bud = budunit_shop(bob_str, a23_str)
@@ -572,7 +572,7 @@ def test_add_bud_to_br00029_csv_ReturnsObj():
     bob_bud.fund_coin = 12
     bob_bud.penny = 13
     bob_bud.respect_bit = 15
-    csv_header = x_ideabricks.get("br00029")
+    csv_header = x_ideas.get("br00029")
     print(f"{csv_header=}")
 
     # WHEN
@@ -586,7 +586,7 @@ def test_add_bud_to_br00029_csv_ReturnsObj():
 def test_add_budunit_to_stance_csv_strs_ReturnsObj():
     # ESTABLISH
     csv_delimiter = ","
-    x_ideabricks = create_init_stance_idea_brick_csv_strs()
+    x_ideas = create_init_stance_idea_csv_strs()
     bob_str = "Bob"
     yao_str = "Yao"
     a23_str = "accord23"
@@ -603,38 +603,38 @@ def test_add_budunit_to_stance_csv_strs_ReturnsObj():
     bob_bud.edit_item_attr(casa_road, awardlink=awardlink_shop(yao_str))
     bob_bud.add_fact(casa_road, clean_road)
 
-    br00020_header = x_ideabricks.get("br00020")
-    br00021_header = x_ideabricks.get("br00021")
-    br00022_header = x_ideabricks.get("br00022")
-    br00023_header = x_ideabricks.get("br00023")
-    br00024_header = x_ideabricks.get("br00024")
-    br00025_header = x_ideabricks.get("br00025")
-    br00026_header = x_ideabricks.get("br00026")
-    br00027_header = x_ideabricks.get("br00027")
-    br00028_header = x_ideabricks.get("br00028")
-    br00029_header = x_ideabricks.get("br00029")
+    br00020_header = x_ideas.get("br00020")
+    br00021_header = x_ideas.get("br00021")
+    br00022_header = x_ideas.get("br00022")
+    br00023_header = x_ideas.get("br00023")
+    br00024_header = x_ideas.get("br00024")
+    br00025_header = x_ideas.get("br00025")
+    br00026_header = x_ideas.get("br00026")
+    br00027_header = x_ideas.get("br00027")
+    br00028_header = x_ideas.get("br00028")
+    br00029_header = x_ideas.get("br00029")
 
     # WHEN
     bob_bud.settle_bud()
-    add_budunit_to_stance_csv_strs(bob_bud, x_ideabricks, csv_delimiter)
+    add_budunit_to_stance_csv_strs(bob_bud, x_ideas, csv_delimiter)
 
     # THEN
-    assert x_ideabricks.get("br00020") != br00020_header
-    assert x_ideabricks.get("br00021") != br00021_header
-    assert x_ideabricks.get("br00022") != br00022_header
-    assert x_ideabricks.get("br00023") != br00023_header
-    # assert x_ideabricks.get("br00024") != br00024_header
-    # assert x_ideabricks.get("br00025") != br00025_header
-    assert x_ideabricks.get("br00026") != br00026_header
-    assert x_ideabricks.get("br00027") != br00027_header
-    assert x_ideabricks.get("br00028") != br00028_header
-    assert x_ideabricks.get("br00029") != br00029_header
+    assert x_ideas.get("br00020") != br00020_header
+    assert x_ideas.get("br00021") != br00021_header
+    assert x_ideas.get("br00022") != br00022_header
+    assert x_ideas.get("br00023") != br00023_header
+    # assert x_ideas.get("br00024") != br00024_header
+    # assert x_ideas.get("br00025") != br00025_header
+    assert x_ideas.get("br00026") != br00026_header
+    assert x_ideas.get("br00027") != br00027_header
+    assert x_ideas.get("br00028") != br00028_header
+    assert x_ideas.get("br00029") != br00029_header
 
 
 def test_add_to_br00042_csv_ReturnsObj():
     # ESTABLISH
     csv_delimiter = ","
-    x_ideabricks = create_init_stance_idea_brick_csv_strs()
+    x_ideas = create_init_stance_idea_csv_strs()
     bob_str = "Bob"
     event7 = 7
     bob_otx_bridge = ";"
@@ -646,7 +646,7 @@ def test_add_to_br00042_csv_ReturnsObj():
     run_otx = "run"
     run_inx = "cours"
     bob7_pidginunit.set_otx2inx("LabelUnit", run_otx, run_inx)
-    csv_header = x_ideabricks.get("br00042")
+    csv_header = x_ideas.get("br00042")
     print(f"{csv_header=}")
 
     # WHEN
@@ -660,7 +660,7 @@ def test_add_to_br00042_csv_ReturnsObj():
 def test_add_to_br00043_csv_ReturnsObj():
     # ESTABLISH
     csv_delimiter = ","
-    x_ideabricks = create_init_stance_idea_brick_csv_strs()
+    x_ideas = create_init_stance_idea_csv_strs()
     bob_str = "Bob"
     event7 = 7
     bob_otx_bridge = ";"
@@ -672,7 +672,7 @@ def test_add_to_br00043_csv_ReturnsObj():
     yao_otx = "Yao"
     yao_inx = "YaoMing"
     bob7_pidginunit.set_otx2inx("NameUnit", yao_otx, yao_inx)
-    csv_header = x_ideabricks.get("br00043")
+    csv_header = x_ideas.get("br00043")
     print(f"{csv_header=}")
 
     # WHEN
@@ -686,7 +686,7 @@ def test_add_to_br00043_csv_ReturnsObj():
 def test_add_to_br00044_csv_ReturnsObj():
     # ESTABLISH
     csv_delimiter = ","
-    x_ideabricks = create_init_stance_idea_brick_csv_strs()
+    x_ideas = create_init_stance_idea_csv_strs()
     bob_str = "Bob"
     event7 = 7
     bob_otx_bridge = ";"
@@ -698,7 +698,7 @@ def test_add_to_br00044_csv_ReturnsObj():
     clean_otx = "clean"
     clean_inx = "prope"
     bob7_pidginunit.set_otx2inx("TagUnit", clean_otx, clean_inx)
-    csv_header = x_ideabricks.get("br00044")
+    csv_header = x_ideas.get("br00044")
     print(f"{csv_header=}")
 
     # WHEN
@@ -712,7 +712,7 @@ def test_add_to_br00044_csv_ReturnsObj():
 def test_add_to_br00045_csv_ReturnsObj():
     # ESTABLISH
     csv_delimiter = ","
-    x_ideabricks = create_init_stance_idea_brick_csv_strs()
+    x_ideas = create_init_stance_idea_csv_strs()
     bob_str = "Bob"
     event7 = 7
     bob_otx_bridge = ";"
@@ -724,7 +724,7 @@ def test_add_to_br00045_csv_ReturnsObj():
     clean_otx = "clean"
     clean_inx = "prope"
     bob7_pidginunit.set_otx2inx("RoadUnit", clean_otx, clean_inx)
-    csv_header = x_ideabricks.get("br00045")
+    csv_header = x_ideas.get("br00045")
     print(f"{csv_header=}")
 
     # WHEN
@@ -738,7 +738,7 @@ def test_add_to_br00045_csv_ReturnsObj():
 def test_add_pidginunit_to_stance_csv_strs_ReturnsObj():
     # ESTABLISH
     csv_delimiter = ","
-    x_ideabricks = create_init_stance_idea_brick_csv_strs()
+    x_ideas = create_init_stance_idea_csv_strs()
     bob_str = "Bob"
     event7 = 7
     bob_otx_bridge = ";"
@@ -759,25 +759,25 @@ def test_add_pidginunit_to_stance_csv_strs_ReturnsObj():
     clean_otx = "clean"
     clean_inx = "prope"
     bob7_pidginunit.set_otx2inx("TagUnit", clean_otx, clean_inx)
-    br00042_header = x_ideabricks.get("br00042")
-    br00043_header = x_ideabricks.get("br00043")
-    br00044_header = x_ideabricks.get("br00044")
-    br00045_header = x_ideabricks.get("br00045")
+    br00042_header = x_ideas.get("br00042")
+    br00043_header = x_ideas.get("br00043")
+    br00044_header = x_ideas.get("br00044")
+    br00045_header = x_ideas.get("br00045")
 
     # WHEN
-    add_pidginunit_to_stance_csv_strs(bob7_pidginunit, x_ideabricks, csv_delimiter)
+    add_pidginunit_to_stance_csv_strs(bob7_pidginunit, x_ideas, csv_delimiter)
 
     # THEN
-    assert x_ideabricks.get("br00042") != br00042_header
-    assert x_ideabricks.get("br00043") != br00043_header
-    assert x_ideabricks.get("br00044") != br00044_header
-    assert x_ideabricks.get("br00045") != br00045_header
+    assert x_ideas.get("br00042") != br00042_header
+    assert x_ideas.get("br00043") != br00043_header
+    assert x_ideas.get("br00044") != br00044_header
+    assert x_ideas.get("br00045") != br00045_header
 
 
 def test_add_pack_to_br00020_csv_ReturnsObj():
     # ESTABLISH
     csv_delimiter = ","
-    x_ideabricks = create_init_stance_idea_brick_csv_strs()
+    x_ideas = create_init_stance_idea_csv_strs()
     bob_str = "Bob"
     yao_str = "Yao"
     a23_str = "accord23"
@@ -793,7 +793,7 @@ def test_add_pack_to_br00020_csv_ReturnsObj():
     event7 = 7
     sue7_pack = packunit_shop(bob_str, sue_str, a23_str, event_int=event7)
     sue7_pack.set_buddelta(bob_buddelta)
-    csv_header = x_ideabricks.get("br00020")
+    csv_header = x_ideas.get("br00020")
 
     # WHEN
     x_csv = add_pack_to_br00020_csv(csv_header, sue7_pack, csv_delimiter)
@@ -810,7 +810,7 @@ def test_add_pack_to_br00020_csv_ReturnsObj():
 def test_add_pack_to_br00021_csv_ReturnsObj():
     # ESTABLISH
     csv_delimiter = ","
-    x_ideabricks = create_init_stance_idea_brick_csv_strs()
+    x_ideas = create_init_stance_idea_csv_strs()
     bob_str = "Bob"
     yao_str = "Yao"
     yao_credit = 33
@@ -824,7 +824,7 @@ def test_add_pack_to_br00021_csv_ReturnsObj():
     event7 = 7
     sue7_pack = packunit_shop(bob_str, sue_str, a23_str, event_int=event7)
     sue7_pack.set_buddelta(bob_buddelta)
-    csv_header = x_ideabricks.get("br00021")
+    csv_header = x_ideas.get("br00021")
 
     # WHEN
     x_csv = add_pack_to_br00021_csv(csv_header, sue7_pack, csv_delimiter)
@@ -839,7 +839,7 @@ def test_add_pack_to_br00021_csv_ReturnsObj():
 def test_add_pack_to_br00022_csv_ReturnsObj():
     # ESTABLISH
     csv_delimiter = ","
-    x_ideabricks = create_init_stance_idea_brick_csv_strs()
+    x_ideas = create_init_stance_idea_csv_strs()
     bob_str = "Bob"
     a23_str = "accord23"
     bob_bud = budunit_shop(bob_str, a23_str)
@@ -856,7 +856,7 @@ def test_add_pack_to_br00022_csv_ReturnsObj():
     event7 = 7
     sue7_pack = packunit_shop(bob_str, sue_str, a23_str, event_int=event7)
     sue7_pack.set_buddelta(bob_buddelta)
-    csv_header = x_ideabricks.get("br00022")
+    csv_header = x_ideas.get("br00022")
     print(f"{csv_header=}")
 
     # WHEN
@@ -870,7 +870,7 @@ def test_add_pack_to_br00022_csv_ReturnsObj():
 def test_add_pack_to_br00023_csv_ReturnsObj():
     # ESTABLISH
     csv_delimiter = ","
-    x_ideabricks = create_init_stance_idea_brick_csv_strs()
+    x_ideas = create_init_stance_idea_csv_strs()
     bob_str = "Bob"
     a23_str = "accord23"
     bob_bud = budunit_shop(bob_str, a23_str)
@@ -887,7 +887,7 @@ def test_add_pack_to_br00023_csv_ReturnsObj():
     event7 = 7
     sue7_pack = packunit_shop(bob_str, sue_str, a23_str, event_int=event7)
     sue7_pack.set_buddelta(bob_buddelta)
-    csv_header = x_ideabricks.get("br00023")
+    csv_header = x_ideas.get("br00023")
     print(f"{csv_header=}")
 
     # WHEN
@@ -904,7 +904,7 @@ def test_add_pack_to_br00023_csv_ReturnsObj():
 def test_add_pack_to_br00024_csv_ReturnsObj():
     # ESTABLISH
     csv_delimiter = ","
-    x_ideabricks = create_init_stance_idea_brick_csv_strs()
+    x_ideas = create_init_stance_idea_csv_strs()
     bob_str = "Bob"
     a23_str = "accord23"
     bob_bud = budunit_shop(bob_str, a23_str)
@@ -919,7 +919,7 @@ def test_add_pack_to_br00024_csv_ReturnsObj():
     event7 = 7
     sue7_pack = packunit_shop(bob_str, sue_str, a23_str, event_int=event7)
     sue7_pack.set_buddelta(bob_buddelta)
-    csv_header = x_ideabricks.get("br00024")
+    csv_header = x_ideas.get("br00024")
     print(f"{csv_header=}")
 
     # WHEN
@@ -938,7 +938,7 @@ def test_add_pack_to_br00024_csv_ReturnsObj():
 def test_add_pack_to_br00025_csv_ReturnsObj():
     # ESTABLISH
     csv_delimiter = ","
-    x_ideabricks = create_init_stance_idea_brick_csv_strs()
+    x_ideas = create_init_stance_idea_csv_strs()
     bob_str = "Bob"
     a23_str = "accord23"
     bob_bud = budunit_shop(bob_str, a23_str)
@@ -953,7 +953,7 @@ def test_add_pack_to_br00025_csv_ReturnsObj():
     event7 = 7
     sue7_pack = packunit_shop(bob_str, sue_str, a23_str, event_int=event7)
     sue7_pack.set_buddelta(bob_buddelta)
-    csv_header = x_ideabricks.get("br00025")
+    csv_header = x_ideas.get("br00025")
     print(f"{csv_header=}")
 
     # WHEN
@@ -969,7 +969,7 @@ def test_add_pack_to_br00025_csv_ReturnsObj():
 def test_add_pack_to_br00026_csv_ReturnsObj():
     # ESTABLISH
     csv_delimiter = ","
-    x_ideabricks = create_init_stance_idea_brick_csv_strs()
+    x_ideas = create_init_stance_idea_csv_strs()
     bob_str = "Bob"
     a23_str = "accord23"
     bob_bud = budunit_shop(bob_str, a23_str)
@@ -996,7 +996,7 @@ def test_add_pack_to_br00026_csv_ReturnsObj():
     event7 = 7
     sue7_pack = packunit_shop(bob_str, sue_str, a23_str, event_int=event7)
     sue7_pack.set_buddelta(bob_buddelta)
-    csv_header = x_ideabricks.get("br00026")
+    csv_header = x_ideas.get("br00026")
     print(f"{csv_header=}")
 
     # WHEN
@@ -1010,7 +1010,7 @@ def test_add_pack_to_br00026_csv_ReturnsObj():
 def test_add_pack_to_br00027_csv_ReturnsObj():
     # ESTABLISH
     csv_delimiter = ","
-    x_ideabricks = create_init_stance_idea_brick_csv_strs()
+    x_ideas = create_init_stance_idea_csv_strs()
     bob_str = "Bob"
     a23_str = "accord23"
     bob_bud = budunit_shop(bob_str, a23_str)
@@ -1029,7 +1029,7 @@ def test_add_pack_to_br00027_csv_ReturnsObj():
     event7 = 7
     sue7_pack = packunit_shop(bob_str, sue_str, a23_str, event_int=event7)
     sue7_pack.set_buddelta(bob_buddelta)
-    csv_header = x_ideabricks.get("br00027")
+    csv_header = x_ideas.get("br00027")
     print(f"{csv_header=}")
 
     # WHEN
@@ -1043,7 +1043,7 @@ def test_add_pack_to_br00027_csv_ReturnsObj():
 def test_add_pack_to_br00028_csv_ReturnsObj():
     # ESTABLISH
     csv_delimiter = ","
-    x_ideabricks = create_init_stance_idea_brick_csv_strs()
+    x_ideas = create_init_stance_idea_csv_strs()
     bob_str = "Bob"
     a23_str = "accord23"
     bob_bud = budunit_shop(bob_str, a23_str)
@@ -1082,7 +1082,7 @@ def test_add_pack_to_br00028_csv_ReturnsObj():
     event7 = 7
     sue7_pack = packunit_shop(bob_str, sue_str, a23_str, event_int=event7)
     sue7_pack.set_buddelta(bob_buddelta)
-    csv_header = x_ideabricks.get("br00028")
+    csv_header = x_ideas.get("br00028")
     print(f"{csv_header=}")
 
     # WHEN
@@ -1103,7 +1103,7 @@ def test_add_pack_to_br00028_csv_ReturnsObj():
 def test_add_pack_to_br00029_csv_ReturnsObj():
     # ESTABLISH
     csv_delimiter = ","
-    x_ideabricks = create_init_stance_idea_brick_csv_strs()
+    x_ideas = create_init_stance_idea_csv_strs()
     bob_str = "Bob"
     a23_str = "accord23"
     bob_bud = budunit_shop(bob_str, a23_str)
@@ -1121,7 +1121,7 @@ def test_add_pack_to_br00029_csv_ReturnsObj():
     event7 = 7
     sue7_pack = packunit_shop(bob_str, sue_str, a23_str, event_int=event7)
     sue7_pack.set_buddelta(bob_buddelta)
-    csv_header = x_ideabricks.get("br00029")
+    csv_header = x_ideas.get("br00029")
     print(f"{csv_header=}")
 
     # WHEN
@@ -1135,7 +1135,7 @@ def test_add_pack_to_br00029_csv_ReturnsObj():
 def test_add_packunit_to_stance_csv_strs_ReturnsObj():
     # ESTABLISH
     csv_delimiter = ","
-    x_ideabricks = create_init_stance_idea_brick_csv_strs()
+    x_ideas = create_init_stance_idea_csv_strs()
     bob_str = "Bob"
     yao_str = "Yao"
     a23_str = "accord23"
@@ -1166,38 +1166,38 @@ def test_add_packunit_to_stance_csv_strs_ReturnsObj():
     sue7_pack = packunit_shop(bob_str, sue_str, a23_str, event_int=event7)
     sue7_pack.set_buddelta(bob_buddelta)
 
-    br00020_header = x_ideabricks.get("br00020")
-    br00021_header = x_ideabricks.get("br00021")
-    br00022_header = x_ideabricks.get("br00022")
-    br00023_header = x_ideabricks.get("br00023")
-    br00024_header = x_ideabricks.get("br00024")
-    br00025_header = x_ideabricks.get("br00025")
-    br00026_header = x_ideabricks.get("br00026")
-    br00027_header = x_ideabricks.get("br00027")
-    br00028_header = x_ideabricks.get("br00028")
-    br00029_header = x_ideabricks.get("br00029")
+    br00020_header = x_ideas.get("br00020")
+    br00021_header = x_ideas.get("br00021")
+    br00022_header = x_ideas.get("br00022")
+    br00023_header = x_ideas.get("br00023")
+    br00024_header = x_ideas.get("br00024")
+    br00025_header = x_ideas.get("br00025")
+    br00026_header = x_ideas.get("br00026")
+    br00027_header = x_ideas.get("br00027")
+    br00028_header = x_ideas.get("br00028")
+    br00029_header = x_ideas.get("br00029")
 
     # WHEN
-    add_packunit_to_stance_csv_strs(sue7_pack, x_ideabricks, csv_delimiter)
+    add_packunit_to_stance_csv_strs(sue7_pack, x_ideas, csv_delimiter)
 
     # THEN
-    assert x_ideabricks.get("br00020") != br00020_header
-    assert x_ideabricks.get("br00021") != br00021_header
-    assert x_ideabricks.get("br00022") != br00022_header
-    assert x_ideabricks.get("br00023") != br00023_header
-    # assert x_ideabricks.get("br00024") != br00024_header
-    # assert x_ideabricks.get("br00025") != br00025_header
-    assert x_ideabricks.get("br00026") != br00026_header
-    assert x_ideabricks.get("br00027") != br00027_header
-    assert x_ideabricks.get("br00028") != br00028_header
-    assert x_ideabricks.get("br00029") != br00029_header
+    assert x_ideas.get("br00020") != br00020_header
+    assert x_ideas.get("br00021") != br00021_header
+    assert x_ideas.get("br00022") != br00022_header
+    assert x_ideas.get("br00023") != br00023_header
+    # assert x_ideas.get("br00024") != br00024_header
+    # assert x_ideas.get("br00025") != br00025_header
+    assert x_ideas.get("br00026") != br00026_header
+    assert x_ideas.get("br00027") != br00027_header
+    assert x_ideas.get("br00028") != br00028_header
+    assert x_ideas.get("br00029") != br00029_header
 
 
-# TODO create function that saves excel file with all x_ideabricks
+# TODO create function that saves excel file with all x_ideas
 # def test_add_packunit_to_stance_csv_strs_ReturnsObj():
 #     # ESTABLISH
 #     csv_delimiter = ","
-#     x_ideabricks = create_init_stance_idea_brick_csv_strs()
+#     x_ideas = create_init_stance_idea_csv_strs()
 #     bob_str = "Bob"
 #     yao_str = "Yao"
 #     a23_str = "accord23"
@@ -1228,28 +1228,28 @@ def test_add_packunit_to_stance_csv_strs_ReturnsObj():
 #     sue7_pack = packunit_shop(bob_str, sue_str, a23_str, event_int=event7)
 #     sue7_pack.set_buddelta(bob_buddelta)
 
-#     br00020_header = x_ideabricks.get("br00020")
-#     br00021_header = x_ideabricks.get("br00021")
-#     br00022_header = x_ideabricks.get("br00022")
-#     br00023_header = x_ideabricks.get("br00023")
-#     br00024_header = x_ideabricks.get("br00024")
-#     br00025_header = x_ideabricks.get("br00025")
-#     br00026_header = x_ideabricks.get("br00026")
-#     br00027_header = x_ideabricks.get("br00027")
-#     br00028_header = x_ideabricks.get("br00028")
-#     br00029_header = x_ideabricks.get("br00029")
-#     add_packunit_to_stance_csv_strs(sue7_pack, x_ideabricks, csv_delimiter)
+#     br00020_header = x_ideas.get("br00020")
+#     br00021_header = x_ideas.get("br00021")
+#     br00022_header = x_ideas.get("br00022")
+#     br00023_header = x_ideas.get("br00023")
+#     br00024_header = x_ideas.get("br00024")
+#     br00025_header = x_ideas.get("br00025")
+#     br00026_header = x_ideas.get("br00026")
+#     br00027_header = x_ideas.get("br00027")
+#     br00028_header = x_ideas.get("br00028")
+#     br00029_header = x_ideas.get("br00029")
+#     add_packunit_to_stance_csv_strs(sue7_pack, x_ideas, csv_delimiter)
 
 #     # WHEN
 #     assert 1 == 2
 
-#     # assert x_ideabricks.get("br00020") != br00020_header
-#     # assert x_ideabricks.get("br00021") != br00021_header
-#     # assert x_ideabricks.get("br00022") != br00022_header
-#     # assert x_ideabricks.get("br00023") != br00023_header
-#     # # assert x_ideabricks.get("br00024") != br00024_header
-#     # # assert x_ideabricks.get("br00025") != br00025_header
-#     # assert x_ideabricks.get("br00026") != br00026_header
-#     # assert x_ideabricks.get("br00027") != br00027_header
-#     # assert x_ideabricks.get("br00028") != br00028_header
-#     # assert x_ideabricks.get("br00029") != br00029_header
+#     # assert x_ideas.get("br00020") != br00020_header
+#     # assert x_ideas.get("br00021") != br00021_header
+#     # assert x_ideas.get("br00022") != br00022_header
+#     # assert x_ideas.get("br00023") != br00023_header
+#     # # assert x_ideas.get("br00024") != br00024_header
+#     # # assert x_ideas.get("br00025") != br00025_header
+#     # assert x_ideas.get("br00026") != br00026_header
+#     # assert x_ideas.get("br00027") != br00027_header
+#     # assert x_ideas.get("br00028") != br00028_header
+#     # assert x_ideas.get("br00029") != br00029_header

--- a/src/a18_etl_toolbox/stance_tool.py
+++ b/src/a18_etl_toolbox/stance_tool.py
@@ -5,7 +5,7 @@ from src.a15_fisc_logic.fisc import (
     get_from_default_path as fiscunit_get_from_default_path,
 )
 from src.a17_idea_logic.idea_csv_tool import (
-    create_init_stance_idea_brick_csv_strs,
+    create_init_stance_idea_csv_strs,
     add_fiscunit_to_stance_csv_strs,
     add_budunit_to_stance_csv_strs,
     add_pidginunit_to_stance_csv_strs,
@@ -16,7 +16,7 @@ from os.path import exists as os_path_exists
 
 
 def collect_stance_csv_strs(fisc_mstr_dir: str) -> dict[str, str]:
-    x_csv_strs = create_init_stance_idea_brick_csv_strs()
+    x_csv_strs = create_init_stance_idea_csv_strs()
     fiscs_dir = create_path(fisc_mstr_dir, "fiscs")
     for fisc_tag in get_level1_dirs(fiscs_dir):
         x_fiscunit = fiscunit_get_from_default_path(fisc_mstr_dir, fisc_tag)

--- a/src/a18_etl_toolbox/test_/test__tran_path_.py
+++ b/src/a18_etl_toolbox/test_/test__tran_path_.py
@@ -1,8 +1,8 @@
 from src.a00_data_toolbox.file_toolbox import create_path
 from src.a18_etl_toolbox.tran_path import (
-    YELL_PIDGIN_FILENAME,
+    BRICK_PIDGIN_FILENAME,
     STANCE0001_FILENAME,
-    create_yell_pidgin_path,
+    create_brick_pidgin_path,
     create_syntax_otx_pidgin_path,
     create_otx_event_pidgin_path,
     create_stances_dir_path,
@@ -17,20 +17,20 @@ from src.a18_etl_toolbox._utils.env_a18 import (
 
 def test_hub_path_constants_are_values():
     # ESTABLISH / WHEN / THEN
-    assert YELL_PIDGIN_FILENAME == "pidgin.xlsx"
+    assert BRICK_PIDGIN_FILENAME == "pidgin.xlsx"
     assert STANCE0001_FILENAME == "stance0001.xlsx"
 
 
-def test_create_yell_pidgin_path_ReturnObj():
+def test_create_brick_pidgin_path_ReturnObj():
     # ESTABLISH
-    x_yell_dir = get_module_temp_dir()
+    x_brick_dir = get_module_temp_dir()
 
     # WHEN
-    gen_yell_event_path = create_yell_pidgin_path(x_yell_dir)
+    gen_brick_event_path = create_brick_pidgin_path(x_brick_dir)
 
     # THEN
-    expected_yell_event_path = create_path(x_yell_dir, YELL_PIDGIN_FILENAME)
-    assert gen_yell_event_path == expected_yell_event_path
+    expected_brick_event_path = create_path(x_brick_dir, BRICK_PIDGIN_FILENAME)
+    assert gen_brick_event_path == expected_brick_event_path
 
 
 def test_create_syntax_otx_pidgin_path_ReturnObj():
@@ -43,7 +43,7 @@ def test_create_syntax_otx_pidgin_path_ReturnObj():
 
     # THEN
     bob_otz_path = create_path(syntax_otz_dir, bob_str)
-    expected_pidgin_path = create_path(bob_otz_path, YELL_PIDGIN_FILENAME)
+    expected_pidgin_path = create_path(bob_otz_path, BRICK_PIDGIN_FILENAME)
     assert gen_pidgin_path == expected_pidgin_path
 
 
@@ -59,7 +59,7 @@ def test_create_otx_event_pidgin_path_ReturnObj():
     # THEN
     bob_otz_path = create_path(syntax_otz_dir, bob_str)
     event_path = create_path(bob_otz_path, event7)
-    expected_pidgin_path = create_path(event_path, YELL_PIDGIN_FILENAME)
+    expected_pidgin_path = create_path(event_path, BRICK_PIDGIN_FILENAME)
     assert gen_pidgin_path == expected_pidgin_path
 
 

--- a/src/a18_etl_toolbox/test_/test__tran_path_doc.py
+++ b/src/a18_etl_toolbox/test_/test__tran_path_doc.py
@@ -1,7 +1,7 @@
 from src.a02_finance_logic._utils.strs_a02 import owner_name_str
 from src.a06_bud_logic._utils.str_a06 import event_int_str, face_name_str
 from src.a18_etl_toolbox.tran_path import (
-    create_yell_pidgin_path,
+    create_brick_pidgin_path,
     create_syntax_otx_pidgin_path,
     create_otx_event_pidgin_path,
     create_stances_dir_path,
@@ -14,12 +14,12 @@ from platform import system as platform_system
 LINUX_OS = platform_system() == "Linux"
 
 
-def test_create_yell_pidgin_path_HasDocString():
+def test_create_brick_pidgin_path_HasDocString():
     # ESTABLISH
-    doc_str = create_yell_pidgin_path(yell_dir="yell_dir")
+    doc_str = create_brick_pidgin_path(brick_dir="brick_dir")
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_yell_pidgin_path) == doc_str
+    assert LINUX_OS or inspect_getdoc(create_brick_pidgin_path) == doc_str
 
 
 def test_create_syntax_otx_pidgin_path_HasDocString():

--- a/src/a18_etl_toolbox/test_/test_tran_sqlstrs_pidgin.py
+++ b/src/a18_etl_toolbox/test_/test_tran_sqlstrs_pidgin.py
@@ -71,72 +71,72 @@ def test_get_bud_prime_create_table_sqlstrs_ReturnsObj_HasAllNeededKeys():
 def test_create_pidgin_prime_tables_CreatesPidginPrimeTables():
     # ESTABLISH
     with sqlite3_connect(":memory:") as fisc_db_conn:
-        pidnam_raw_table = "pidgin_label_raw"
-        pidnam_agg_table = "pidgin_label_agg"
-        pidtag_raw_table = "pidgin_name_raw"
-        pidtag_agg_table = "pidgin_name_agg"
-        pidroa_raw_table = "pidgin_road_raw"
-        pidroa_agg_table = "pidgin_road_agg"
-        pidlab_raw_table = "pidgin_tag_raw"
-        pidlab_agg_table = "pidgin_tag_agg"
+        pidname_raw_table = "pidgin_label_raw"
+        pidname_agg_table = "pidgin_label_agg"
+        pidtagg_raw_table = "pidgin_name_raw"
+        pidtagg_agg_table = "pidgin_name_agg"
+        pidroad_raw_table = "pidgin_road_raw"
+        pidroad_agg_table = "pidgin_road_agg"
+        pidlabe_raw_table = "pidgin_tag_raw"
+        pidlabe_agg_table = "pidgin_tag_agg"
         cursor = fisc_db_conn.cursor()
-        assert not db_table_exists(cursor, pidnam_raw_table)
-        assert not db_table_exists(cursor, pidnam_agg_table)
-        assert not db_table_exists(cursor, pidtag_raw_table)
-        assert not db_table_exists(cursor, pidtag_agg_table)
-        assert not db_table_exists(cursor, pidroa_raw_table)
-        assert not db_table_exists(cursor, pidroa_agg_table)
-        assert not db_table_exists(cursor, pidlab_raw_table)
-        assert not db_table_exists(cursor, pidlab_agg_table)
+        assert not db_table_exists(cursor, pidname_raw_table)
+        assert not db_table_exists(cursor, pidname_agg_table)
+        assert not db_table_exists(cursor, pidtagg_raw_table)
+        assert not db_table_exists(cursor, pidtagg_agg_table)
+        assert not db_table_exists(cursor, pidroad_raw_table)
+        assert not db_table_exists(cursor, pidroad_agg_table)
+        assert not db_table_exists(cursor, pidlabe_raw_table)
+        assert not db_table_exists(cursor, pidlabe_agg_table)
 
         # WHEN
         create_pidgin_prime_tables(cursor)
 
         # THEN
-        assert db_table_exists(cursor, pidnam_raw_table)
-        assert db_table_exists(cursor, pidnam_agg_table)
-        assert db_table_exists(cursor, pidtag_raw_table)
-        assert db_table_exists(cursor, pidtag_agg_table)
-        assert db_table_exists(cursor, pidroa_raw_table)
-        assert db_table_exists(cursor, pidroa_agg_table)
-        assert db_table_exists(cursor, pidlab_raw_table)
-        assert db_table_exists(cursor, pidlab_agg_table)
+        assert db_table_exists(cursor, pidname_raw_table)
+        assert db_table_exists(cursor, pidname_agg_table)
+        assert db_table_exists(cursor, pidtagg_raw_table)
+        assert db_table_exists(cursor, pidtagg_agg_table)
+        assert db_table_exists(cursor, pidroad_raw_table)
+        assert db_table_exists(cursor, pidroad_agg_table)
+        assert db_table_exists(cursor, pidlabe_raw_table)
+        assert db_table_exists(cursor, pidlabe_agg_table)
 
-        pidnam_raw_columns = get_table_columns(cursor, pidnam_raw_table)
-        pidnam_agg_columns = get_table_columns(cursor, pidnam_agg_table)
-        pidtag_raw_columns = get_table_columns(cursor, pidtag_raw_table)
-        pidtag_agg_columns = get_table_columns(cursor, pidtag_agg_table)
-        pidroa_raw_columns = get_table_columns(cursor, pidroa_raw_table)
-        pidroa_agg_columns = get_table_columns(cursor, pidroa_agg_table)
-        pidlab_raw_columns = get_table_columns(cursor, pidlab_raw_table)
-        pidlab_agg_columns = get_table_columns(cursor, pidlab_agg_table)
+        pidname_raw_columns = get_table_columns(cursor, pidname_raw_table)
+        pidname_agg_columns = get_table_columns(cursor, pidname_agg_table)
+        pidtagg_raw_columns = get_table_columns(cursor, pidtagg_raw_table)
+        pidtagg_agg_columns = get_table_columns(cursor, pidtagg_agg_table)
+        pidroad_raw_columns = get_table_columns(cursor, pidroad_raw_table)
+        pidroad_agg_columns = get_table_columns(cursor, pidroad_agg_table)
+        pidlabe_raw_columns = get_table_columns(cursor, pidlabe_raw_table)
+        pidlabe_agg_columns = get_table_columns(cursor, pidlabe_agg_table)
 
-        print(f"{pidnam_raw_columns=}")
-        print(f"{pidnam_agg_columns=}")
-        assert "error_message" in pidnam_raw_columns
-        assert "error_message" not in pidnam_agg_columns
-        assert "error_message" in pidtag_raw_columns
-        assert "error_message" not in pidtag_agg_columns
-        assert "error_message" in pidroa_raw_columns
-        assert "error_message" not in pidroa_agg_columns
-        assert "error_message" in pidlab_raw_columns
-        assert "error_message" not in pidlab_agg_columns
-        assert idea_number_str() in pidnam_raw_columns
-        assert idea_number_str() not in pidnam_agg_columns
-        assert idea_number_str() in pidtag_raw_columns
-        assert idea_number_str() not in pidtag_agg_columns
-        assert idea_number_str() in pidroa_raw_columns
-        assert idea_number_str() not in pidroa_agg_columns
-        assert idea_number_str() in pidlab_raw_columns
-        assert idea_number_str() not in pidlab_agg_columns
-        assert len(pidnam_raw_columns) == 9
-        assert len(pidnam_agg_columns) == 7
-        assert len(pidtag_raw_columns) == 9
-        assert len(pidtag_agg_columns) == 7
-        assert len(pidroa_raw_columns) == 9
-        assert len(pidroa_agg_columns) == 7
-        assert len(pidlab_raw_columns) == 9
-        assert len(pidlab_agg_columns) == 7
+        print(f"{pidname_raw_columns=}")
+        print(f"{pidname_agg_columns=}")
+        assert "error_message" in pidname_raw_columns
+        assert "error_message" not in pidname_agg_columns
+        assert "error_message" in pidtagg_raw_columns
+        assert "error_message" not in pidtagg_agg_columns
+        assert "error_message" in pidroad_raw_columns
+        assert "error_message" not in pidroad_agg_columns
+        assert "error_message" in pidlabe_raw_columns
+        assert "error_message" not in pidlabe_agg_columns
+        assert idea_number_str() in pidname_raw_columns
+        assert idea_number_str() not in pidname_agg_columns
+        assert idea_number_str() in pidtagg_raw_columns
+        assert idea_number_str() not in pidtagg_agg_columns
+        assert idea_number_str() in pidroad_raw_columns
+        assert idea_number_str() not in pidroad_agg_columns
+        assert idea_number_str() in pidlabe_raw_columns
+        assert idea_number_str() not in pidlabe_agg_columns
+        assert len(pidname_raw_columns) == 9
+        assert len(pidname_agg_columns) == 7
+        assert len(pidtagg_raw_columns) == 9
+        assert len(pidtagg_agg_columns) == 7
+        assert len(pidroad_raw_columns) == 9
+        assert len(pidroad_agg_columns) == 7
+        assert len(pidlabe_raw_columns) == 9
+        assert len(pidlabe_agg_columns) == 7
 
 
 # def test_get_fisc_inconsistency_sqlstrs_ReturnsObj():

--- a/src/a18_etl_toolbox/test_stance/test_stance_tool.py
+++ b/src/a18_etl_toolbox/test_stance/test_stance_tool.py
@@ -4,7 +4,7 @@ from src.a12_hub_tools.hub_path import create_fisc_json_path, create_gut_path
 from src.a15_fisc_logic.fisc import fiscunit_shop
 from src.a17_idea_logic.idea_db_tool import get_sheet_names
 from src.a17_idea_logic.idea_csv_tool import (
-    create_init_stance_idea_brick_csv_strs,
+    create_init_stance_idea_csv_strs,
     add_budunit_to_stance_csv_strs,
     add_fiscunit_to_stance_csv_strs,
 )
@@ -31,7 +31,7 @@ def test_collect_stance_csv_strs_ReturnsObj_Scenario0_NoFiscUnits(
     gen_stance_csv_strs = collect_stance_csv_strs(fisc_mstr_dir)
 
     # THEN
-    expected_stance_csv_strs = create_init_stance_idea_brick_csv_strs()
+    expected_stance_csv_strs = create_init_stance_idea_csv_strs()
     assert gen_stance_csv_strs == expected_stance_csv_strs
 
 
@@ -49,7 +49,7 @@ def test_collect_stance_csv_strs_ReturnsObj_Scenario1_SingleFiscUnit_NoBudUnits(
     gen_stance_csv_strs = collect_stance_csv_strs(fisc_mstr_dir)
 
     # THEN
-    expected_stance_csv_strs = create_init_stance_idea_brick_csv_strs()
+    expected_stance_csv_strs = create_init_stance_idea_csv_strs()
     add_fiscunit_to_stance_csv_strs(a23_fisc, expected_stance_csv_strs, ",")
     assert gen_stance_csv_strs == expected_stance_csv_strs
 
@@ -74,7 +74,7 @@ def test_collect_stance_csv_strs_ReturnsObj_Scenario2_gut_BudUnits(
     gen_stance_csv_strs = collect_stance_csv_strs(fisc_mstr_dir)
 
     # THEN
-    expected_stance_csv_strs = create_init_stance_idea_brick_csv_strs()
+    expected_stance_csv_strs = create_init_stance_idea_csv_strs()
     add_fiscunit_to_stance_csv_strs(a23_fisc, expected_stance_csv_strs, ",")
     add_budunit_to_stance_csv_strs(bob_gut, expected_stance_csv_strs, ",")
     assert gen_stance_csv_strs == expected_stance_csv_strs
@@ -94,5 +94,5 @@ def test_create_stance0001_file_CreatesFile_Scenario0_NoFiscUnits(
     # THEN
     assert os_path_exists(stance0001_path)
     bob_stance0001_sheetnames = get_sheet_names(stance0001_path)
-    stance_csv_strs = create_init_stance_idea_brick_csv_strs()
+    stance_csv_strs = create_init_stance_idea_csv_strs()
     assert set(bob_stance0001_sheetnames) == set(stance_csv_strs.keys())

--- a/src/a18_etl_toolbox/test_tran/test_brick_agg_sheets2_brick_valid_sheets.py
+++ b/src/a18_etl_toolbox/test_tran/test_brick_agg_sheets2_brick_valid_sheets.py
@@ -2,10 +2,10 @@ from src.a00_data_toolbox.file_toolbox import create_path
 from src.a02_finance_logic._utils.strs_a02 import fisc_tag_str
 from src.a06_bud_logic._utils.str_a06 import face_name_str, event_int_str
 from src.a15_fisc_logic._utils.str_a15 import cumlative_minute_str, hour_tag_str
-from src.a17_idea_logic._utils.str_a17 import yell_valid_str, yell_agg_str
+from src.a17_idea_logic._utils.str_a17 import brick_valid_str, brick_agg_str
 from src.a17_idea_logic.idea_db_tool import sheet_exists, upsert_sheet
 from src.a18_etl_toolbox.transformers import (
-    etl_yell_agg_non_pidgin_ideas_to_yell_valid,
+    etl_brick_agg_non_pidgin_ideas_to_brick_valid,
 )
 from src.a18_etl_toolbox._utils.env_a18 import (
     get_module_temp_dir,
@@ -17,7 +17,7 @@ from pandas.testing import (
 from pandas import DataFrame, read_excel as pandas_read_excel
 
 
-def test_etl_yell_agg_non_pidgin_ideas_to_yell_valid_CreatesSheets_Scenario0(
+def test_etl_brick_agg_non_pidgin_ideas_to_brick_valid_CreatesSheets_Scenario0(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -42,24 +42,26 @@ def test_etl_yell_agg_non_pidgin_ideas_to_yell_valid_CreatesSheets_Scenario0(
     row2 = [sue_str, event1, accord23_str, hour7am, minute_420]
     row3 = [yao_str, event3, accord23_str, hour7am, minute_420]
     row4 = [yao_str, event9, accord23_str, hour7am, minute_420]
-    yell_dir = create_path(get_module_temp_dir(), "yell")
-    yell_file_path = create_path(yell_dir, "br00003.xlsx")
-    yell_agg_df = DataFrame([row1, row2, row3, row4], columns=br00003_columns)
-    upsert_sheet(yell_file_path, yell_agg_str(), yell_agg_df)
+    brick_dir = create_path(get_module_temp_dir(), "brick")
+    brick_file_path = create_path(brick_dir, "br00003.xlsx")
+    brick_agg_df = DataFrame([row1, row2, row3, row4], columns=br00003_columns)
+    upsert_sheet(brick_file_path, brick_agg_str(), brick_agg_df)
     legitimate_events = {event1, event9}
-    assert sheet_exists(yell_file_path, yell_valid_str()) is False
+    assert sheet_exists(brick_file_path, brick_valid_str()) is False
 
     # WHEN
-    etl_yell_agg_non_pidgin_ideas_to_yell_valid(yell_dir, legitimate_events)
+    etl_brick_agg_non_pidgin_ideas_to_brick_valid(brick_dir, legitimate_events)
 
     # THEN
-    assert sheet_exists(yell_file_path, yell_valid_str())
-    gen_yell_valid_df = pandas_read_excel(yell_file_path, sheet_name=yell_valid_str())
-    print(f"{gen_yell_valid_df.columns=}")
-    example_yell_valid_df = DataFrame([row1, row2, row4], columns=br00003_columns)
-    assert len(gen_yell_valid_df.columns) == len(example_yell_valid_df.columns)
-    assert list(gen_yell_valid_df.columns) == list(example_yell_valid_df.columns)
-    assert len(gen_yell_valid_df) > 0
-    assert len(gen_yell_valid_df) == 3
-    assert len(gen_yell_valid_df) == len(example_yell_valid_df)
-    pandas_assert_frame_equal(gen_yell_valid_df, example_yell_valid_df)
+    assert sheet_exists(brick_file_path, brick_valid_str())
+    gen_brick_valid_df = pandas_read_excel(
+        brick_file_path, sheet_name=brick_valid_str()
+    )
+    print(f"{gen_brick_valid_df.columns=}")
+    example_brick_valid_df = DataFrame([row1, row2, row4], columns=br00003_columns)
+    assert len(gen_brick_valid_df.columns) == len(example_brick_valid_df.columns)
+    assert list(gen_brick_valid_df.columns) == list(example_brick_valid_df.columns)
+    assert len(gen_brick_valid_df) > 0
+    assert len(gen_brick_valid_df) == 3
+    assert len(gen_brick_valid_df) == len(example_brick_valid_df)
+    pandas_assert_frame_equal(gen_brick_valid_df, example_brick_valid_df)

--- a/src/a18_etl_toolbox/test_tran/test_brick_agg_sheets2brick_events_sheets.py
+++ b/src/a18_etl_toolbox/test_tran/test_brick_agg_sheets2brick_events_sheets.py
@@ -7,17 +7,17 @@ from src.a00_data_toolbox.db_toolbox import (
 from src.a02_finance_logic._utils.strs_a02 import fisc_tag_str
 from src.a06_bud_logic._utils.str_a06 import face_name_str, event_int_str
 from src.a15_fisc_logic._utils.str_a15 import cumlative_minute_str, hour_tag_str
-from src.a17_idea_logic._utils.str_a17 import idea_number_str, yell_agg_str
+from src.a17_idea_logic._utils.str_a17 import idea_number_str, brick_agg_str
 from src.a17_idea_logic.idea_db_tool import create_idea_sorted_table
 from src.a18_etl_toolbox.transformers import (
-    etl_yell_raw_db_to_yell_agg_events_db,
-    etl_yell_agg_events_db_to_yell_valid_events_db,
-    etl_yell_agg_events_db_to_event_dict,
+    etl_brick_raw_db_to_brick_agg_events_db,
+    etl_brick_agg_events_db_to_brick_valid_events_db,
+    etl_brick_agg_events_db_to_event_dict,
 )
 from sqlite3 import connect as sqlite3_connect
 
 
-def test_etl_yell_agg_db_to_yell_agg_events_db_PopulatesTables_Scenario0():
+def test_etl_brick_agg_db_to_brick_agg_events_db_PopulatesTables_Scenario0():
     # ESTABLISH
     a23_str = "accord23"
     sue_str = "Sue"
@@ -29,7 +29,7 @@ def test_etl_yell_agg_db_to_yell_agg_events_db_PopulatesTables_Scenario0():
     minute_420 = 420
     hour6am = "6am"
     hour7am = "7am"
-    agg_br00003_tablename = f"{yell_agg_str()}_br00003"
+    agg_br00003_tablename = f"{brick_agg_str()}_br00003"
     agg_br00003_columns = [
         face_name_str(),
         event_int_str(),
@@ -66,25 +66,25 @@ VALUES
 """
         insert_sqlstr = f"{insert_into_clause} {values_clause}"
         cursor.execute(insert_sqlstr)
-        yell_events_tablename = "yell_agg_events"
+        brick_events_tablename = "brick_agg_events"
         assert get_row_count(cursor, agg_br00003_tablename) == 4
-        assert not db_table_exists(cursor, yell_events_tablename)
+        assert not db_table_exists(cursor, brick_events_tablename)
 
         # WHEN
-        etl_yell_raw_db_to_yell_agg_events_db(cursor)
+        etl_brick_raw_db_to_brick_agg_events_db(cursor)
 
         # THEN
-        assert db_table_exists(cursor, yell_events_tablename)
-        yell_events_table_cols = set(get_table_columns(cursor, yell_events_tablename))
-        assert len(yell_events_table_cols) == 4
-        assert idea_number_str() in yell_events_table_cols
-        assert face_name_str() in yell_events_table_cols
-        assert event_int_str() in yell_events_table_cols
-        assert "error_message" in yell_events_table_cols
-        assert get_row_count(cursor, yell_events_tablename) == 3
+        assert db_table_exists(cursor, brick_events_tablename)
+        brick_events_table_cols = set(get_table_columns(cursor, brick_events_tablename))
+        assert len(brick_events_table_cols) == 4
+        assert idea_number_str() in brick_events_table_cols
+        assert face_name_str() in brick_events_table_cols
+        assert event_int_str() in brick_events_table_cols
+        assert "error_message" in brick_events_table_cols
+        assert get_row_count(cursor, brick_events_tablename) == 3
         select_agg_sqlstr = f"""
 SELECT * 
-FROM {yell_events_tablename} 
+FROM {brick_events_tablename} 
 ORDER BY {face_name_str()}, {event_int_str()};"""
         cursor.execute(select_agg_sqlstr)
 
@@ -99,7 +99,7 @@ ORDER BY {face_name_str()}, {event_int_str()};"""
         assert rows[2] == yao9_r
 
 
-def test_etl_yell_agg_db_to_yell_agg_events_db_PopulatesTables_Scenario1():
+def test_etl_brick_agg_db_to_brick_agg_events_db_PopulatesTables_Scenario1():
     # ESTABLISH
     a23_str = "accord23"
     sue_str = "Sue"
@@ -112,7 +112,7 @@ def test_etl_yell_agg_db_to_yell_agg_events_db_PopulatesTables_Scenario1():
     minute_420 = 420
     hour6am = "6am"
     hour7am = "7am"
-    agg_br00003_tablename = f"{yell_agg_str()}_br00003"
+    agg_br00003_tablename = f"{brick_agg_str()}_br00003"
     agg_br00003_columns = [
         face_name_str(),
         event_int_str(),
@@ -150,19 +150,19 @@ VALUES
 """
         insert_sqlstr = f"{insert_into_clause} {values_clause}"
         cursor.execute(insert_sqlstr)
-        yell_events_tablename = "yell_agg_events"
+        brick_events_tablename = "brick_agg_events"
         assert get_row_count(cursor, agg_br00003_tablename) == 5
-        assert not db_table_exists(cursor, yell_events_tablename)
+        assert not db_table_exists(cursor, brick_events_tablename)
 
         # WHEN
-        etl_yell_raw_db_to_yell_agg_events_db(cursor)
+        etl_brick_raw_db_to_brick_agg_events_db(cursor)
 
         # THEN
-        assert db_table_exists(cursor, yell_events_tablename)
-        assert get_row_count(cursor, yell_events_tablename) == 4
+        assert db_table_exists(cursor, brick_events_tablename)
+        assert get_row_count(cursor, brick_events_tablename) == 4
         select_agg_sqlstr = f"""
 SELECT * 
-FROM {yell_events_tablename} 
+FROM {brick_events_tablename} 
 ORDER BY {face_name_str()}, {event_int_str()};"""
         cursor.execute(select_agg_sqlstr)
 
@@ -180,7 +180,7 @@ ORDER BY {face_name_str()}, {event_int_str()};"""
         assert rows[3] == yao9_row
 
 
-def test_etl_yell_agg_events_db_to_yell_valid_events_db_PopulatesTables_Scenario0():
+def test_etl_brick_agg_events_db_to_brick_valid_events_db_PopulatesTables_Scenario0():
     # ESTABLISH
     sue_str = "Sue"
     yao_str = "Yao"
@@ -190,7 +190,7 @@ def test_etl_yell_agg_events_db_to_yell_valid_events_db_PopulatesTables_Scenario
     event9 = 9
     with sqlite3_connect(":memory:") as db_conn:
         cursor = db_conn.cursor()
-        agg_events_tablename = "yell_agg_events"
+        agg_events_tablename = "brick_agg_events"
         agg_events_columns = ["idea_number", "face_name", "event_int", "error_message"]
         create_idea_sorted_table(cursor, agg_events_tablename, agg_events_columns)
         insert_into_clause = f"""INSERT INTO {agg_events_tablename} (
@@ -211,11 +211,11 @@ VALUES
         insert_sqlstr = f"{insert_into_clause} {values_clause}"
         cursor.execute(insert_sqlstr)
         assert get_row_count(cursor, agg_events_tablename) == 4
-        valid_events_tablename = "yell_valid_events"
+        valid_events_tablename = "brick_valid_events"
         assert not db_table_exists(cursor, valid_events_tablename)
 
         # WHEN
-        etl_yell_agg_events_db_to_yell_valid_events_db(cursor)
+        etl_brick_agg_events_db_to_brick_valid_events_db(cursor)
 
         # THEN
         assert db_table_exists(cursor, valid_events_tablename)
@@ -235,7 +235,7 @@ ORDER BY {face_name_str()}, {event_int_str()};"""
         assert rows[1] == yao9_row
 
 
-def test_etl_yell_agg_events_db_to_event_dict_ReturnsObj_Scenario0():
+def test_etl_brick_agg_events_db_to_event_dict_ReturnsObj_Scenario0():
     # ESTABLISH
     sue_str = "Sue"
     yao_str = "Yao"
@@ -251,7 +251,7 @@ def test_etl_yell_agg_events_db_to_event_dict_ReturnsObj_Scenario0():
     }
     with sqlite3_connect(":memory:") as db_conn:
         cursor = db_conn.cursor()
-        agg_events_tablename = "yell_agg_events"
+        agg_events_tablename = "brick_agg_events"
         create_table_from_columns(cursor, agg_events_tablename, agg_columns, agg_types)
         insert_into_clause = f"""
 INSERT INTO {agg_events_tablename} ({face_name_str()}, {event_int_str()}, error_message)
@@ -265,11 +265,11 @@ VALUES
 ;
 """
         cursor.execute(insert_into_clause)
-        etl_yell_agg_events_db_to_yell_valid_events_db(cursor)
+        etl_brick_agg_events_db_to_brick_valid_events_db(cursor)
         assert get_row_count(cursor, agg_events_tablename) == 6
 
         # WHEN
-        events_dict = etl_yell_agg_events_db_to_event_dict(cursor)
+        events_dict = etl_brick_agg_events_db_to_event_dict(cursor)
 
         # THEN
         assert events_dict == {event3: bob_str, event9: yao_str}

--- a/src/a18_etl_toolbox/test_tran/test_brick_agg_sheets2pidgin_acct_raw_sheets.py
+++ b/src/a18_etl_toolbox/test_tran/test_brick_agg_sheets2pidgin_acct_raw_sheets.py
@@ -8,11 +8,11 @@ from src.a16_pidgin_logic._utils.str_a16 import (
     otx_name_str,
     unknown_word_str,
 )
-from src.a17_idea_logic._utils.str_a17 import yell_agg_str
+from src.a17_idea_logic._utils.str_a17 import brick_agg_str
 from src.a17_idea_logic.idea_db_tool import get_sheet_names, upsert_sheet
-from src.a18_etl_toolbox.tran_path import create_yell_pidgin_path
+from src.a18_etl_toolbox.tran_path import create_brick_pidgin_path
 from src.a18_etl_toolbox.pidgin_agg import PidginPrimeColumns
-from src.a18_etl_toolbox.transformers import etl_yell_agg_to_pidgin_name_raw
+from src.a18_etl_toolbox.transformers import etl_brick_agg_to_pidgin_name_raw
 from src.a18_etl_toolbox._utils.env_a18 import (
     get_module_temp_dir,
     env_dir_setup_cleanup,
@@ -21,7 +21,7 @@ from pandas import DataFrame, read_excel as pandas_read_excel
 from os.path import exists as os_path_exists
 
 
-def test_etl_yell_agg_to_pidgin_name_raw_CreatesFile_Scenario0_SingleIdea(
+def test_etl_brick_agg_to_pidgin_name_raw_CreatesFile_Scenario0_SingleIdea(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -32,8 +32,8 @@ def test_etl_yell_agg_to_pidgin_name_raw_CreatesFile_Scenario0_SingleIdea(
     bob_inx = "Bobito"
     m_str = "accord23"
     event7 = 7
-    x_yell_dir = get_module_temp_dir()
-    br00113_file_path = create_path(x_yell_dir, "br00113.xlsx")
+    x_brick_dir = get_module_temp_dir()
+    br00113_file_path = create_path(x_brick_dir, "br00113.xlsx")
     br00113_columns = [
         face_name_str(),
         event_int_str(),
@@ -47,13 +47,13 @@ def test_etl_yell_agg_to_pidgin_name_raw_CreatesFile_Scenario0_SingleIdea(
     sue1 = [sue_str, event7, m_str, bob_str, bob_str, bob_str, bob_inx]
     br00113_rows = [sue0, sue1]
     br00113_df = DataFrame(br00113_rows, columns=br00113_columns)
-    upsert_sheet(br00113_file_path, yell_agg_str(), br00113_df)
-    pidgin_path = create_yell_pidgin_path(x_yell_dir)
+    upsert_sheet(br00113_file_path, brick_agg_str(), br00113_df)
+    pidgin_path = create_brick_pidgin_path(x_brick_dir)
     assert os_path_exists(pidgin_path) is False
 
     # WHEN
     legitimate_events = {event7}
-    etl_yell_agg_to_pidgin_name_raw(legitimate_events, x_yell_dir)
+    etl_brick_agg_to_pidgin_name_raw(legitimate_events, x_brick_dir)
 
     # THEN
     assert os_path_exists(pidgin_path)
@@ -74,7 +74,7 @@ def test_etl_yell_agg_to_pidgin_name_raw_CreatesFile_Scenario0_SingleIdea(
     assert get_sheet_names(pidgin_path) == [name_raw_str]
 
 
-def test_etl_yell_agg_to_pidgin_name_raw_CreatesFile_Scenario1_MultipleIdeasFiles(
+def test_etl_brick_agg_to_pidgin_name_raw_CreatesFile_Scenario1_MultipleIdeasFiles(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -90,8 +90,8 @@ def test_etl_yell_agg_to_pidgin_name_raw_CreatesFile_Scenario1_MultipleIdeasFile
     event2 = 2
     event5 = 5
     event7 = 7
-    x_yell_dir = get_module_temp_dir()
-    br00113_file_path = create_path(x_yell_dir, "br00113.xlsx")
+    x_brick_dir = get_module_temp_dir()
+    br00113_file_path = create_path(x_brick_dir, "br00113.xlsx")
     br00113_columns = [
         face_name_str(),
         event_int_str(),
@@ -101,7 +101,7 @@ def test_etl_yell_agg_to_pidgin_name_raw_CreatesFile_Scenario1_MultipleIdeasFile
         otx_name_str(),
         inx_name_str(),
     ]
-    br00043_file_path = create_path(x_yell_dir, "br00043.xlsx")
+    br00043_file_path = create_path(x_brick_dir, "br00043.xlsx")
     br00043_columns = [
         face_name_str(),
         event_int_str(),
@@ -118,16 +118,16 @@ def test_etl_yell_agg_to_pidgin_name_raw_CreatesFile_Scenario1_MultipleIdeasFile
     yao1 = [yao_str, event7, yao_str, yao_inx, rdx, rdx, ukx]
     br00113_rows = [sue0, sue1]
     br00113_df = DataFrame(br00113_rows, columns=br00113_columns)
-    upsert_sheet(br00113_file_path, yell_agg_str(), br00113_df)
+    upsert_sheet(br00113_file_path, brick_agg_str(), br00113_df)
     br00043_df = [sue2, sue3, yao1]
     br00043_df = DataFrame(br00043_df, columns=br00043_columns)
-    upsert_sheet(br00043_file_path, yell_agg_str(), br00043_df)
-    pidgin_path = create_yell_pidgin_path(x_yell_dir)
+    upsert_sheet(br00043_file_path, brick_agg_str(), br00043_df)
+    pidgin_path = create_brick_pidgin_path(x_brick_dir)
     assert os_path_exists(pidgin_path) is False
 
     # WHEN
     legitimate_events = {event1, event2, event7, event5}
-    etl_yell_agg_to_pidgin_name_raw(legitimate_events, x_yell_dir)
+    etl_brick_agg_to_pidgin_name_raw(legitimate_events, x_brick_dir)
 
     # THEN
     assert os_path_exists(pidgin_path)
@@ -153,7 +153,7 @@ def test_etl_yell_agg_to_pidgin_name_raw_CreatesFile_Scenario1_MultipleIdeasFile
     assert get_sheet_names(pidgin_path) == [name_raw_str]
 
 
-def test_etl_yell_agg_to_pidgin_name_raw_CreatesFile_Scenario2_WorldUnit_events_Filters(
+def test_etl_brick_agg_to_pidgin_name_raw_CreatesFile_Scenario2_WorldUnit_events_Filters(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -168,8 +168,8 @@ def test_etl_yell_agg_to_pidgin_name_raw_CreatesFile_Scenario2_WorldUnit_events_
     event1 = 1
     event2 = 2
     event5 = 5
-    x_yell_dir = get_module_temp_dir()
-    br00113_file_path = create_path(x_yell_dir, "br00113.xlsx")
+    x_brick_dir = get_module_temp_dir()
+    br00113_file_path = create_path(x_brick_dir, "br00113.xlsx")
     br00113_columns = [
         face_name_str(),
         event_int_str(),
@@ -179,7 +179,7 @@ def test_etl_yell_agg_to_pidgin_name_raw_CreatesFile_Scenario2_WorldUnit_events_
         otx_name_str(),
         inx_name_str(),
     ]
-    br00043_file_path = create_path(x_yell_dir, "br00043.xlsx")
+    br00043_file_path = create_path(x_brick_dir, "br00043.xlsx")
     br00043_columns = [
         face_name_str(),
         event_int_str(),
@@ -196,16 +196,16 @@ def test_etl_yell_agg_to_pidgin_name_raw_CreatesFile_Scenario2_WorldUnit_events_
     yao1 = [yao_str, event1, yao_str, yao_inx, rdx, rdx, ukx]
     br00113_rows = [sue0, sue1]
     br00113_df = DataFrame(br00113_rows, columns=br00113_columns)
-    upsert_sheet(br00113_file_path, yell_agg_str(), br00113_df)
+    upsert_sheet(br00113_file_path, brick_agg_str(), br00113_df)
     br00043_df = [sue2, sue3, yao1]
     br00043_df = DataFrame(br00043_df, columns=br00043_columns)
-    upsert_sheet(br00043_file_path, yell_agg_str(), br00043_df)
-    pidgin_path = create_yell_pidgin_path(x_yell_dir)
+    upsert_sheet(br00043_file_path, brick_agg_str(), br00043_df)
+    pidgin_path = create_brick_pidgin_path(x_brick_dir)
     legitimate_events = {event2: sue_str, event5: sue_str}
     assert os_path_exists(pidgin_path) is False
 
     # WHEN
-    etl_yell_agg_to_pidgin_name_raw(legitimate_events, x_yell_dir)
+    etl_brick_agg_to_pidgin_name_raw(legitimate_events, x_brick_dir)
 
     # THEN
     assert os_path_exists(pidgin_path)

--- a/src/a18_etl_toolbox/test_tran/test_brick_agg_sheets2pidgin_group_raw_sheets.py
+++ b/src/a18_etl_toolbox/test_tran/test_brick_agg_sheets2pidgin_group_raw_sheets.py
@@ -8,11 +8,11 @@ from src.a16_pidgin_logic._utils.str_a16 import (
     otx_label_str,
     unknown_word_str,
 )
-from src.a17_idea_logic._utils.str_a17 import yell_agg_str
+from src.a17_idea_logic._utils.str_a17 import brick_agg_str
 from src.a17_idea_logic.idea_db_tool import get_sheet_names, upsert_sheet
-from src.a18_etl_toolbox.tran_path import create_yell_pidgin_path
+from src.a18_etl_toolbox.tran_path import create_brick_pidgin_path
 from src.a18_etl_toolbox.pidgin_agg import PidginPrimeColumns
-from src.a18_etl_toolbox.transformers import etl_yell_agg_to_pidgin_label_raw
+from src.a18_etl_toolbox.transformers import etl_brick_agg_to_pidgin_label_raw
 from src.a18_etl_toolbox._utils.env_a18 import (
     get_module_temp_dir,
     env_dir_setup_cleanup,
@@ -21,7 +21,7 @@ from pandas import DataFrame, read_excel as pandas_read_excel
 from os.path import exists as os_path_exists
 
 
-def test_etl_yell_agg_to_pidgin_label_raw_CreatesFile_Scenario0_SingleIdea(
+def test_etl_brick_agg_to_pidgin_label_raw_CreatesFile_Scenario0_SingleIdea(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -32,8 +32,8 @@ def test_etl_yell_agg_to_pidgin_label_raw_CreatesFile_Scenario0_SingleIdea(
     bob_inx = "Bobito"
     m_str = "accord23"
     event7 = 7
-    x_yell_dir = get_module_temp_dir()
-    br00115_file_path = create_path(x_yell_dir, "br00115.xlsx")
+    x_brick_dir = get_module_temp_dir()
+    br00115_file_path = create_path(x_brick_dir, "br00115.xlsx")
     br00115_columns = [
         face_name_str(),
         event_int_str(),
@@ -47,13 +47,13 @@ def test_etl_yell_agg_to_pidgin_label_raw_CreatesFile_Scenario0_SingleIdea(
     sue1 = [sue_str, event7, m_str, bob_str, bob_str, bob_str, bob_inx]
     br00115_rows = [sue0, sue1]
     br00115_df = DataFrame(br00115_rows, columns=br00115_columns)
-    upsert_sheet(br00115_file_path, yell_agg_str(), br00115_df)
-    pidgin_path = create_yell_pidgin_path(x_yell_dir)
+    upsert_sheet(br00115_file_path, brick_agg_str(), br00115_df)
+    pidgin_path = create_brick_pidgin_path(x_brick_dir)
     assert os_path_exists(pidgin_path) is False
 
     # WHEN
     legitimate_events = {event7}
-    etl_yell_agg_to_pidgin_label_raw(legitimate_events, x_yell_dir)
+    etl_brick_agg_to_pidgin_label_raw(legitimate_events, x_brick_dir)
 
     # THEN
     assert os_path_exists(pidgin_path)
@@ -74,7 +74,7 @@ def test_etl_yell_agg_to_pidgin_label_raw_CreatesFile_Scenario0_SingleIdea(
     assert get_sheet_names(pidgin_path) == [label_raw_str]
 
 
-def test_etl_yell_agg_to_pidgin_label_raw_CreatesFile_Scenario1_MultipleIdeasFiles(
+def test_etl_brick_agg_to_pidgin_label_raw_CreatesFile_Scenario1_MultipleIdeasFiles(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -90,8 +90,8 @@ def test_etl_yell_agg_to_pidgin_label_raw_CreatesFile_Scenario1_MultipleIdeasFil
     event2 = 2
     event5 = 5
     event7 = 7
-    x_yell_dir = get_module_temp_dir()
-    br00115_file_path = create_path(x_yell_dir, "br00115.xlsx")
+    x_brick_dir = get_module_temp_dir()
+    br00115_file_path = create_path(x_brick_dir, "br00115.xlsx")
     br00115_columns = [
         face_name_str(),
         event_int_str(),
@@ -101,7 +101,7 @@ def test_etl_yell_agg_to_pidgin_label_raw_CreatesFile_Scenario1_MultipleIdeasFil
         otx_label_str(),
         inx_label_str(),
     ]
-    br00042_file_path = create_path(x_yell_dir, "br00042.xlsx")
+    br00042_file_path = create_path(x_brick_dir, "br00042.xlsx")
     br00042_columns = [
         face_name_str(),
         event_int_str(),
@@ -118,16 +118,16 @@ def test_etl_yell_agg_to_pidgin_label_raw_CreatesFile_Scenario1_MultipleIdeasFil
     yao1 = [yao_str, event7, yao_str, yao_inx, rdx, rdx, ukx]
     br00115_rows = [sue0, sue1]
     br00115_df = DataFrame(br00115_rows, columns=br00115_columns)
-    upsert_sheet(br00115_file_path, yell_agg_str(), br00115_df)
+    upsert_sheet(br00115_file_path, brick_agg_str(), br00115_df)
     br00042_rows = [sue2, sue3, yao1]
     br00042_df = DataFrame(br00042_rows, columns=br00042_columns)
-    upsert_sheet(br00042_file_path, yell_agg_str(), br00042_df)
-    pidgin_path = create_yell_pidgin_path(x_yell_dir)
+    upsert_sheet(br00042_file_path, brick_agg_str(), br00042_df)
+    pidgin_path = create_brick_pidgin_path(x_brick_dir)
     assert os_path_exists(pidgin_path) is False
 
     # WHEN
     legitimate_events = {event1, event2, event5, event7}
-    etl_yell_agg_to_pidgin_label_raw(legitimate_events, x_yell_dir)
+    etl_brick_agg_to_pidgin_label_raw(legitimate_events, x_brick_dir)
 
     # THEN
     assert os_path_exists(pidgin_path)
@@ -153,7 +153,7 @@ def test_etl_yell_agg_to_pidgin_label_raw_CreatesFile_Scenario1_MultipleIdeasFil
     assert get_sheet_names(pidgin_path) == [label_raw_str]
 
 
-def test_etl_yell_agg_to_pidgin_label_raw_CreatesFile_Scenario2_WorldUnit_events_Filters(
+def test_etl_brick_agg_to_pidgin_label_raw_CreatesFile_Scenario2_WorldUnit_events_Filters(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -168,8 +168,8 @@ def test_etl_yell_agg_to_pidgin_label_raw_CreatesFile_Scenario2_WorldUnit_events
     event1 = 1
     event2 = 2
     event5 = 5
-    x_yell_dir = get_module_temp_dir()
-    br00115_file_path = create_path(x_yell_dir, "br00115.xlsx")
+    x_brick_dir = get_module_temp_dir()
+    br00115_file_path = create_path(x_brick_dir, "br00115.xlsx")
     br00115_columns = [
         face_name_str(),
         event_int_str(),
@@ -179,7 +179,7 @@ def test_etl_yell_agg_to_pidgin_label_raw_CreatesFile_Scenario2_WorldUnit_events
         otx_label_str(),
         inx_label_str(),
     ]
-    br00042_file_path = create_path(x_yell_dir, "br00042.xlsx")
+    br00042_file_path = create_path(x_brick_dir, "br00042.xlsx")
     br00042_columns = [
         face_name_str(),
         event_int_str(),
@@ -196,16 +196,16 @@ def test_etl_yell_agg_to_pidgin_label_raw_CreatesFile_Scenario2_WorldUnit_events
     yao1 = [yao_str, event1, yao_str, yao_inx, rdx, rdx, ukx]
     br00115_rows = [sue0, sue1]
     br00115_df = DataFrame(br00115_rows, columns=br00115_columns)
-    upsert_sheet(br00115_file_path, yell_agg_str(), br00115_df)
+    upsert_sheet(br00115_file_path, brick_agg_str(), br00115_df)
     b40_rows = [sue2, sue3, yao1]
     br00042_df = DataFrame(b40_rows, columns=br00042_columns)
-    upsert_sheet(br00042_file_path, yell_agg_str(), br00042_df)
-    pidgin_path = create_yell_pidgin_path(x_yell_dir)
+    upsert_sheet(br00042_file_path, brick_agg_str(), br00042_df)
+    pidgin_path = create_brick_pidgin_path(x_brick_dir)
     assert os_path_exists(pidgin_path) is False
 
     # WHEN
     legitimate_events = {event2, event5}
-    etl_yell_agg_to_pidgin_label_raw(legitimate_events, x_yell_dir)
+    etl_brick_agg_to_pidgin_label_raw(legitimate_events, x_brick_dir)
 
     # THEN
     assert os_path_exists(pidgin_path)

--- a/src/a18_etl_toolbox/test_tran/test_brick_agg_sheets2pidgin_road_raw_sheets.py
+++ b/src/a18_etl_toolbox/test_tran/test_brick_agg_sheets2pidgin_road_raw_sheets.py
@@ -8,11 +8,11 @@ from src.a16_pidgin_logic._utils.str_a16 import (
     otx_road_str,
     unknown_word_str,
 )
-from src.a17_idea_logic._utils.str_a17 import yell_agg_str
+from src.a17_idea_logic._utils.str_a17 import brick_agg_str
 from src.a17_idea_logic.idea_db_tool import get_sheet_names, upsert_sheet
-from src.a18_etl_toolbox.tran_path import create_yell_pidgin_path
+from src.a18_etl_toolbox.tran_path import create_brick_pidgin_path
 from src.a18_etl_toolbox.pidgin_agg import PidginPrimeColumns
-from src.a18_etl_toolbox.transformers import etl_yell_agg_to_pidgin_road_raw
+from src.a18_etl_toolbox.transformers import etl_brick_agg_to_pidgin_road_raw
 from src.a18_etl_toolbox._utils.env_a18 import (
     get_module_temp_dir,
     env_dir_setup_cleanup,
@@ -21,7 +21,7 @@ from pandas import DataFrame, read_excel as pandas_read_excel
 from os.path import exists as os_path_exists
 
 
-def test_etl_yell_agg_to_pidgin_road_raw_CreatesFile_Scenario0_SingleIdea(
+def test_etl_brick_agg_to_pidgin_road_raw_CreatesFile_Scenario0_SingleIdea(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -32,8 +32,8 @@ def test_etl_yell_agg_to_pidgin_road_raw_CreatesFile_Scenario0_SingleIdea(
     bob_inx = "Bobito"
     m_str = "accord23"
     event7 = 7
-    x_yell_dir = get_module_temp_dir()
-    br00117_file_path = create_path(x_yell_dir, "br00117.xlsx")
+    x_brick_dir = get_module_temp_dir()
+    br00117_file_path = create_path(x_brick_dir, "br00117.xlsx")
     br00117_columns = [
         face_name_str(),
         event_int_str(),
@@ -47,12 +47,12 @@ def test_etl_yell_agg_to_pidgin_road_raw_CreatesFile_Scenario0_SingleIdea(
     sue1 = [sue_str, event7, m_str, bob_str, bob_str, bob_str, bob_inx]
     b117_rows = [sue0, sue1]
     br00117_df = DataFrame(b117_rows, columns=br00117_columns)
-    upsert_sheet(br00117_file_path, yell_agg_str(), br00117_df)
-    pidgin_path = create_yell_pidgin_path(x_yell_dir)
+    upsert_sheet(br00117_file_path, brick_agg_str(), br00117_df)
+    pidgin_path = create_brick_pidgin_path(x_brick_dir)
     assert os_path_exists(pidgin_path) is False
 
     # WHEN
-    etl_yell_agg_to_pidgin_road_raw({event7}, x_yell_dir)
+    etl_brick_agg_to_pidgin_road_raw({event7}, x_brick_dir)
 
     # THEN
     assert os_path_exists(pidgin_path)
@@ -73,7 +73,7 @@ def test_etl_yell_agg_to_pidgin_road_raw_CreatesFile_Scenario0_SingleIdea(
     assert get_sheet_names(pidgin_path) == [road_raw_str]
 
 
-def test_etl_yell_agg_to_pidgin_road_raw_CreatesFile_Scenario1_MultipleIdeasFiles(
+def test_etl_brick_agg_to_pidgin_road_raw_CreatesFile_Scenario1_MultipleIdeasFiles(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -89,8 +89,8 @@ def test_etl_yell_agg_to_pidgin_road_raw_CreatesFile_Scenario1_MultipleIdeasFile
     event2 = 2
     event5 = 5
     event7 = 7
-    x_yell_dir = get_module_temp_dir()
-    br00117_file_path = create_path(x_yell_dir, "br00117.xlsx")
+    x_brick_dir = get_module_temp_dir()
+    br00117_file_path = create_path(x_brick_dir, "br00117.xlsx")
     br00117_columns = [
         face_name_str(),
         event_int_str(),
@@ -100,7 +100,7 @@ def test_etl_yell_agg_to_pidgin_road_raw_CreatesFile_Scenario1_MultipleIdeasFile
         otx_road_str(),
         inx_road_str(),
     ]
-    br00045_file_path = create_path(x_yell_dir, "br00045.xlsx")
+    br00045_file_path = create_path(x_brick_dir, "br00045.xlsx")
     br00045_columns = [
         face_name_str(),
         event_int_str(),
@@ -117,16 +117,16 @@ def test_etl_yell_agg_to_pidgin_road_raw_CreatesFile_Scenario1_MultipleIdeasFile
     yao1 = [yao_str, event7, yao_str, yao_inx, rdx, rdx, ukx]
     b117_rows = [sue0, sue1]
     br00117_df = DataFrame(b117_rows, columns=br00117_columns)
-    upsert_sheet(br00117_file_path, yell_agg_str(), br00117_df)
+    upsert_sheet(br00117_file_path, brick_agg_str(), br00117_df)
     br00045_rows = [sue2, sue3, yao1]
     br00045_df = DataFrame(br00045_rows, columns=br00045_columns)
-    upsert_sheet(br00045_file_path, yell_agg_str(), br00045_df)
-    pidgin_path = create_yell_pidgin_path(x_yell_dir)
+    upsert_sheet(br00045_file_path, brick_agg_str(), br00045_df)
+    pidgin_path = create_brick_pidgin_path(x_brick_dir)
     assert os_path_exists(pidgin_path) is False
 
     # WHEN
     legitimate_events = {event1, event2, event5, event7}
-    etl_yell_agg_to_pidgin_road_raw(legitimate_events, x_yell_dir)
+    etl_brick_agg_to_pidgin_road_raw(legitimate_events, x_brick_dir)
 
     # THEN
     assert os_path_exists(pidgin_path)
@@ -152,7 +152,7 @@ def test_etl_yell_agg_to_pidgin_road_raw_CreatesFile_Scenario1_MultipleIdeasFile
     assert get_sheet_names(pidgin_path) == [road_raw_str]
 
 
-def test_etl_yell_agg_to_pidgin_road_raw_CreatesFile_Scenario2_WorldUnit_events_Filters(
+def test_etl_brick_agg_to_pidgin_road_raw_CreatesFile_Scenario2_WorldUnit_events_Filters(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -167,8 +167,8 @@ def test_etl_yell_agg_to_pidgin_road_raw_CreatesFile_Scenario2_WorldUnit_events_
     event1 = 1
     event2 = 2
     event5 = 5
-    x_yell_dir = get_module_temp_dir()
-    br00117_file_path = create_path(x_yell_dir, "br00117.xlsx")
+    x_brick_dir = get_module_temp_dir()
+    br00117_file_path = create_path(x_brick_dir, "br00117.xlsx")
     br00117_columns = [
         face_name_str(),
         event_int_str(),
@@ -178,7 +178,7 @@ def test_etl_yell_agg_to_pidgin_road_raw_CreatesFile_Scenario2_WorldUnit_events_
         otx_road_str(),
         inx_road_str(),
     ]
-    br00045_file_path = create_path(x_yell_dir, "br00045.xlsx")
+    br00045_file_path = create_path(x_brick_dir, "br00045.xlsx")
     br00045_columns = [
         face_name_str(),
         event_int_str(),
@@ -195,16 +195,16 @@ def test_etl_yell_agg_to_pidgin_road_raw_CreatesFile_Scenario2_WorldUnit_events_
     yao1 = [yao_str, event1, yao_str, yao_inx, rdx, rdx, ukx]
     b117_rows = [sue0, sue1]
     br00117_df = DataFrame(b117_rows, columns=br00117_columns)
-    upsert_sheet(br00117_file_path, yell_agg_str(), br00117_df)
+    upsert_sheet(br00117_file_path, brick_agg_str(), br00117_df)
     br00045_rows = [sue2, sue3, yao1]
     br00045_df = DataFrame(br00045_rows, columns=br00045_columns)
-    upsert_sheet(br00045_file_path, yell_agg_str(), br00045_df)
-    pidgin_path = create_yell_pidgin_path(x_yell_dir)
+    upsert_sheet(br00045_file_path, brick_agg_str(), br00045_df)
+    pidgin_path = create_brick_pidgin_path(x_brick_dir)
     legitimate_events = {event2, event5}
     assert os_path_exists(pidgin_path) is False
 
     # WHEN
-    etl_yell_agg_to_pidgin_road_raw(legitimate_events, x_yell_dir)
+    etl_brick_agg_to_pidgin_road_raw(legitimate_events, x_brick_dir)
 
     # THEN
     assert os_path_exists(pidgin_path)

--- a/src/a18_etl_toolbox/test_tran/test_brick_agg_sheets2pidgin_tag_raw_sheets.py
+++ b/src/a18_etl_toolbox/test_tran/test_brick_agg_sheets2pidgin_tag_raw_sheets.py
@@ -8,11 +8,11 @@ from src.a16_pidgin_logic._utils.str_a16 import (
     otx_tag_str,
     unknown_word_str,
 )
-from src.a17_idea_logic._utils.str_a17 import yell_agg_str
+from src.a17_idea_logic._utils.str_a17 import brick_agg_str
 from src.a17_idea_logic.idea_db_tool import get_sheet_names, upsert_sheet
-from src.a18_etl_toolbox.tran_path import create_yell_pidgin_path
+from src.a18_etl_toolbox.tran_path import create_brick_pidgin_path
 from src.a18_etl_toolbox.pidgin_agg import PidginPrimeColumns
-from src.a18_etl_toolbox.transformers import etl_yell_agg_to_pidgin_tag_raw
+from src.a18_etl_toolbox.transformers import etl_brick_agg_to_pidgin_tag_raw
 from src.a18_etl_toolbox._utils.env_a18 import (
     get_module_temp_dir,
     env_dir_setup_cleanup,
@@ -21,7 +21,7 @@ from pandas import DataFrame, read_excel as pandas_read_excel
 from os.path import exists as os_path_exists
 
 
-def test_etl_yell_agg_to_pidgin_tag_raw_CreatesFile_Scenario0_SingleIdea(
+def test_etl_brick_agg_to_pidgin_tag_raw_CreatesFile_Scenario0_SingleIdea(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -32,8 +32,8 @@ def test_etl_yell_agg_to_pidgin_tag_raw_CreatesFile_Scenario0_SingleIdea(
     bob_inx = "Bobito"
     m_str = "accord23"
     event7 = 7
-    x_yell_dir = get_module_temp_dir()
-    br00116_file_path = create_path(x_yell_dir, "br00116.xlsx")
+    x_brick_dir = get_module_temp_dir()
+    br00116_file_path = create_path(x_brick_dir, "br00116.xlsx")
     br00116_columns = [
         face_name_str(),
         event_int_str(),
@@ -47,12 +47,12 @@ def test_etl_yell_agg_to_pidgin_tag_raw_CreatesFile_Scenario0_SingleIdea(
     sue1 = [sue_str, event7, m_str, bob_str, bob_str, bob_str, bob_inx]
     br00116_rows = [sue0, sue1]
     br00116_df = DataFrame(br00116_rows, columns=br00116_columns)
-    upsert_sheet(br00116_file_path, yell_agg_str(), br00116_df)
-    pidgin_path = create_yell_pidgin_path(x_yell_dir)
+    upsert_sheet(br00116_file_path, brick_agg_str(), br00116_df)
+    pidgin_path = create_brick_pidgin_path(x_brick_dir)
     assert os_path_exists(pidgin_path) is False
 
     # WHEN
-    etl_yell_agg_to_pidgin_tag_raw({event7}, x_yell_dir)
+    etl_brick_agg_to_pidgin_tag_raw({event7}, x_brick_dir)
 
     # THEN
     assert os_path_exists(pidgin_path)
@@ -73,7 +73,7 @@ def test_etl_yell_agg_to_pidgin_tag_raw_CreatesFile_Scenario0_SingleIdea(
     assert get_sheet_names(pidgin_path) == [tag_raw_str]
 
 
-def test_etl_yell_agg_to_pidgin_tag_raw_CreatesFile_Scenario1_MultipleIdeasFiles(
+def test_etl_brick_agg_to_pidgin_tag_raw_CreatesFile_Scenario1_MultipleIdeasFiles(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -89,8 +89,8 @@ def test_etl_yell_agg_to_pidgin_tag_raw_CreatesFile_Scenario1_MultipleIdeasFiles
     event2 = 2
     event5 = 5
     event7 = 7
-    x_yell_dir = get_module_temp_dir()
-    br00116_file_path = create_path(x_yell_dir, "br00116.xlsx")
+    x_brick_dir = get_module_temp_dir()
+    br00116_file_path = create_path(x_brick_dir, "br00116.xlsx")
     br00116_columns = [
         face_name_str(),
         event_int_str(),
@@ -100,7 +100,7 @@ def test_etl_yell_agg_to_pidgin_tag_raw_CreatesFile_Scenario1_MultipleIdeasFiles
         otx_tag_str(),
         inx_tag_str(),
     ]
-    br00044_file_path = create_path(x_yell_dir, "br00044.xlsx")
+    br00044_file_path = create_path(x_brick_dir, "br00044.xlsx")
     br00044_columns = [
         face_name_str(),
         event_int_str(),
@@ -117,16 +117,16 @@ def test_etl_yell_agg_to_pidgin_tag_raw_CreatesFile_Scenario1_MultipleIdeasFiles
     yao1 = [yao_str, event7, yao_str, yao_inx, rdx, rdx, ukx]
     br00116_rows = [sue0, sue1]
     br00116_df = DataFrame(br00116_rows, columns=br00116_columns)
-    upsert_sheet(br00116_file_path, yell_agg_str(), br00116_df)
+    upsert_sheet(br00116_file_path, brick_agg_str(), br00116_df)
     br00044_rows = [sue2, sue3, yao1]
     br00044_df = DataFrame(br00044_rows, columns=br00044_columns)
-    upsert_sheet(br00044_file_path, yell_agg_str(), br00044_df)
-    pidgin_path = create_yell_pidgin_path(x_yell_dir)
+    upsert_sheet(br00044_file_path, brick_agg_str(), br00044_df)
+    pidgin_path = create_brick_pidgin_path(x_brick_dir)
     assert os_path_exists(pidgin_path) is False
 
     # WHEN
     legitimate_events = {event1, event2, event5, event7}
-    etl_yell_agg_to_pidgin_tag_raw(legitimate_events, x_yell_dir)
+    etl_brick_agg_to_pidgin_tag_raw(legitimate_events, x_brick_dir)
 
     # THEN
     assert os_path_exists(pidgin_path)
@@ -152,7 +152,7 @@ def test_etl_yell_agg_to_pidgin_tag_raw_CreatesFile_Scenario1_MultipleIdeasFiles
     assert get_sheet_names(pidgin_path) == [tag_raw_str]
 
 
-def test_etl_yell_agg_to_pidgin_tag_raw_CreatesFile_Scenario2_WorldUnit_events_Filters(
+def test_etl_brick_agg_to_pidgin_tag_raw_CreatesFile_Scenario2_WorldUnit_events_Filters(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -167,8 +167,8 @@ def test_etl_yell_agg_to_pidgin_tag_raw_CreatesFile_Scenario2_WorldUnit_events_F
     event1 = 1
     event2 = 2
     event5 = 5
-    x_yell_dir = get_module_temp_dir()
-    br00116_file_path = create_path(x_yell_dir, "br00116.xlsx")
+    x_brick_dir = get_module_temp_dir()
+    br00116_file_path = create_path(x_brick_dir, "br00116.xlsx")
     br00116_columns = [
         face_name_str(),
         event_int_str(),
@@ -178,7 +178,7 @@ def test_etl_yell_agg_to_pidgin_tag_raw_CreatesFile_Scenario2_WorldUnit_events_F
         otx_tag_str(),
         inx_tag_str(),
     ]
-    br00044_file_path = create_path(x_yell_dir, "br00044.xlsx")
+    br00044_file_path = create_path(x_brick_dir, "br00044.xlsx")
     br00044_columns = [
         face_name_str(),
         event_int_str(),
@@ -195,16 +195,16 @@ def test_etl_yell_agg_to_pidgin_tag_raw_CreatesFile_Scenario2_WorldUnit_events_F
     yao1 = [yao_str, event1, yao_str, yao_inx, rdx, rdx, ukx]
     br00116_rows = [sue0, sue1]
     br00116_df = DataFrame(br00116_rows, columns=br00116_columns)
-    upsert_sheet(br00116_file_path, yell_agg_str(), br00116_df)
+    upsert_sheet(br00116_file_path, brick_agg_str(), br00116_df)
     br00044_rows = [sue2, sue3, yao1]
     br00044_df = DataFrame(br00044_rows, columns=br00044_columns)
-    upsert_sheet(br00044_file_path, yell_agg_str(), br00044_df)
-    pidgin_path = create_yell_pidgin_path(x_yell_dir)
+    upsert_sheet(br00044_file_path, brick_agg_str(), br00044_df)
+    pidgin_path = create_brick_pidgin_path(x_brick_dir)
     legitimate_events = {event2, event5}
     assert os_path_exists(pidgin_path) is False
 
     # WHEN
-    etl_yell_agg_to_pidgin_tag_raw(legitimate_events, x_yell_dir)
+    etl_brick_agg_to_pidgin_tag_raw(legitimate_events, x_brick_dir)
 
     # THEN
     assert os_path_exists(pidgin_path)

--- a/src/a18_etl_toolbox/test_tran/test_brick_agg_to_pidgin_raw.py
+++ b/src/a18_etl_toolbox/test_tran/test_brick_agg_to_pidgin_raw.py
@@ -630,25 +630,25 @@ def test_brick_valid_tables_to_pidgin_prime_raw_tables_PopulatesTables():
         assert get_row_count(cursor, pidgin_raw_name_tablename) == 5
         assert get_row_count(cursor, pidgin_raw_tag_tablename) == 5
         assert get_row_count(cursor, pidgin_raw_road_tablename) == 7
-        pidlab_raw_cols = get_table_columns(cursor, pidgin_raw_label_tablename)
-        pidnam_raw_cols = get_table_columns(cursor, pidgin_raw_name_tablename)
-        pidtag_raw_cols = get_table_columns(cursor, pidgin_raw_tag_tablename)
-        pidroa_raw_cols = get_table_columns(cursor, pidgin_raw_road_tablename)
+        pidlabe_raw_cols = get_table_columns(cursor, pidgin_raw_label_tablename)
+        pidname_raw_cols = get_table_columns(cursor, pidgin_raw_name_tablename)
+        pidtagg_raw_cols = get_table_columns(cursor, pidgin_raw_tag_tablename)
+        pidroad_raw_cols = get_table_columns(cursor, pidgin_raw_road_tablename)
         lab_table = pidgin_raw_label_tablename
         nam_table = pidgin_raw_name_tablename
         tag_table = pidgin_raw_tag_tablename
         roa_table = pidgin_raw_road_tablename
-        select_pidlab = create_select_query(cursor, lab_table, pidlab_raw_cols)
-        select_pidnam = create_select_query(cursor, nam_table, pidnam_raw_cols)
-        select_pidtag = create_select_query(cursor, tag_table, pidtag_raw_cols)
-        select_pidroa = create_select_query(cursor, roa_table, pidroa_raw_cols)
-        cursor.execute(select_pidlab)
+        select_pidlabe = create_select_query(cursor, lab_table, pidlabe_raw_cols)
+        select_pidname = create_select_query(cursor, nam_table, pidname_raw_cols)
+        select_pidtagg = create_select_query(cursor, tag_table, pidtagg_raw_cols)
+        select_pidroad = create_select_query(cursor, roa_table, pidroad_raw_cols)
+        cursor.execute(select_pidlabe)
         lab_rows = cursor.fetchall()
-        cursor.execute(select_pidnam)
+        cursor.execute(select_pidname)
         nam_rows = cursor.fetchall()
-        cursor.execute(select_pidtag)
+        cursor.execute(select_pidtagg)
         tag_rows = cursor.fetchall()
-        cursor.execute(select_pidroa)
+        cursor.execute(select_pidroad)
         roa_rows = cursor.fetchall()
         assert len(lab_rows) == 5
         assert len(nam_rows) == 5
@@ -835,18 +835,18 @@ VALUES
 #         assert get_row_count(cursor, agg_nam_table) == 3
 #         assert get_row_count(cursor, agg_tag_table) == 2
 #         assert get_row_count(cursor, agg_roa_table) == 5
-#         pidlab_raw_cols = get_table_columns(cursor, agg_lab_table)
-#         pidnam_raw_cols = get_table_columns(cursor, agg_nam_table)
-#         pidtag_raw_cols = get_table_columns(cursor, agg_tag_table)
-#         pidroa_raw_cols = get_table_columns(cursor, agg_roa_table)
-#         select_pidlab = create_select_query(cursor, agg_lab_table, pidlab_raw_cols)
-#         select_pidnam = create_select_query(cursor, agg_nam_table, pidnam_raw_cols)
-#         select_pidtag = create_select_query(cursor, agg_tag_table, pidtag_raw_cols)
-#         select_pidroa = create_select_query(cursor, agg_roa_table, pidroa_raw_cols)
-#         pidgin_agg_lab_rows = cursor.execute(select_pidlab).fetchall()
-#         pidgin_agg_nam_rows = cursor.execute(select_pidnam).fetchall()
-#         pidgin_agg_tag_rows = cursor.execute(select_pidtag).fetchall()
-#         pidgin_agg_roa_rows = cursor.execute(select_pidroa).fetchall()
+#         pidlabe_raw_cols = get_table_columns(cursor, agg_lab_table)
+#         pidname_raw_cols = get_table_columns(cursor, agg_nam_table)
+#         pidtagg_raw_cols = get_table_columns(cursor, agg_tag_table)
+#         pidroad_raw_cols = get_table_columns(cursor, agg_roa_table)
+#         select_pidlabe = create_select_query(cursor, agg_lab_table, pidlabe_raw_cols)
+#         select_pidname = create_select_query(cursor, agg_nam_table, pidname_raw_cols)
+#         select_pidtagg = create_select_query(cursor, agg_tag_table, pidtagg_raw_cols)
+#         select_pidroad = create_select_query(cursor, agg_roa_table, pidroad_raw_cols)
+#         pidgin_agg_lab_rows = cursor.execute(select_pidlabe).fetchall()
+#         pidgin_agg_nam_rows = cursor.execute(select_pidname).fetchall()
+#         pidgin_agg_tag_rows = cursor.execute(select_pidtagg).fetchall()
+#         pidgin_agg_roa_rows = cursor.execute(select_pidroad).fetchall()
 #         assert len(pidgin_agg_lab_rows) == 5
 #         assert len(pidgin_agg_nam_rows) == 5
 #         assert len(pidgin_agg_tag_rows) == 5

--- a/src/a18_etl_toolbox/test_tran/test_brick_agg_to_pidgin_raw.py
+++ b/src/a18_etl_toolbox/test_tran/test_brick_agg_to_pidgin_raw.py
@@ -23,8 +23,8 @@ from src.a16_pidgin_logic._utils.str_a16 import (
 )
 from src.a17_idea_logic._utils.str_a17 import (
     idea_number_str,
-    yell_agg_str,
-    yell_valid_str,
+    brick_agg_str,
+    brick_valid_str,
 )
 from src.a17_idea_logic.idea_db_tool import (
     upsert_sheet,
@@ -32,12 +32,12 @@ from src.a17_idea_logic.idea_db_tool import (
     _get_pidgen_idea_format_filenames,
     get_default_sorted_list,
 )
-from src.a18_etl_toolbox.tran_path import create_yell_pidgin_path
+from src.a18_etl_toolbox.tran_path import create_brick_pidgin_path
 from src.a18_etl_toolbox.pidgin_agg import PidginPrimeColumns
 from src.a18_etl_toolbox.tran_sqlstrs import create_pidgin_prime_tables
 from src.a18_etl_toolbox.transformers import (
-    etl_yell_agg_df_to_yell_pidgin_raw_df,
-    yell_valid_tables_to_pidgin_prime_raw_tables,
+    etl_brick_agg_df_to_brick_pidgin_raw_df,
+    brick_valid_tables_to_pidgin_prime_raw_tables,
     etl_pidgin_prime_raw_to_pidgin_prime_agg,
 )
 from src.a18_etl_toolbox._utils.env_a18 import (
@@ -67,7 +67,7 @@ def test_get_pidgen_idea_format_filenames_ReturnsObj():
     }
 
 
-def test_etl_yell_agg_df_to_yell_pidgin_raw_df_CreatesFile(env_dir_setup_cleanup):
+def test_etl_brick_agg_df_to_brick_pidgin_raw_df_CreatesFile(env_dir_setup_cleanup):
     # ESTABLISH
     bob_str = "Bob"
     sue_str = "Sue"
@@ -80,8 +80,8 @@ def test_etl_yell_agg_df_to_yell_pidgin_raw_df_CreatesFile(env_dir_setup_cleanup
     event1 = 1
     event2 = 2
     event5 = 5
-    yell_dir = etl_dir()
-    br00113_file_path = create_path(yell_dir, "br00113.xlsx")
+    brick_dir = etl_dir()
+    br00113_file_path = create_path(brick_dir, "br00113.xlsx")
     br00113_columns = [
         face_name_str(),
         event_int_str(),
@@ -91,7 +91,7 @@ def test_etl_yell_agg_df_to_yell_pidgin_raw_df_CreatesFile(env_dir_setup_cleanup
         otx_name_str(),
         inx_name_str(),
     ]
-    br00043_file_path = create_path(yell_dir, "br00043.xlsx")
+    br00043_file_path = create_path(brick_dir, "br00043.xlsx")
     br00043_columns = [
         face_name_str(),
         event_int_str(),
@@ -108,13 +108,13 @@ def test_etl_yell_agg_df_to_yell_pidgin_raw_df_CreatesFile(env_dir_setup_cleanup
     yao1 = [yao_str, event1, yao_str, yao_inx, rdx, rdx, ukx]
     br00113_rows = [sue0, sue1]
     br00113_df = DataFrame(br00113_rows, columns=br00113_columns)
-    upsert_sheet(br00113_file_path, yell_agg_str(), br00113_df)
+    upsert_sheet(br00113_file_path, brick_agg_str(), br00113_df)
     br00043_df = [sue2, sue3, yao1]
     br00043_df = DataFrame(br00043_df, columns=br00043_columns)
-    upsert_sheet(br00043_file_path, yell_agg_str(), br00043_df)
-    pidgin_path = create_yell_pidgin_path(yell_dir)
+    upsert_sheet(br00043_file_path, brick_agg_str(), br00043_df)
+    pidgin_path = create_brick_pidgin_path(brick_dir)
 
-    br00115_file_path = create_path(yell_dir, "br00115.xlsx")
+    br00115_file_path = create_path(brick_dir, "br00115.xlsx")
     br00115_columns = [
         face_name_str(),
         event_int_str(),
@@ -124,7 +124,7 @@ def test_etl_yell_agg_df_to_yell_pidgin_raw_df_CreatesFile(env_dir_setup_cleanup
         otx_label_str(),
         inx_label_str(),
     ]
-    br00042_file_path = create_path(yell_dir, "br00042.xlsx")
+    br00042_file_path = create_path(brick_dir, "br00042.xlsx")
     br00042_columns = [
         face_name_str(),
         event_int_str(),
@@ -141,12 +141,12 @@ def test_etl_yell_agg_df_to_yell_pidgin_raw_df_CreatesFile(env_dir_setup_cleanup
     yao1 = [yao_str, event1, yao_str, yao_inx, rdx, rdx, ukx]
     br00115_rows = [sue0, sue1]
     br00115_df = DataFrame(br00115_rows, columns=br00115_columns)
-    upsert_sheet(br00115_file_path, yell_agg_str(), br00115_df)
+    upsert_sheet(br00115_file_path, brick_agg_str(), br00115_df)
     b40_rows = [sue2, sue3, yao1]
     br00042_df = DataFrame(b40_rows, columns=br00042_columns)
-    upsert_sheet(br00042_file_path, yell_agg_str(), br00042_df)
+    upsert_sheet(br00042_file_path, brick_agg_str(), br00042_df)
 
-    br00116_file_path = create_path(yell_dir, "br00116.xlsx")
+    br00116_file_path = create_path(brick_dir, "br00116.xlsx")
     br00116_columns = [
         face_name_str(),
         event_int_str(),
@@ -156,7 +156,7 @@ def test_etl_yell_agg_df_to_yell_pidgin_raw_df_CreatesFile(env_dir_setup_cleanup
         otx_tag_str(),
         inx_tag_str(),
     ]
-    br00044_file_path = create_path(yell_dir, "br00044.xlsx")
+    br00044_file_path = create_path(brick_dir, "br00044.xlsx")
     br00044_columns = [
         face_name_str(),
         event_int_str(),
@@ -173,12 +173,12 @@ def test_etl_yell_agg_df_to_yell_pidgin_raw_df_CreatesFile(env_dir_setup_cleanup
     yao1 = [yao_str, event1, yao_str, yao_inx, rdx, rdx, ukx]
     br00116_rows = [sue0, sue1]
     br00116_df = DataFrame(br00116_rows, columns=br00116_columns)
-    upsert_sheet(br00116_file_path, yell_agg_str(), br00116_df)
+    upsert_sheet(br00116_file_path, brick_agg_str(), br00116_df)
     br00044_rows = [sue2, sue3, yao1]
     br00044_df = DataFrame(br00044_rows, columns=br00044_columns)
-    upsert_sheet(br00044_file_path, yell_agg_str(), br00044_df)
+    upsert_sheet(br00044_file_path, brick_agg_str(), br00044_df)
 
-    br00117_file_path = create_path(yell_dir, "br00117.xlsx")
+    br00117_file_path = create_path(brick_dir, "br00117.xlsx")
     br00117_columns = [
         face_name_str(),
         event_int_str(),
@@ -188,7 +188,7 @@ def test_etl_yell_agg_df_to_yell_pidgin_raw_df_CreatesFile(env_dir_setup_cleanup
         otx_road_str(),
         inx_road_str(),
     ]
-    br00045_file_path = create_path(yell_dir, "br00045.xlsx")
+    br00045_file_path = create_path(brick_dir, "br00045.xlsx")
     br00045_columns = [
         face_name_str(),
         event_int_str(),
@@ -205,16 +205,16 @@ def test_etl_yell_agg_df_to_yell_pidgin_raw_df_CreatesFile(env_dir_setup_cleanup
     yao1 = [yao_str, event1, yao_str, yao_inx, rdx, rdx, ukx]
     b117_rows = [sue0, sue1]
     br00117_df = DataFrame(b117_rows, columns=br00117_columns)
-    upsert_sheet(br00117_file_path, yell_agg_str(), br00117_df)
+    upsert_sheet(br00117_file_path, brick_agg_str(), br00117_df)
     br00045_rows = [sue2, sue3, yao1]
     br00045_df = DataFrame(br00045_rows, columns=br00045_columns)
-    upsert_sheet(br00045_file_path, yell_agg_str(), br00045_df)
+    upsert_sheet(br00045_file_path, brick_agg_str(), br00045_df)
 
     events = {event2: sue_str, event5: sue_str}
     assert os_path_exists(pidgin_path) is False
 
     # WHEN
-    etl_yell_agg_df_to_yell_pidgin_raw_df(events, yell_dir)
+    etl_brick_agg_df_to_brick_pidgin_raw_df(events, brick_dir)
 
     # THEN
     assert os_path_exists(pidgin_path)
@@ -307,7 +307,7 @@ def test_etl_yell_agg_df_to_yell_pidgin_raw_df_CreatesFile(env_dir_setup_cleanup
     assert gen_road_df.to_csv(index=False) == e1_road_df.to_csv(index=False)
 
 
-def create_yell_valid_table(cursor, idea_number: str):
+def create_brick_valid_table(cursor, idea_number: str):
     if idea_number == "br00113":
         x_columns = [
             face_name_str(),
@@ -389,11 +389,11 @@ def create_yell_valid_table(cursor, idea_number: str):
             unknown_word_str(),
         ]
     x_types = {x_column: "TEXT" for x_column in x_columns}
-    agg_tablename = f"{yell_valid_str()}_{idea_number}"
+    agg_tablename = f"{brick_valid_str()}_{idea_number}"
     create_table_from_columns(cursor, agg_tablename, x_columns, x_types)
 
 
-def populate_yell_valid_table(cursor, idea_number: str):
+def populate_brick_valid_table(cursor, idea_number: str):
     bob_str = "Bob"
     sue_str = "Sue"
     yao_str = "Yao"
@@ -408,7 +408,7 @@ def populate_yell_valid_table(cursor, idea_number: str):
     event2 = 2
     event5 = 5
     event9 = 9
-    agg_tablename = f"{yell_valid_str()}_{idea_number}"
+    agg_tablename = f"{brick_valid_str()}_{idea_number}"
     if idea_number == "br00042":
         insert_into_clause = f"""
 INSERT INTO {agg_tablename} (
@@ -556,7 +556,7 @@ VALUES
     cursor.execute(insert_sqlstr)
 
 
-def test_yell_valid_tables_to_pidgin_prime_raw_tables_PopulatesTables():
+def test_brick_valid_tables_to_pidgin_prime_raw_tables_PopulatesTables():
     # ESTABLISH
     bob_str = "Bob"
     sue_str = "Sue"
@@ -580,30 +580,30 @@ def test_yell_valid_tables_to_pidgin_prime_raw_tables_PopulatesTables():
         br00044_str = "br00044"
         br00117_str = "br00117"
         br00045_str = "br00045"
-        create_yell_valid_table(cursor, br00113_str)
-        create_yell_valid_table(cursor, br00043_str)
-        create_yell_valid_table(cursor, br00115_str)
-        create_yell_valid_table(cursor, br00042_str)
-        create_yell_valid_table(cursor, br00116_str)
-        create_yell_valid_table(cursor, br00044_str)
-        create_yell_valid_table(cursor, br00117_str)
-        create_yell_valid_table(cursor, br00045_str)
-        populate_yell_valid_table(cursor, br00113_str)
-        populate_yell_valid_table(cursor, br00043_str)
-        populate_yell_valid_table(cursor, br00115_str)
-        populate_yell_valid_table(cursor, br00042_str)
-        populate_yell_valid_table(cursor, br00116_str)
-        populate_yell_valid_table(cursor, br00044_str)
-        populate_yell_valid_table(cursor, br00117_str)
-        populate_yell_valid_table(cursor, br00045_str)
-        br00113_tablename = f"{yell_valid_str()}_{br00113_str}"
-        br00043_tablename = f"{yell_valid_str()}_{br00043_str}"
-        br00115_tablename = f"{yell_valid_str()}_{br00115_str}"
-        br00042_tablename = f"{yell_valid_str()}_{br00042_str}"
-        br00116_tablename = f"{yell_valid_str()}_{br00116_str}"
-        br00044_tablename = f"{yell_valid_str()}_{br00044_str}"
-        br00117_tablename = f"{yell_valid_str()}_{br00117_str}"
-        br00045_tablename = f"{yell_valid_str()}_{br00045_str}"
+        create_brick_valid_table(cursor, br00113_str)
+        create_brick_valid_table(cursor, br00043_str)
+        create_brick_valid_table(cursor, br00115_str)
+        create_brick_valid_table(cursor, br00042_str)
+        create_brick_valid_table(cursor, br00116_str)
+        create_brick_valid_table(cursor, br00044_str)
+        create_brick_valid_table(cursor, br00117_str)
+        create_brick_valid_table(cursor, br00045_str)
+        populate_brick_valid_table(cursor, br00113_str)
+        populate_brick_valid_table(cursor, br00043_str)
+        populate_brick_valid_table(cursor, br00115_str)
+        populate_brick_valid_table(cursor, br00042_str)
+        populate_brick_valid_table(cursor, br00116_str)
+        populate_brick_valid_table(cursor, br00044_str)
+        populate_brick_valid_table(cursor, br00117_str)
+        populate_brick_valid_table(cursor, br00045_str)
+        br00113_tablename = f"{brick_valid_str()}_{br00113_str}"
+        br00043_tablename = f"{brick_valid_str()}_{br00043_str}"
+        br00115_tablename = f"{brick_valid_str()}_{br00115_str}"
+        br00042_tablename = f"{brick_valid_str()}_{br00042_str}"
+        br00116_tablename = f"{brick_valid_str()}_{br00116_str}"
+        br00044_tablename = f"{brick_valid_str()}_{br00044_str}"
+        br00117_tablename = f"{brick_valid_str()}_{br00117_str}"
+        br00045_tablename = f"{brick_valid_str()}_{br00045_str}"
         assert get_row_count(cursor, br00113_tablename) == 2
         assert get_row_count(cursor, br00043_tablename) == 3
         assert get_row_count(cursor, br00115_tablename) == 3
@@ -623,7 +623,7 @@ def test_yell_valid_tables_to_pidgin_prime_raw_tables_PopulatesTables():
         assert get_row_count(cursor, pidgin_raw_road_tablename) == 0
 
         # WHEN
-        yell_valid_tables_to_pidgin_prime_raw_tables(cursor)
+        brick_valid_tables_to_pidgin_prime_raw_tables(cursor)
 
         # THEN
         assert get_row_count(cursor, pidgin_raw_label_tablename) == 5

--- a/src/a18_etl_toolbox/test_tran/test_brick_idea_sheets2face_idea_sheets.py
+++ b/src/a18_etl_toolbox/test_tran/test_brick_idea_sheets2face_idea_sheets.py
@@ -9,9 +9,9 @@ from src.a16_pidgin_logic._utils.str_a16 import (
     otx_name_str,
     unknown_word_str,
 )
-from src.a17_idea_logic._utils.str_a17 import yell_valid_str
+from src.a17_idea_logic._utils.str_a17 import brick_valid_str
 from src.a17_idea_logic.idea_db_tool import get_sheet_names, upsert_sheet, sheet_exists
-from src.a18_etl_toolbox.transformers import etl_yell_ideas_to_otz_face_ideas
+from src.a18_etl_toolbox.transformers import etl_brick_ideas_to_otz_face_ideas
 from src.a18_etl_toolbox._utils.env_a18 import (
     get_module_temp_dir,
     env_dir_setup_cleanup,
@@ -22,7 +22,7 @@ from pandas.testing import (
 from pandas import DataFrame, read_excel as pandas_read_excel
 
 
-def test_etl_yell_ideas_to_otz_face_ideas_CreatesFaceIdeaSheets_Scenario0_SingleFaceName(
+def test_etl_brick_ideas_to_otz_face_ideas_CreatesFaceIdeaSheets_Scenario0_SingleFaceName(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -42,38 +42,38 @@ def test_etl_yell_ideas_to_otz_face_ideas_CreatesFaceIdeaSheets_Scenario0_Single
     accord23_str = "accord23"
     row1 = [sue_str, event3, accord23_str, hour6am, minute_360]
     row2 = [sue_str, event3, accord23_str, hour7am, minute_420]
-    br00003_yell_agg_df = DataFrame([row1, row2], columns=idea_columns)
+    br00003_brick_agg_df = DataFrame([row1, row2], columns=idea_columns)
     x_etl_dir = get_module_temp_dir()
-    x_yell_dir = create_path(x_etl_dir, "yell")
+    x_brick_dir = create_path(x_etl_dir, "brick")
     x_syntax_otz_dir = create_path(x_etl_dir, "syntax_otz")
     br00003_filename = "br00003.xlsx"
-    br00003_agg_file_path = create_path(x_yell_dir, br00003_filename)
-    upsert_sheet(br00003_agg_file_path, yell_valid_str(), br00003_yell_agg_df)
-    assert sheet_exists(br00003_agg_file_path, yell_valid_str())
+    br00003_agg_file_path = create_path(x_brick_dir, br00003_filename)
+    upsert_sheet(br00003_agg_file_path, brick_valid_str(), br00003_brick_agg_df)
+    assert sheet_exists(br00003_agg_file_path, brick_valid_str())
     sue_dir = create_path(x_syntax_otz_dir, sue_str)
     sue_br00003_filepath = create_path(sue_dir, br00003_filename)
-    assert sheet_exists(sue_br00003_filepath, yell_valid_str()) is False
+    assert sheet_exists(sue_br00003_filepath, brick_valid_str()) is False
 
     # WHEN
-    etl_yell_ideas_to_otz_face_ideas(x_yell_dir, x_syntax_otz_dir)
+    etl_brick_ideas_to_otz_face_ideas(x_brick_dir, x_syntax_otz_dir)
 
     # THEN
-    assert sheet_exists(sue_br00003_filepath, yell_valid_str())
+    assert sheet_exists(sue_br00003_filepath, brick_valid_str())
     sue_br3_agg_df = pandas_read_excel(
-        br00003_agg_file_path, sheet_name=yell_valid_str()
+        br00003_agg_file_path, sheet_name=brick_valid_str()
     )
     print(f"{sue_br3_agg_df.columns=}")
 
-    assert len(sue_br3_agg_df.columns) == len(br00003_yell_agg_df.columns)
-    assert list(sue_br3_agg_df.columns) == list(br00003_yell_agg_df.columns)
+    assert len(sue_br3_agg_df.columns) == len(br00003_brick_agg_df.columns)
+    assert list(sue_br3_agg_df.columns) == list(br00003_brick_agg_df.columns)
     assert len(sue_br3_agg_df) > 0
-    assert len(sue_br3_agg_df) == len(br00003_yell_agg_df)
+    assert len(sue_br3_agg_df) == len(br00003_brick_agg_df)
     assert len(sue_br3_agg_df) == 2
-    assert sue_br3_agg_df.to_csv() == br00003_yell_agg_df.to_csv()
-    assert get_sheet_names(sue_br00003_filepath) == [yell_valid_str()]
+    assert sue_br3_agg_df.to_csv() == br00003_brick_agg_df.to_csv()
+    assert get_sheet_names(sue_br00003_filepath) == [brick_valid_str()]
 
 
-def test_etl_yell_ideas_to_otz_face_ideas_CreatesFaceIdeaSheets_Scenario1_MultpleFaceNames(
+def test_etl_brick_ideas_to_otz_face_ideas_CreatesFaceIdeaSheets_Scenario1_MultpleFaceNames(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -96,33 +96,33 @@ def test_etl_yell_ideas_to_otz_face_ideas_CreatesFaceIdeaSheets_Scenario1_Multpl
     sue1 = [sue_str, event3, accord23_str, hour6am, minute_360]
     sue2 = [sue_str, event3, accord23_str, hour7am, minute_420]
     zia3 = [zia_str, event7, accord23_str, hour7am, minute_420]
-    br00003_yell_agg_df = DataFrame([sue1, sue2, zia3], columns=idea_columns)
+    br00003_brick_agg_df = DataFrame([sue1, sue2, zia3], columns=idea_columns)
     x_etl_dir = get_module_temp_dir()
-    x_yell_dir = create_path(x_etl_dir, "yell")
+    x_brick_dir = create_path(x_etl_dir, "brick")
     x_syntax_otz_dir = create_path(x_etl_dir, "syntax_otz")
     br00003_filename = "br00003.xlsx"
-    br00003_agg_file_path = create_path(x_yell_dir, br00003_filename)
-    upsert_sheet(br00003_agg_file_path, yell_valid_str(), br00003_yell_agg_df)
+    br00003_agg_file_path = create_path(x_brick_dir, br00003_filename)
+    upsert_sheet(br00003_agg_file_path, brick_valid_str(), br00003_brick_agg_df)
     sue_dir = create_path(x_syntax_otz_dir, sue_str)
     zia_dir = create_path(x_syntax_otz_dir, zia_str)
     sue_br00003_filepath = create_path(sue_dir, br00003_filename)
     zia_br00003_filepath = create_path(zia_dir, br00003_filename)
-    assert sheet_exists(sue_br00003_filepath, yell_valid_str()) is False
-    assert sheet_exists(zia_br00003_filepath, yell_valid_str()) is False
+    assert sheet_exists(sue_br00003_filepath, brick_valid_str()) is False
+    assert sheet_exists(zia_br00003_filepath, brick_valid_str()) is False
 
     # WHEN
-    etl_yell_ideas_to_otz_face_ideas(x_yell_dir, x_syntax_otz_dir)
+    etl_brick_ideas_to_otz_face_ideas(x_brick_dir, x_syntax_otz_dir)
 
     # THEN
-    assert sheet_exists(sue_br00003_filepath, yell_valid_str())
-    assert sheet_exists(zia_br00003_filepath, yell_valid_str())
-    assert get_sheet_names(sue_br00003_filepath) == [yell_valid_str()]
-    assert get_sheet_names(zia_br00003_filepath) == [yell_valid_str()]
+    assert sheet_exists(sue_br00003_filepath, brick_valid_str())
+    assert sheet_exists(zia_br00003_filepath, brick_valid_str())
+    assert get_sheet_names(sue_br00003_filepath) == [brick_valid_str()]
+    assert get_sheet_names(zia_br00003_filepath) == [brick_valid_str()]
     sue_br3_agg_df = pandas_read_excel(
-        sue_br00003_filepath, sheet_name=yell_valid_str()
+        sue_br00003_filepath, sheet_name=brick_valid_str()
     )
     zia_br3_agg_df = pandas_read_excel(
-        zia_br00003_filepath, sheet_name=yell_valid_str()
+        zia_br00003_filepath, sheet_name=brick_valid_str()
     )
     print(f"{sue_br3_agg_df.columns=}")
     print(f"{zia_br3_agg_df.columns=}")
@@ -132,7 +132,7 @@ def test_etl_yell_ideas_to_otz_face_ideas_CreatesFaceIdeaSheets_Scenario1_Multpl
     pandas_assert_frame_equal(zia_br3_agg_df, example_zia_df)
 
 
-def test_etl_yell_ideas_to_otz_face_ideas_Scenario2_PidginDimenIdeasAreNotLoaded(
+def test_etl_brick_ideas_to_otz_face_ideas_Scenario2_PidginDimenIdeasAreNotLoaded(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -152,7 +152,7 @@ def test_etl_yell_ideas_to_otz_face_ideas_Scenario2_PidginDimenIdeasAreNotLoaded
     accord23_str = "accord23"
     sue3_0 = [sue_str, event3, accord23_str, hour6am, minute_360]
     sue3_1 = [sue_str, event3, accord23_str, hour7am, minute_420]
-    br00003_yell_agg_df = DataFrame([sue3_0, sue3_1], columns=br00003_columns)
+    br00003_brick_agg_df = DataFrame([sue3_0, sue3_1], columns=br00003_columns)
 
     br00043_columns = [
         face_name_str(),
@@ -165,34 +165,34 @@ def test_etl_yell_ideas_to_otz_face_ideas_Scenario2_PidginDimenIdeasAreNotLoaded
     ]
     sue43_0 = [sue_str, event3, ":", "Bob", ":", "Bobby", "Unknown"]
     sue43_1 = [sue_str, event3, ":", "Bob", ":", "Bobby", "Unknown"]
-    br00043_yell_agg_df = DataFrame([sue43_0, sue43_1], columns=br00043_columns)
+    br00043_brick_agg_df = DataFrame([sue43_0, sue43_1], columns=br00043_columns)
 
     x_etl_dir = get_module_temp_dir()
-    x_yell_dir = create_path(x_etl_dir, "yell")
+    x_brick_dir = create_path(x_etl_dir, "brick")
     x_syntax_otz_dir = create_path(x_etl_dir, "syntax_otz")
     br00003_filename = "br00003.xlsx"
     br00043_filename = "br00043.xlsx"
-    br00003_agg_file_path = create_path(x_yell_dir, br00003_filename)
-    br00043_agg_file_path = create_path(x_yell_dir, br00043_filename)
-    upsert_sheet(br00003_agg_file_path, yell_valid_str(), br00003_yell_agg_df)
-    upsert_sheet(br00043_agg_file_path, yell_valid_str(), br00043_yell_agg_df)
-    assert sheet_exists(br00003_agg_file_path, yell_valid_str())
-    assert sheet_exists(br00043_agg_file_path, yell_valid_str())
+    br00003_agg_file_path = create_path(x_brick_dir, br00003_filename)
+    br00043_agg_file_path = create_path(x_brick_dir, br00043_filename)
+    upsert_sheet(br00003_agg_file_path, brick_valid_str(), br00003_brick_agg_df)
+    upsert_sheet(br00043_agg_file_path, brick_valid_str(), br00043_brick_agg_df)
+    assert sheet_exists(br00003_agg_file_path, brick_valid_str())
+    assert sheet_exists(br00043_agg_file_path, brick_valid_str())
 
     sue_dir = create_path(x_syntax_otz_dir, sue_str)
     sue_br00003_filepath = create_path(sue_dir, br00003_filename)
     sue_br00043_filepath = create_path(sue_dir, br00043_filename)
-    assert sheet_exists(sue_br00003_filepath, yell_valid_str()) is False
-    assert sheet_exists(sue_br00043_filepath, yell_valid_str()) is False
+    assert sheet_exists(sue_br00003_filepath, brick_valid_str()) is False
+    assert sheet_exists(sue_br00043_filepath, brick_valid_str()) is False
 
     # WHEN
-    etl_yell_ideas_to_otz_face_ideas(x_yell_dir, x_syntax_otz_dir)
+    etl_brick_ideas_to_otz_face_ideas(x_brick_dir, x_syntax_otz_dir)
 
     # THEN
-    assert sheet_exists(sue_br00003_filepath, yell_valid_str())
-    assert sheet_exists(sue_br00043_filepath, yell_valid_str()) is False
+    assert sheet_exists(sue_br00003_filepath, brick_valid_str())
+    assert sheet_exists(sue_br00043_filepath, brick_valid_str()) is False
     sue_br3_agg_df = pandas_read_excel(
-        sue_br00003_filepath, sheet_name=yell_valid_str()
+        sue_br00003_filepath, sheet_name=brick_valid_str()
     )
     print(f"{sue_br3_agg_df.columns=}")
     example_sue_df = DataFrame([sue3_0, sue3_1], columns=br00003_columns)

--- a/src/a18_etl_toolbox/test_tran/test_brick_raw_sheets2brick_agg_sheets.py
+++ b/src/a18_etl_toolbox/test_tran/test_brick_raw_sheets2brick_agg_sheets.py
@@ -8,12 +8,16 @@ from src.a00_data_toolbox.db_toolbox import (
 from src.a02_finance_logic._utils.strs_a02 import fisc_tag_str
 from src.a06_bud_logic._utils.str_a06 import face_name_str, event_int_str
 from src.a15_fisc_logic._utils.str_a15 import cumlative_minute_str, hour_tag_str
-from src.a17_idea_logic._utils.str_a17 import yell_raw_str, yell_agg_str, yell_valid_str
+from src.a17_idea_logic._utils.str_a17 import (
+    brick_raw_str,
+    brick_agg_str,
+    brick_valid_str,
+)
 from src.a17_idea_logic.idea_db_tool import sheet_exists
 from src.a18_etl_toolbox.transformers import (
-    etl_yell_raw_db_to_yell_agg_db,
-    etl_yell_agg_db_to_yell_valid_db,
-    etl_yell_agg_db_to_yell_agg_df,
+    etl_brick_raw_db_to_brick_agg_db,
+    etl_brick_agg_db_to_brick_valid_db,
+    etl_brick_agg_db_to_brick_agg_df,
 )
 from src.a18_etl_toolbox._utils.env_a18 import (
     get_module_temp_dir,
@@ -23,7 +27,7 @@ from pandas import DataFrame, read_excel as pandas_read_excel
 from sqlite3 import connect as sqlite3_connect
 
 
-def test_etl_yell_raw_db_to_yell_agg_db_PopulatesAggTable_Scenario0_GroupByWorks():
+def test_etl_brick_raw_db_to_brick_agg_db_PopulatesAggTable_Scenario0_GroupByWorks():
     # ESTABLISH
     a23_str = "accord23"
     sue_str = "Sue"
@@ -32,7 +36,7 @@ def test_etl_yell_raw_db_to_yell_agg_db_PopulatesAggTable_Scenario0_GroupByWorks
     minute_420 = 420
     hour6am = "6am"
     hour7am = "7am"
-    raw_br00003_tablename = f"{yell_raw_str()}_br00003"
+    raw_br00003_tablename = f"{brick_raw_str()}_br00003"
     raw_br00003_columns = [
         face_name_str(),
         event_int_str(),
@@ -68,12 +72,12 @@ VALUES
 """
         insert_sqlstr = f"{insert_into_clause} {values_clause}"
         cursor.execute(insert_sqlstr)
-        agg_br00003_tablename = f"{yell_agg_str()}_br00003"
+        agg_br00003_tablename = f"{brick_agg_str()}_br00003"
         assert get_row_count(cursor, raw_br00003_tablename) == 3
         assert not db_table_exists(cursor, agg_br00003_tablename)
 
         # WHEN
-        etl_yell_raw_db_to_yell_agg_db(cursor)
+        etl_brick_raw_db_to_brick_agg_db(cursor)
 
         # THEN
         assert db_table_exists(cursor, agg_br00003_tablename)
@@ -105,7 +109,7 @@ ORDER BY {event_int_str()}, {cumlative_minute_str()};"""
         assert rows[1] == row1
 
 
-def test_etl_yell_raw_db_to_yell_agg_db_PopulatesAggTable_Scenario1_GroupByOnlyNonConflictingRecords():
+def test_etl_brick_raw_db_to_brick_agg_db_PopulatesAggTable_Scenario1_GroupByOnlyNonConflictingRecords():
     # ESTABLISH
     a23_str = "accord23"
     sue_str = "Sue"
@@ -116,7 +120,7 @@ def test_etl_yell_raw_db_to_yell_agg_db_PopulatesAggTable_Scenario1_GroupByOnlyN
     hour7am = "7am"
     hour8am = "8am"
 
-    raw_br00003_tablename = f"{yell_raw_str()}_br00003"
+    raw_br00003_tablename = f"{brick_raw_str()}_br00003"
     raw_br00003_columns = [
         face_name_str(),
         event_int_str(),
@@ -152,12 +156,12 @@ VALUES
 """
         insert_sqlstr = f"{insert_into_clause} {values_clause}"
         cursor.execute(insert_sqlstr)
-        agg_br00003_tablename = f"{yell_agg_str()}_br00003"
+        agg_br00003_tablename = f"{brick_agg_str()}_br00003"
         assert get_row_count(cursor, raw_br00003_tablename) == 3
         assert not db_table_exists(cursor, agg_br00003_tablename)
 
         # WHEN
-        etl_yell_raw_db_to_yell_agg_db(cursor)
+        etl_brick_raw_db_to_brick_agg_db(cursor)
 
         # THEN
         assert db_table_exists(cursor, agg_br00003_tablename)
@@ -183,7 +187,7 @@ VALUES
         assert rows[0] == row0
 
 
-def test_etl_yell_agg_db_to_yell_agg_df_PopulatesAggTable_Scenario0_GroupByWorks(
+def test_etl_brick_agg_db_to_brick_agg_df_PopulatesAggTable_Scenario0_GroupByWorks(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -197,7 +201,7 @@ def test_etl_yell_agg_db_to_yell_agg_df_PopulatesAggTable_Scenario0_GroupByWorks
     hour6am = "6am"
     hour7am = "7am"
     hour8am = "8am"
-    agg_br00003_tablename = f"{yell_agg_str()}_br00003"
+    agg_br00003_tablename = f"{brick_agg_str()}_br00003"
     agg_br00003_columns = [
         face_name_str(),
         event_int_str(),
@@ -234,16 +238,16 @@ VALUES
         insert_sqlstr = f"{insert_into_clause} {values_clause}"
         cursor.execute(insert_sqlstr)
         assert get_row_count(cursor, agg_br00003_tablename) == 3
-        yell_dir = create_path(get_module_temp_dir(), "yell")
-        yell_file_path = create_path(yell_dir, "br00003.xlsx")
-        assert not sheet_exists(yell_file_path, yell_agg_str())
+        brick_dir = create_path(get_module_temp_dir(), "brick")
+        brick_file_path = create_path(brick_dir, "br00003.xlsx")
+        assert not sheet_exists(brick_file_path, brick_agg_str())
 
         # WHEN
-        etl_yell_agg_db_to_yell_agg_df(db_conn, yell_dir)
+        etl_brick_agg_db_to_brick_agg_df(db_conn, brick_dir)
 
         # THEN
-        assert sheet_exists(yell_file_path, yell_agg_str())
-        agg_df = pandas_read_excel(yell_file_path, sheet_name=yell_agg_str())
+        assert sheet_exists(brick_file_path, brick_agg_str())
+        agg_df = pandas_read_excel(brick_file_path, sheet_name=brick_agg_str())
         row0 = [sue_str, event_1, a23_str, minute_360, hour6am]
         row1 = [sue_str, event_1, a23_str, minute_420, hour7am]
         row2 = [sue_str, event_2, a23_str, minute_480, hour8am]
@@ -257,7 +261,7 @@ VALUES
         assert ex_agg_df.to_csv() == agg_df.to_csv()
 
 
-def test_etl_yell_agg_db_to_yell_valid_db_PopulatesValidTable_Scenario0_Only_valid_events():
+def test_etl_brick_agg_db_to_brick_valid_db_PopulatesValidTable_Scenario0_Only_valid_events():
     # ESTABLISH
     a23_str = "accord23"
     sue_str = "Sue"
@@ -270,7 +274,7 @@ def test_etl_yell_agg_db_to_yell_valid_db_PopulatesValidTable_Scenario0_Only_val
     hour7am = "7am"
     hour8am = "8am"
 
-    agg_br00003_tablename = f"{yell_agg_str()}_br00003"
+    agg_br00003_tablename = f"{brick_agg_str()}_br00003"
     agg_br00003_columns = [
         face_name_str(),
         event_int_str(),
@@ -310,7 +314,7 @@ VALUES
 
         valid_events_columns = [face_name_str(), event_int_str()]
         valid_events_types = {face_name_str(): "TEXT", event_int_str(): "TEXT"}
-        valid_events_tablename = "yell_valid_events"
+        valid_events_tablename = "brick_valid_events"
         create_table_from_columns(
             cursor, valid_events_tablename, valid_events_columns, valid_events_types
         )
@@ -324,11 +328,11 @@ VALUES
         cursor.execute(insert_into_valid_events)
         assert get_row_count(cursor, valid_events_tablename) == 2
 
-        valid_br00003_tablename = f"{yell_valid_str()}_br00003"
+        valid_br00003_tablename = f"{brick_valid_str()}_br00003"
         assert not db_table_exists(cursor, valid_br00003_tablename)
 
         # WHEN
-        etl_yell_agg_db_to_yell_valid_db(cursor)
+        etl_brick_agg_db_to_brick_valid_db(cursor)
 
         # THEN
         assert db_table_exists(cursor, valid_br00003_tablename)

--- a/src/a18_etl_toolbox/test_tran/test_mud_sheets2brick_raw_sheets.py
+++ b/src/a18_etl_toolbox/test_tran/test_mud_sheets2brick_raw_sheets.py
@@ -7,11 +7,11 @@ from src.a00_data_toolbox.db_toolbox import (
 from src.a02_finance_logic._utils.strs_a02 import fisc_tag_str
 from src.a06_bud_logic._utils.str_a06 import face_name_str, event_int_str
 from src.a15_fisc_logic._utils.str_a15 import cumlative_minute_str, hour_tag_str
-from src.a17_idea_logic._utils.str_a17 import yell_raw_str
+from src.a17_idea_logic._utils.str_a17 import brick_raw_str
 from src.a17_idea_logic.idea_db_tool import get_sheet_names, upsert_sheet
 from src.a18_etl_toolbox.transformers import (
-    etl_mud_df_to_yell_raw_db,
-    etl_yell_raw_db_to_yell_raw_df,
+    etl_mud_df_to_brick_raw_db,
+    etl_brick_raw_db_to_brick_raw_df,
 )
 from src.a18_etl_toolbox._utils.env_a18 import (
     get_module_temp_dir,
@@ -22,7 +22,7 @@ from os.path import exists as os_path_exists
 from sqlite3 import connect as sqlite3_connect
 
 
-def test_etl_mud_df_to_yell_raw_db_PopulatesYellTables(env_dir_setup_cleanup):
+def test_etl_mud_df_to_brick_raw_db_PopulatesBrickTables(env_dir_setup_cleanup):
     # ESTABLISH
     sue_str = "Sue"
     event_1 = 1
@@ -33,7 +33,7 @@ def test_etl_mud_df_to_yell_raw_db_PopulatesYellTables(env_dir_setup_cleanup):
     hour7am = "7am"
     ex_filename = "fizzbuzz.xlsx"
     mud_dir = create_path(get_module_temp_dir(), "mud")
-    yell_dir = create_path(get_module_temp_dir(), "yell")
+    brick_dir = create_path(get_module_temp_dir(), "brick")
     mud_file_path = create_path(mud_dir, ex_filename)
     idea_columns = [
         face_name_str(),
@@ -66,11 +66,11 @@ def test_etl_mud_df_to_yell_raw_db_PopulatesYellTables(env_dir_setup_cleanup):
     upsert_sheet(mud_file_path, br00003_ex3_str, df3)
     with sqlite3_connect(":memory:") as db_conn:
         cursor = db_conn.cursor()
-        br00003_tablename = f"{yell_raw_str()}_br00003"
+        br00003_tablename = f"{brick_raw_str()}_br00003"
         assert not db_table_exists(cursor, br00003_tablename)
 
         # WHEN
-        etl_mud_df_to_yell_raw_db(db_conn, mud_dir)
+        etl_mud_df_to_brick_raw_db(db_conn, mud_dir)
 
         # THEN
         assert db_table_exists(cursor, br00003_tablename)
@@ -112,19 +112,19 @@ ORDER BY sheet_name, {event_int_str()}, {cumlative_minute_str()};"""
         assert rows[3] == row3
         assert rows[4] == row4
 
-        yell_file_path = create_path(yell_dir, "br00003.xlsx")
-        assert os_path_exists(yell_file_path) is False
+        brick_file_path = create_path(brick_dir, "br00003.xlsx")
+        assert os_path_exists(brick_file_path) is False
 
         # WHEN
-        etl_yell_raw_db_to_yell_raw_df(db_conn, yell_dir)
+        etl_brick_raw_db_to_brick_raw_df(db_conn, brick_dir)
 
         # THEN
-        print(f"{yell_file_path=}")
-        assert os_path_exists(yell_file_path)
-        x_df = pandas_read_excel(yell_file_path, sheet_name=yell_raw_str())
+        print(f"{brick_file_path=}")
+        assert os_path_exists(brick_file_path)
+        x_df = pandas_read_excel(brick_file_path, sheet_name=brick_raw_str())
         assert set(idea_columns).issubset(set(x_df.columns))
         assert file_dir_str in set(x_df.columns)
         assert filename_str in set(x_df.columns)
         assert sheet_name_str in set(x_df.columns)
         assert len(x_df) == 5
-        assert get_sheet_names(yell_file_path) == [yell_raw_str()]
+        assert get_sheet_names(brick_file_path) == [brick_raw_str()]

--- a/src/a18_etl_toolbox/test_tran/test_mud_sheets2yell_raw_sheets.py
+++ b/src/a18_etl_toolbox/test_tran/test_mud_sheets2yell_raw_sheets.py
@@ -10,7 +10,7 @@ from src.a15_fisc_logic._utils.str_a15 import cumlative_minute_str, hour_tag_str
 from src.a17_idea_logic._utils.str_a17 import yell_raw_str
 from src.a17_idea_logic.idea_db_tool import get_sheet_names, upsert_sheet
 from src.a18_etl_toolbox.transformers import (
-    etl_sound_df_to_yell_raw_db,
+    etl_mud_df_to_yell_raw_db,
     etl_yell_raw_db_to_yell_raw_df,
 )
 from src.a18_etl_toolbox._utils.env_a18 import (
@@ -22,7 +22,7 @@ from os.path import exists as os_path_exists
 from sqlite3 import connect as sqlite3_connect
 
 
-def test_etl_sound_df_to_yell_raw_db_PopulatesYellTables(env_dir_setup_cleanup):
+def test_etl_mud_df_to_yell_raw_db_PopulatesYellTables(env_dir_setup_cleanup):
     # ESTABLISH
     sue_str = "Sue"
     event_1 = 1
@@ -32,9 +32,9 @@ def test_etl_sound_df_to_yell_raw_db_PopulatesYellTables(env_dir_setup_cleanup):
     hour6am = "6am"
     hour7am = "7am"
     ex_filename = "fizzbuzz.xlsx"
-    sound_dir = create_path(get_module_temp_dir(), "sound")
+    mud_dir = create_path(get_module_temp_dir(), "mud")
     yell_dir = create_path(get_module_temp_dir(), "yell")
-    sound_file_path = create_path(sound_dir, ex_filename)
+    mud_file_path = create_path(mud_dir, ex_filename)
     idea_columns = [
         face_name_str(),
         event_int_str(),
@@ -61,16 +61,16 @@ def test_etl_sound_df_to_yell_raw_db_PopulatesYellTables(env_dir_setup_cleanup):
     br00003_ex1_str = "example1_br00003"
     br00003_ex2_str = "example2_br00003"
     br00003_ex3_str = "example3_br00003"
-    upsert_sheet(sound_file_path, br00003_ex1_str, df1)
-    upsert_sheet(sound_file_path, br00003_ex2_str, df2)
-    upsert_sheet(sound_file_path, br00003_ex3_str, df3)
+    upsert_sheet(mud_file_path, br00003_ex1_str, df1)
+    upsert_sheet(mud_file_path, br00003_ex2_str, df2)
+    upsert_sheet(mud_file_path, br00003_ex3_str, df3)
     with sqlite3_connect(":memory:") as db_conn:
         cursor = db_conn.cursor()
         br00003_tablename = f"{yell_raw_str()}_br00003"
         assert not db_table_exists(cursor, br00003_tablename)
 
         # WHEN
-        etl_sound_df_to_yell_raw_db(db_conn, sound_dir)
+        etl_mud_df_to_yell_raw_db(db_conn, mud_dir)
 
         # THEN
         assert db_table_exists(cursor, br00003_tablename)
@@ -94,7 +94,7 @@ ORDER BY sheet_name, {event_int_str()}, {cumlative_minute_str()};"""
         file = ex_filename
         e1 = event_1
         e2 = event_2
-        s_dir = create_path(sound_dir, ".")
+        s_dir = create_path(mud_dir, ".")
         m_360 = minute_360
         m_420 = minute_420
         br3_ex1_str = br00003_ex1_str

--- a/src/a18_etl_toolbox/test_tran/test_otx_event_idea_sheets2inx_event_idea_sheets.py
+++ b/src/a18_etl_toolbox/test_tran/test_otx_event_idea_sheets2inx_event_idea_sheets.py
@@ -9,7 +9,7 @@ from src.a06_bud_logic._utils.str_a06 import (
 )
 from src.a16_pidgin_logic._utils.str_a16 import pidgin_filename
 from src.a16_pidgin_logic.pidgin import pidginunit_shop
-from src.a17_idea_logic._utils.str_a17 import yell_valid_str
+from src.a17_idea_logic._utils.str_a17 import brick_valid_str
 from src.a17_idea_logic.idea_db_tool import upsert_sheet, sheet_exists
 from src.a18_etl_toolbox.transformers import (
     etl_otz_event_ideas_to_inz_events,
@@ -58,19 +58,19 @@ def test_etl_otz_event_ideas_to_inz_events_Scenario0_NoPidginUnit():
     x_otz_dir = create_path(get_module_temp_dir(), "syntax_otz")
     sue_otz_dir = create_path(x_otz_dir, sue_otx)
     otz_e3_dir = create_path(sue_otz_dir, event3)
-    yell_e3_br00011_path = create_path(otz_e3_dir, br00011_filename)
-    print(f"{yell_e3_br00011_path=}")
-    upsert_sheet(yell_e3_br00011_path, yell_valid_str(), e3_accord23_df)
-    print(f"{yell_valid_str()=}")
+    brick_e3_br00011_path = create_path(otz_e3_dir, br00011_filename)
+    print(f"{brick_e3_br00011_path=}")
+    upsert_sheet(brick_e3_br00011_path, brick_valid_str(), e3_accord23_df)
+    print(f"{brick_valid_str()=}")
     inx_str = "inx"
-    assert sheet_exists(yell_e3_br00011_path, inx_str) is False
+    assert sheet_exists(brick_e3_br00011_path, inx_str) is False
 
     # WHEN
     etl_otz_event_ideas_to_inz_events(x_otz_dir, x_event_pidgins)
 
     # THEN
-    assert sheet_exists(yell_e3_br00011_path, inx_str)
-    e3_inx_df = pandas_read_excel(yell_e3_br00011_path, sheet_name=inx_str)
+    assert sheet_exists(brick_e3_br00011_path, inx_str)
+    e3_inx_df = pandas_read_excel(brick_e3_br00011_path, sheet_name=inx_str)
     sue_i0 = [sue_otx, event3, accord23_str, bob_otx, bob_otx]
     sue_i1 = [sue_otx, event3, accord23_str, yao_otx, bob_otx]
     sue_i2 = [sue_otx, event3, accord23_str, yao_otx, yao_otx]
@@ -125,16 +125,16 @@ def test_etl_otz_event_ideas_to_inz_events_Scenario1_MultpleFaceNames_CreatesEve
     otz_e3_dir = create_path(sue_otz_dir, event3)
     otz_e7_dir = create_path(zia_otz_dir, event7)
     otz_e9_dir = create_path(zia_otz_dir, event9)
-    yell_e3_br00011_path = create_path(otz_e3_dir, br00011_filename)
-    yell_e7_br00011_path = create_path(otz_e7_dir, br00011_filename)
-    yell_e9_br00011_path = create_path(otz_e9_dir, br00011_filename)
-    print(f"{yell_e3_br00011_path=}")
-    print(f"{yell_e7_br00011_path=}")
-    print(f"{yell_e9_br00011_path=}")
-    upsert_sheet(yell_e3_br00011_path, yell_valid_str(), e3_accord23_df)
-    upsert_sheet(yell_e7_br00011_path, yell_valid_str(), e7_accord23_df)
-    upsert_sheet(yell_e9_br00011_path, yell_valid_str(), e9_accord23_df)
-    print(f"{yell_valid_str()=}")
+    brick_e3_br00011_path = create_path(otz_e3_dir, br00011_filename)
+    brick_e7_br00011_path = create_path(otz_e7_dir, br00011_filename)
+    brick_e9_br00011_path = create_path(otz_e9_dir, br00011_filename)
+    print(f"{brick_e3_br00011_path=}")
+    print(f"{brick_e7_br00011_path=}")
+    print(f"{brick_e9_br00011_path=}")
+    upsert_sheet(brick_e3_br00011_path, brick_valid_str(), e3_accord23_df)
+    upsert_sheet(brick_e7_br00011_path, brick_valid_str(), e7_accord23_df)
+    upsert_sheet(brick_e9_br00011_path, brick_valid_str(), e9_accord23_df)
+    print(f"{brick_valid_str()=}")
     inx_str = "inx"
     e3_pidginunit = pidginunit_shop(sue_otx, event3)
     e7_pidginunit = pidginunit_shop(zia_otx, event7)
@@ -152,20 +152,20 @@ def test_etl_otz_event_ideas_to_inz_events_Scenario1_MultpleFaceNames_CreatesEve
     save_file(otz_e3_dir, pidgin_filename(), e3_pidginunit.get_json())
     save_file(otz_e7_dir, pidgin_filename(), e7_pidginunit.get_json())
     save_file(otz_e9_dir, pidgin_filename(), e9_pidginunit.get_json())
-    assert sheet_exists(yell_e3_br00011_path, inx_str) is False
-    assert sheet_exists(yell_e7_br00011_path, inx_str) is False
-    assert sheet_exists(yell_e9_br00011_path, inx_str) is False
+    assert sheet_exists(brick_e3_br00011_path, inx_str) is False
+    assert sheet_exists(brick_e7_br00011_path, inx_str) is False
+    assert sheet_exists(brick_e9_br00011_path, inx_str) is False
 
     # WHEN
     etl_otz_event_ideas_to_inz_events(x_otz_dir, x_event_pidgins)
 
     # THEN
-    assert sheet_exists(yell_e3_br00011_path, inx_str)
-    assert sheet_exists(yell_e7_br00011_path, inx_str)
-    assert sheet_exists(yell_e9_br00011_path, inx_str)
-    e3_inx_df = pandas_read_excel(yell_e3_br00011_path, sheet_name=inx_str)
-    e7_inx_df = pandas_read_excel(yell_e7_br00011_path, sheet_name=inx_str)
-    e9_inx_df = pandas_read_excel(yell_e9_br00011_path, sheet_name=inx_str)
+    assert sheet_exists(brick_e3_br00011_path, inx_str)
+    assert sheet_exists(brick_e7_br00011_path, inx_str)
+    assert sheet_exists(brick_e9_br00011_path, inx_str)
+    e3_inx_df = pandas_read_excel(brick_e3_br00011_path, sheet_name=inx_str)
+    e7_inx_df = pandas_read_excel(brick_e7_br00011_path, sheet_name=inx_str)
+    e9_inx_df = pandas_read_excel(brick_e9_br00011_path, sheet_name=inx_str)
     sue_i0 = [sue_inx, event3, accord23_str, bob0_inx, bob0_inx]
     sue_i1 = [sue_inx, event3, accord23_str, yao0_inx, bob0_inx]
     sue_i2 = [sue_inx, event3, accord23_str, yao0_inx, yao0_inx]

--- a/src/a18_etl_toolbox/test_tran/test_otz_event_ideas_sheets2inz_event_ideas_sheets.py
+++ b/src/a18_etl_toolbox/test_tran/test_otz_event_ideas_sheets2inz_event_ideas_sheets.py
@@ -15,7 +15,7 @@ from pandas.testing import (
 from pandas import DataFrame, read_excel as pandas_read_excel
 
 
-def test_etl_otz_event_ideas_to_yell_events_Scenario0():
+def test_etl_otz_event_ideas_to_brick_events_Scenario0():
     # ESTABLISH
     sue_otx = "Sue"
     sue_inx = "Suzy"
@@ -62,7 +62,7 @@ def test_etl_otz_event_ideas_to_yell_events_Scenario0():
     pandas_assert_frame_equal(inz_e3_df, e3_accord23_df)
 
 
-# def test_etl_otz_event_ideas_to_yell_events_Scenario1_MultpleFaceNames_CreatesEventInxSheets(
+# def test_etl_otz_event_ideas_to_brick_events_Scenario1_MultpleFaceNames_CreatesEventInxSheets(
 #     env_dir_setup_cleanup,
 # ):
 #     # ESTABLISH
@@ -109,16 +109,16 @@ def test_etl_otz_event_ideas_to_yell_events_Scenario0():
 #     otz_e3_dir = create_path(sue_otz_dir, event3)
 #     otz_e7_dir = create_path(zia_otz_dir, event7)
 #     otz_e9_dir = create_path(zia_otz_dir, event9)
-#     yell_e3_br00011_path = create_path(otz_e3_dir, br00011_filename)
-#     yell_e7_br00011_path = create_path(otz_e7_dir, br00011_filename)
-#     yell_e9_br00011_path = create_path(otz_e9_dir, br00011_filename)
-#     print(f"{yell_e3_br00011_path=}")
-#     print(f"{yell_e7_br00011_path=}")
-#     print(f"{yell_e9_br00011_path=}")
-#     upsert_sheet(yell_e3_br00011_path, yell_valid_str(), e3_accord23_df)
-#     upsert_sheet(yell_e7_br00011_path, yell_valid_str(), e7_accord23_df)
-#     upsert_sheet(yell_e9_br00011_path, yell_valid_str(), e9_accord23_df)
-#     print(f"{yell_valid_str()=}")
+#     brick_e3_br00011_path = create_path(otz_e3_dir, br00011_filename)
+#     brick_e7_br00011_path = create_path(otz_e7_dir, br00011_filename)
+#     brick_e9_br00011_path = create_path(otz_e9_dir, br00011_filename)
+#     print(f"{brick_e3_br00011_path=}")
+#     print(f"{brick_e7_br00011_path=}")
+#     print(f"{brick_e9_br00011_path=}")
+#     upsert_sheet(brick_e3_br00011_path, brick_valid_str(), e3_accord23_df)
+#     upsert_sheet(brick_e7_br00011_path, brick_valid_str(), e7_accord23_df)
+#     upsert_sheet(brick_e9_br00011_path, brick_valid_str(), e9_accord23_df)
+#     print(f"{brick_valid_str()=}")
 #     inx_str = "inx"
 #     e3_pidginunit = pidginunit_shop(sue_otx, event3)
 #     e7_pidginunit = pidginunit_shop(zia_otx, event7)
@@ -136,20 +136,20 @@ def test_etl_otz_event_ideas_to_yell_events_Scenario0():
 #     save_file(otz_e3_dir, pidgin_filename(), e3_pidginunit.get_json())
 #     save_file(otz_e7_dir, pidgin_filename(), e7_pidginunit.get_json())
 #     save_file(otz_e9_dir, pidgin_filename(), e9_pidginunit.get_json())
-#     assert sheet_exists(yell_e3_br00011_path, inx_str) is False
-#     assert sheet_exists(yell_e7_br00011_path, inx_str) is False
-#     assert sheet_exists(yell_e9_br00011_path, inx_str) is False
+#     assert sheet_exists(brick_e3_br00011_path, inx_str) is False
+#     assert sheet_exists(brick_e7_br00011_path, inx_str) is False
+#     assert sheet_exists(brick_e9_br00011_path, inx_str) is False
 
 #     # WHEN
 #     etl_otz_inx_event_ideas_to_inz_faces(x_otz_dir, x_event_pidgins)
 
 #     # THEN
-#     assert sheet_exists(yell_e3_br00011_path, inx_str)
-#     assert sheet_exists(yell_e7_br00011_path, inx_str)
-#     assert sheet_exists(yell_e9_br00011_path, inx_str)
-#     e3_inx_df = pandas_read_excel(yell_e3_br00011_path, sheet_name=inx_str)
-#     e7_inx_df = pandas_read_excel(yell_e7_br00011_path, sheet_name=inx_str)
-#     e9_inx_df = pandas_read_excel(yell_e9_br00011_path, sheet_name=inx_str)
+#     assert sheet_exists(brick_e3_br00011_path, inx_str)
+#     assert sheet_exists(brick_e7_br00011_path, inx_str)
+#     assert sheet_exists(brick_e9_br00011_path, inx_str)
+#     e3_inx_df = pandas_read_excel(brick_e3_br00011_path, sheet_name=inx_str)
+#     e7_inx_df = pandas_read_excel(brick_e7_br00011_path, sheet_name=inx_str)
+#     e9_inx_df = pandas_read_excel(brick_e9_br00011_path, sheet_name=inx_str)
 #     sue_i0 = [sue_inx, event3, accord23_str, bob0_inx, bob0_inx]
 #     sue_i1 = [sue_inx, event3, accord23_str, yao0_inx, bob0_inx]
 #     sue_i2 = [sue_inx, event3, accord23_str, yao0_inx, yao0_inx]

--- a/src/a18_etl_toolbox/test_tran/test_otz_face_ideas_sheets2otz_event_ideas_sheets.py
+++ b/src/a18_etl_toolbox/test_tran/test_otz_face_ideas_sheets2otz_event_ideas_sheets.py
@@ -2,7 +2,7 @@ from src.a00_data_toolbox.file_toolbox import create_path
 from src.a02_finance_logic._utils.strs_a02 import fisc_tag_str
 from src.a06_bud_logic._utils.str_a06 import face_name_str, event_int_str
 from src.a15_fisc_logic._utils.str_a15 import cumlative_minute_str, hour_tag_str
-from src.a17_idea_logic._utils.str_a17 import yell_valid_str
+from src.a17_idea_logic._utils.str_a17 import brick_valid_str
 from src.a17_idea_logic.idea_db_tool import upsert_sheet, sheet_exists
 from src.a18_etl_toolbox.transformers import etl_otz_face_ideas_to_otz_event_otx_ideas
 from src.a18_etl_toolbox._utils.env_a18 import (
@@ -50,8 +50,8 @@ def test_etl_otz_face_ideas_to_otz_event_otx_ideas_CreatesFaceIdeaSheets_Scenari
     zia_dir = create_path(x_syntax_otz_dir, zia_str)
     sue_br00003_filepath = create_path(sue_dir, br00003_filename)
     zia_br00003_filepath = create_path(zia_dir, br00003_filename)
-    upsert_sheet(sue_br00003_filepath, yell_valid_str(), example_sue_df)
-    upsert_sheet(zia_br00003_filepath, yell_valid_str(), example_zia_df)
+    upsert_sheet(sue_br00003_filepath, brick_valid_str(), example_sue_df)
+    upsert_sheet(zia_br00003_filepath, brick_valid_str(), example_zia_df)
 
     event3_dir = create_path(sue_dir, event3)
     event7_dir = create_path(zia_dir, event7)
@@ -59,21 +59,21 @@ def test_etl_otz_face_ideas_to_otz_event_otx_ideas_CreatesFaceIdeaSheets_Scenari
     event3_br00003_filepath = create_path(event3_dir, br00003_filename)
     event7_br00003_filepath = create_path(event7_dir, br00003_filename)
     event9_br00003_filepath = create_path(event9_dir, br00003_filename)
-    assert sheet_exists(event3_br00003_filepath, yell_valid_str()) is False
-    assert sheet_exists(event7_br00003_filepath, yell_valid_str()) is False
-    assert sheet_exists(event9_br00003_filepath, yell_valid_str()) is False
+    assert sheet_exists(event3_br00003_filepath, brick_valid_str()) is False
+    assert sheet_exists(event7_br00003_filepath, brick_valid_str()) is False
+    assert sheet_exists(event9_br00003_filepath, brick_valid_str()) is False
 
     # WHEN
     etl_otz_face_ideas_to_otz_event_otx_ideas(x_syntax_otz_dir)
 
     # THEN
-    assert sheet_exists(event3_br00003_filepath, yell_valid_str())
-    assert sheet_exists(event7_br00003_filepath, yell_valid_str())
-    assert sheet_exists(event9_br00003_filepath, yell_valid_str())
+    assert sheet_exists(event3_br00003_filepath, brick_valid_str())
+    assert sheet_exists(event7_br00003_filepath, brick_valid_str())
+    assert sheet_exists(event9_br00003_filepath, brick_valid_str())
 
-    gen_event3_df = pandas_read_excel(event3_br00003_filepath, yell_valid_str())
-    gen_event7_df = pandas_read_excel(event7_br00003_filepath, yell_valid_str())
-    gen_event9_df = pandas_read_excel(event9_br00003_filepath, yell_valid_str())
+    gen_event3_df = pandas_read_excel(event3_br00003_filepath, brick_valid_str())
+    gen_event7_df = pandas_read_excel(event7_br00003_filepath, brick_valid_str())
+    gen_event9_df = pandas_read_excel(event9_br00003_filepath, brick_valid_str())
     example_event3_df = DataFrame([sue0, sue1], columns=idea_columns)
     example_event7_df = DataFrame([zia0], columns=idea_columns)
     example_event9_df = DataFrame([zia1, zia2], columns=idea_columns)

--- a/src/a18_etl_toolbox/test_tran/test_pidgin_agg_sheets2face_pidgin_sheets.py
+++ b/src/a18_etl_toolbox/test_tran/test_pidgin_agg_sheets2face_pidgin_sheets.py
@@ -1,12 +1,12 @@
 from src.a00_data_toolbox.file_toolbox import create_path
 from src.a17_idea_logic.idea_db_tool import upsert_sheet, sheet_exists
 from src.a18_etl_toolbox.tran_path import (
-    create_yell_pidgin_path,
+    create_brick_pidgin_path,
     create_syntax_otx_pidgin_path,
 )
 from src.a18_etl_toolbox.pidgin_agg import PidginPrimeColumns
 from src.a18_etl_toolbox.transformers import (
-    etl_yell_pidgin_agg_df_to_otz_face_pidgin_agg_df,
+    etl_brick_pidgin_agg_df_to_otz_face_pidgin_agg_df,
 )
 from src.a18_etl_toolbox._utils.env_a18 import (
     get_module_temp_dir,
@@ -17,7 +17,7 @@ from pandas.testing import assert_frame_equal as pandas_testing_assert_frame_equ
 from os.path import exists as os_path_exists
 
 
-def test_etl_yell_pidgin_agg_df_to_otz_face_pidgin_agg_df_Scenario0_Two_face_names(
+def test_etl_brick_pidgin_agg_df_to_otz_face_pidgin_agg_df_Scenario0_Two_face_names(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -39,14 +39,14 @@ def test_etl_yell_pidgin_agg_df_to_otz_face_pidgin_agg_df_Scenario0_Two_face_nam
     name_rows = [name0, name1, name2, name3]
     e1_name_agg_df = DataFrame(name_rows, columns=name_agg_columns)
 
-    yell_dir = create_path(get_module_temp_dir(), "yell")
-    agg_pidgin_path = create_yell_pidgin_path(yell_dir)
+    brick_dir = create_path(get_module_temp_dir(), "brick")
+    agg_pidgin_path = create_brick_pidgin_path(brick_dir)
     upsert_sheet(agg_pidgin_path, name_agg_str, e1_name_agg_df)
 
     faces_dir = create_path(get_module_temp_dir(), "syntax_otz")
 
     # WHEN
-    etl_yell_pidgin_agg_df_to_otz_face_pidgin_agg_df(yell_dir, faces_dir)
+    etl_brick_pidgin_agg_df_to_otz_face_pidgin_agg_df(brick_dir, faces_dir)
 
     # THEN
     sue_dir = create_path(faces_dir, sue_str)
@@ -69,7 +69,7 @@ def test_etl_yell_pidgin_agg_df_to_otz_face_pidgin_agg_df_Scenario0_Two_face_nam
     pandas_testing_assert_frame_equal(gen_zia_name_df, e1_zia_name_agg_df)
 
 
-def test_etl_yell_pidgin_agg_df_to_otz_face_pidgin_agg_df_Scenario1_AllMapDimens(
+def test_etl_brick_pidgin_agg_df_to_otz_face_pidgin_agg_df_Scenario1_AllMapDimens(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -124,8 +124,8 @@ def test_etl_yell_pidgin_agg_df_to_otz_face_pidgin_agg_df_Scenario1_AllMapDimens
     e1_tag_rows = [e1_tag0, e1_tag1]
     e1_tag_agg_df = DataFrame(e1_tag_rows, columns=tag_agg_columns)
 
-    yell_dir = create_path(get_module_temp_dir(), "yell")
-    agg_pidgin_path = create_yell_pidgin_path(yell_dir)
+    brick_dir = create_path(get_module_temp_dir(), "brick")
+    agg_pidgin_path = create_brick_pidgin_path(brick_dir)
     upsert_sheet(agg_pidgin_path, name_agg_str, e1_name_agg_df)
     upsert_sheet(agg_pidgin_path, label_agg_str, e1_label_agg_df)
     upsert_sheet(agg_pidgin_path, road_agg_str, e1_road_agg_df)
@@ -134,7 +134,7 @@ def test_etl_yell_pidgin_agg_df_to_otz_face_pidgin_agg_df_Scenario1_AllMapDimens
     faces_dir = create_path(get_module_temp_dir(), "syntax_otz")
 
     # WHEN
-    etl_yell_pidgin_agg_df_to_otz_face_pidgin_agg_df(yell_dir, faces_dir)
+    etl_brick_pidgin_agg_df_to_otz_face_pidgin_agg_df(brick_dir, faces_dir)
 
     # THEN
     sue_dir = create_path(faces_dir, sue_str)

--- a/src/a18_etl_toolbox/test_tran/test_pidgin_raw_sheets2pidgin_agg_sheets.py
+++ b/src/a18_etl_toolbox/test_tran/test_pidgin_raw_sheets2pidgin_agg_sheets.py
@@ -1,13 +1,13 @@
 from src.a00_data_toolbox.file_toolbox import create_path
 from src.a17_idea_logic.idea_db_tool import upsert_sheet, sheet_exists
-from src.a18_etl_toolbox.tran_path import create_yell_pidgin_path
+from src.a18_etl_toolbox.tran_path import create_brick_pidgin_path
 from src.a18_etl_toolbox.pidgin_agg import PidginPrimeColumns
 from src.a18_etl_toolbox.transformers import (
     etl_pidgin_name_raw_to_name_agg,
     etl_pidgin_label_raw_to_label_agg,
     etl_pidgin_tag_raw_to_tag_agg,
     etl_pidgin_road_raw_to_road_agg,
-    etl_yell_pidgin_raw_df_to_pidgin_agg_df,
+    etl_brick_pidgin_raw_df_to_pidgin_agg_df,
 )
 from src.a18_etl_toolbox._utils.env_a18 import (
     get_module_temp_dir,
@@ -38,15 +38,15 @@ def test_etl_pidgin_name_raw_to_name_agg_Scenario0_CreatesEmptyFileBecauseOfConf
     e1_name1 = [bx, sue_str, event7, bob_str, bob_inx, None, slash_str, None]
     e1_name_rows = [e1_name0, e1_name1]
     raw_name_df = DataFrame(e1_name_rows, columns=name_raw_columns)
-    x_yell_dir = get_module_temp_dir()
-    pidgin_path = create_yell_pidgin_path(x_yell_dir)
+    x_brick_dir = get_module_temp_dir()
+    pidgin_path = create_brick_pidgin_path(x_brick_dir)
     upsert_sheet(pidgin_path, name_raw_str, raw_name_df)
     assert os_path_exists(pidgin_path)
     assert sheet_exists(pidgin_path, name_raw_str)
     assert sheet_exists(pidgin_path, name_agg_str) is False
 
     # WHEN
-    etl_pidgin_name_raw_to_name_agg(x_yell_dir)
+    etl_pidgin_name_raw_to_name_agg(x_brick_dir)
 
     # THEN
     assert os_path_exists(pidgin_path)
@@ -77,15 +77,15 @@ def test_etl_pidgin_name_raw_to_name_agg_Scenario1_CreatesFileFromSingleIdea(
     e1_name1 = [bx, sue_str, event7, bob_str, bob_inx, None, None, None]
     e1_name_rows = [e1_name0, e1_name1]
     raw_name_df = DataFrame(e1_name_rows, columns=name_raw_columns)
-    x_yell_dir = get_module_temp_dir()
-    pidgin_path = create_yell_pidgin_path(x_yell_dir)
+    x_brick_dir = get_module_temp_dir()
+    pidgin_path = create_brick_pidgin_path(x_brick_dir)
     upsert_sheet(pidgin_path, name_raw_str, raw_name_df)
     assert os_path_exists(pidgin_path)
     assert sheet_exists(pidgin_path, name_raw_str)
     assert sheet_exists(pidgin_path, name_agg_str) is False
 
     # WHEN
-    etl_pidgin_name_raw_to_name_agg(x_yell_dir)
+    etl_pidgin_name_raw_to_name_agg(x_brick_dir)
 
     # THEN
     assert os_path_exists(pidgin_path)
@@ -121,15 +121,15 @@ def test_etl_pidgin_label_raw_to_label_agg_Scenario0_CreatesFileFromSingleIdea(
     e1_label1 = [bx, sue_str, event7, run_str, run_inx, None, None, None]
     e1_label_rows = [e1_label0, e1_label1]
     raw_label_df = DataFrame(e1_label_rows, columns=label_raw_columns)
-    x_yell_dir = get_module_temp_dir()
-    pidgin_path = create_yell_pidgin_path(x_yell_dir)
+    x_brick_dir = get_module_temp_dir()
+    pidgin_path = create_brick_pidgin_path(x_brick_dir)
     upsert_sheet(pidgin_path, label_raw_str, raw_label_df)
     assert os_path_exists(pidgin_path)
     assert sheet_exists(pidgin_path, label_raw_str)
     assert sheet_exists(pidgin_path, label_agg_str) is False
 
     # WHEN
-    etl_pidgin_label_raw_to_label_agg(x_yell_dir)
+    etl_pidgin_label_raw_to_label_agg(x_brick_dir)
 
     # THEN
     assert os_path_exists(pidgin_path)
@@ -165,15 +165,15 @@ def test_etl_pidgin_road_raw_to_road_agg_Scenario0_CreatesFileFromSingleIdea(
     e1_road1 = [bx, sue_str, event7, clean_otx, clean_inx, None, None, None]
     e1_road_rows = [e1_road0, e1_road1]
     raw_road_df = DataFrame(e1_road_rows, columns=road_raw_columns)
-    x_yell_dir = get_module_temp_dir()
-    pidgin_path = create_yell_pidgin_path(x_yell_dir)
+    x_brick_dir = get_module_temp_dir()
+    pidgin_path = create_brick_pidgin_path(x_brick_dir)
     upsert_sheet(pidgin_path, road_raw_str, raw_road_df)
     assert os_path_exists(pidgin_path)
     assert sheet_exists(pidgin_path, road_raw_str)
     assert sheet_exists(pidgin_path, road_agg_str) is False
 
     # WHEN
-    etl_pidgin_road_raw_to_road_agg(x_yell_dir)
+    etl_pidgin_road_raw_to_road_agg(x_brick_dir)
 
     # THEN
     assert os_path_exists(pidgin_path)
@@ -209,15 +209,15 @@ def test_etl_pidgin_tag_raw_to_tag_agg_Scenario0_CreatesFileFromSingleIdea(
     e1_tag1 = [bx, sue_str, event7, t6am_otx, t6am_inx, None, None, None]
     e1_tag_rows = [e1_tag0, e1_tag1]
     raw_tag_df = DataFrame(e1_tag_rows, columns=tag_raw_columns)
-    x_yell_dir = get_module_temp_dir()
-    pidgin_path = create_yell_pidgin_path(x_yell_dir)
+    x_brick_dir = get_module_temp_dir()
+    pidgin_path = create_brick_pidgin_path(x_brick_dir)
     upsert_sheet(pidgin_path, tag_raw_str, raw_tag_df)
     assert os_path_exists(pidgin_path)
     assert sheet_exists(pidgin_path, tag_raw_str)
     assert sheet_exists(pidgin_path, tag_agg_str) is False
 
     # WHEN
-    etl_pidgin_tag_raw_to_tag_agg(x_yell_dir)
+    etl_pidgin_tag_raw_to_tag_agg(x_brick_dir)
 
     # THEN
     assert os_path_exists(pidgin_path)
@@ -235,7 +235,7 @@ def test_etl_pidgin_tag_raw_to_tag_agg_Scenario0_CreatesFileFromSingleIdea(
     pandas_testing_assert_frame_equal(gen_tag_agg_df, e1_tag_agg_df)
 
 
-def test_etl_yell_pidgin_raw_df_to_pidgin_agg_df_Scenario0_CreatesFileWithAllDimens(
+def test_etl_brick_pidgin_raw_df_to_pidgin_agg_df_Scenario0_CreatesFileWithAllDimens(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -296,8 +296,8 @@ def test_etl_yell_pidgin_raw_df_to_pidgin_agg_df_Scenario0_CreatesFileWithAllDim
     e1_tag_rows = [e1_tag0, e1_tag1]
     raw_tag_df = DataFrame(e1_tag_rows, columns=tag_raw_columns)
 
-    x_yell_dir = get_module_temp_dir()
-    pidgin_path = create_yell_pidgin_path(x_yell_dir)
+    x_brick_dir = get_module_temp_dir()
+    pidgin_path = create_brick_pidgin_path(x_brick_dir)
     upsert_sheet(pidgin_path, name_raw_str, raw_name_df)
     upsert_sheet(pidgin_path, label_raw_str, raw_label_df)
     upsert_sheet(pidgin_path, road_raw_str, raw_road_df)
@@ -313,7 +313,7 @@ def test_etl_yell_pidgin_raw_df_to_pidgin_agg_df_Scenario0_CreatesFileWithAllDim
     assert sheet_exists(pidgin_path, tag_agg_str) is False
 
     # WHEN
-    etl_yell_pidgin_raw_df_to_pidgin_agg_df(x_yell_dir)
+    etl_brick_pidgin_raw_df_to_pidgin_agg_df(x_brick_dir)
 
     # THEN
     assert os_path_exists(pidgin_path)

--- a/src/a18_etl_toolbox/tran_path.py
+++ b/src/a18_etl_toolbox/tran_path.py
@@ -2,13 +2,13 @@ from src.a00_data_toolbox.file_toolbox import create_path
 from src.a01_word_logic.road import OwnerName, TagUnit, FaceName, EventInt
 
 
-YELL_PIDGIN_FILENAME = "pidgin.xlsx"
+BRICK_PIDGIN_FILENAME = "pidgin.xlsx"
 STANCE0001_FILENAME = "stance0001.xlsx"
 
 
-def create_yell_pidgin_path(yell_dir: str) -> str:
-    """Returns path: yell_dir\\pidgin.xlsx"""
-    return create_path(yell_dir, "pidgin.xlsx")
+def create_brick_pidgin_path(brick_dir: str) -> str:
+    """Returns path: brick_dir\\pidgin.xlsx"""
+    return create_path(brick_dir, "pidgin.xlsx")
 
 
 def create_syntax_otx_pidgin_path(syntax_otz_dir: str, face_name: FaceName) -> str:

--- a/src/a18_etl_toolbox/tran_sqlstrs.py
+++ b/src/a18_etl_toolbox/tran_sqlstrs.py
@@ -7,14 +7,14 @@ from src.a17_idea_logic.idea_config import (
 from sqlite3 import Connection as sqlite3_Connection
 
 
-CREATE_PIDLAB_RAW_SQLSTR = """CREATE TABLE IF NOT EXISTS pidgin_label_raw (idea_number TEXT, face_name TEXT, event_int INTEGER, otx_label TEXT, inx_label TEXT, otx_bridge TEXT, inx_bridge TEXT, unknown_word TEXT, error_message TEXT)"""
-CREATE_PIDLAB_AGG_SQLSTR = """CREATE TABLE IF NOT EXISTS pidgin_label_agg (face_name TEXT, event_int INTEGER, otx_label TEXT, inx_label TEXT, otx_bridge TEXT, inx_bridge TEXT, unknown_word TEXT)"""
-CREATE_PIDNAM_RAW_SQLSTR = """CREATE TABLE IF NOT EXISTS pidgin_name_raw (idea_number TEXT, face_name TEXT, event_int INTEGER, otx_name TEXT, inx_name TEXT, otx_bridge TEXT, inx_bridge TEXT, unknown_word TEXT, error_message TEXT)"""
-CREATE_PIDNAM_AGG_SQLSTR = """CREATE TABLE IF NOT EXISTS pidgin_name_agg (face_name TEXT, event_int INTEGER, otx_name TEXT, inx_name TEXT, otx_bridge TEXT, inx_bridge TEXT, unknown_word TEXT)"""
-CREATE_PIDROA_RAW_SQLSTR = """CREATE TABLE IF NOT EXISTS pidgin_road_raw (idea_number TEXT, face_name TEXT, event_int INTEGER, otx_road TEXT, inx_road TEXT, otx_bridge TEXT, inx_bridge TEXT, unknown_word TEXT, error_message TEXT)"""
-CREATE_PIDROA_AGG_SQLSTR = """CREATE TABLE IF NOT EXISTS pidgin_road_agg (face_name TEXT, event_int INTEGER, otx_road TEXT, inx_road TEXT, otx_bridge TEXT, inx_bridge TEXT, unknown_word TEXT)"""
-CREATE_PIDTAG_RAW_SQLSTR = """CREATE TABLE IF NOT EXISTS pidgin_tag_raw (idea_number TEXT, face_name TEXT, event_int INTEGER, otx_tag TEXT, inx_tag TEXT, otx_bridge TEXT, inx_bridge TEXT, unknown_word TEXT, error_message TEXT)"""
-CREATE_PIDTAG_AGG_SQLSTR = """CREATE TABLE IF NOT EXISTS pidgin_tag_agg (face_name TEXT, event_int INTEGER, otx_tag TEXT, inx_tag TEXT, otx_bridge TEXT, inx_bridge TEXT, unknown_word TEXT)"""
+CREATE_PIDLABE_RAW_SQLSTR = """CREATE TABLE IF NOT EXISTS pidgin_label_raw (idea_number TEXT, face_name TEXT, event_int INTEGER, otx_label TEXT, inx_label TEXT, otx_bridge TEXT, inx_bridge TEXT, unknown_word TEXT, error_message TEXT)"""
+CREATE_PIDLABE_AGG_SQLSTR = """CREATE TABLE IF NOT EXISTS pidgin_label_agg (face_name TEXT, event_int INTEGER, otx_label TEXT, inx_label TEXT, otx_bridge TEXT, inx_bridge TEXT, unknown_word TEXT)"""
+CREATE_PIDNAME_RAW_SQLSTR = """CREATE TABLE IF NOT EXISTS pidgin_name_raw (idea_number TEXT, face_name TEXT, event_int INTEGER, otx_name TEXT, inx_name TEXT, otx_bridge TEXT, inx_bridge TEXT, unknown_word TEXT, error_message TEXT)"""
+CREATE_PIDNAME_AGG_SQLSTR = """CREATE TABLE IF NOT EXISTS pidgin_name_agg (face_name TEXT, event_int INTEGER, otx_name TEXT, inx_name TEXT, otx_bridge TEXT, inx_bridge TEXT, unknown_word TEXT)"""
+CREATE_PIDROAD_RAW_SQLSTR = """CREATE TABLE IF NOT EXISTS pidgin_road_raw (idea_number TEXT, face_name TEXT, event_int INTEGER, otx_road TEXT, inx_road TEXT, otx_bridge TEXT, inx_bridge TEXT, unknown_word TEXT, error_message TEXT)"""
+CREATE_PIDROAD_AGG_SQLSTR = """CREATE TABLE IF NOT EXISTS pidgin_road_agg (face_name TEXT, event_int INTEGER, otx_road TEXT, inx_road TEXT, otx_bridge TEXT, inx_bridge TEXT, unknown_word TEXT)"""
+CREATE_PIDTAGG_RAW_SQLSTR = """CREATE TABLE IF NOT EXISTS pidgin_tag_raw (idea_number TEXT, face_name TEXT, event_int INTEGER, otx_tag TEXT, inx_tag TEXT, otx_bridge TEXT, inx_bridge TEXT, unknown_word TEXT, error_message TEXT)"""
+CREATE_PIDTAGG_AGG_SQLSTR = """CREATE TABLE IF NOT EXISTS pidgin_tag_agg (face_name TEXT, event_int INTEGER, otx_tag TEXT, inx_tag TEXT, otx_bridge TEXT, inx_bridge TEXT, unknown_word TEXT)"""
 
 CREATE_FISCCASH_AGG_SQLSTR = """CREATE TABLE IF NOT EXISTS fisc_cashbook_agg (fisc_tag TEXT, owner_name TEXT, acct_name TEXT, tran_time INTEGER, amount REAL)"""
 CREATE_FISCCASH_RAW_SQLSTR = """CREATE TABLE IF NOT EXISTS fisc_cashbook_raw (idea_number TEXT, face_name TEXT, event_int INTEGER, fisc_tag TEXT, owner_name TEXT, acct_name TEXT, tran_time INTEGER, amount REAL, error_message TEXT)"""
@@ -75,14 +75,14 @@ CREATE_BUDUNIT_DEL_RAW_SQLSTR = """CREATE TABLE IF NOT EXISTS budunit_del_raw (i
 
 def get_pidgin_prime_create_table_sqlstrs() -> dict[str, str]:
     return {
-        "pidgin_label_raw": CREATE_PIDLAB_RAW_SQLSTR,
-        "pidgin_label_agg": CREATE_PIDLAB_AGG_SQLSTR,
-        "pidgin_name_raw": CREATE_PIDNAM_RAW_SQLSTR,
-        "pidgin_name_agg": CREATE_PIDNAM_AGG_SQLSTR,
-        "pidgin_road_raw": CREATE_PIDROA_RAW_SQLSTR,
-        "pidgin_road_agg": CREATE_PIDROA_AGG_SQLSTR,
-        "pidgin_tag_raw": CREATE_PIDTAG_RAW_SQLSTR,
-        "pidgin_tag_agg": CREATE_PIDTAG_AGG_SQLSTR,
+        "pidgin_label_raw": CREATE_PIDLABE_RAW_SQLSTR,
+        "pidgin_label_agg": CREATE_PIDLABE_AGG_SQLSTR,
+        "pidgin_name_raw": CREATE_PIDNAME_RAW_SQLSTR,
+        "pidgin_name_agg": CREATE_PIDNAME_AGG_SQLSTR,
+        "pidgin_road_raw": CREATE_PIDROAD_RAW_SQLSTR,
+        "pidgin_road_agg": CREATE_PIDROAD_AGG_SQLSTR,
+        "pidgin_tag_raw": CREATE_PIDTAGG_RAW_SQLSTR,
+        "pidgin_tag_agg": CREATE_PIDTAGG_AGG_SQLSTR,
     }
 
 
@@ -174,7 +174,7 @@ def create_all_idea_tables(conn_or_cursor: sqlite3_Connection):
         create_table_from_columns(conn_or_cursor, x_tablename, x_columns, col_types)
 
 
-PIDLAB_INCONSISTENCY_SQLSTR = """SELECT otx_label
+PIDLABE_INCONSISTENCY_SQLSTR = """SELECT otx_label
 FROM pidgin_label_raw
 GROUP BY otx_label
 HAVING MIN(inx_label) != MAX(inx_label)
@@ -182,7 +182,7 @@ HAVING MIN(inx_label) != MAX(inx_label)
     OR MIN(inx_bridge) != MAX(inx_bridge)
     OR MIN(unknown_word) != MAX(unknown_word)
 """
-PIDNAM_INCONSISTENCY_SQLSTR = """SELECT otx_name
+PIDNAME_INCONSISTENCY_SQLSTR = """SELECT otx_name
 FROM pidgin_name_raw
 GROUP BY otx_name
 HAVING MIN(inx_name) != MAX(inx_name)
@@ -190,7 +190,7 @@ HAVING MIN(inx_name) != MAX(inx_name)
     OR MIN(inx_bridge) != MAX(inx_bridge)
     OR MIN(unknown_word) != MAX(unknown_word)
 """
-PIDROA_INCONSISTENCY_SQLSTR = """SELECT otx_road
+PIDROAD_INCONSISTENCY_SQLSTR = """SELECT otx_road
 FROM pidgin_road_raw
 GROUP BY otx_road
 HAVING MIN(inx_road) != MAX(inx_road)
@@ -198,7 +198,7 @@ HAVING MIN(inx_road) != MAX(inx_road)
     OR MIN(inx_bridge) != MAX(inx_bridge)
     OR MIN(unknown_word) != MAX(unknown_word)
 """
-PIDTAG_INCONSISTENCY_SQLSTR = """SELECT otx_tag
+PIDTAGG_INCONSISTENCY_SQLSTR = """SELECT otx_tag
 FROM pidgin_tag_raw
 GROUP BY otx_tag
 HAVING MIN(inx_tag) != MAX(inx_tag)
@@ -330,10 +330,10 @@ HAVING MIN(credor_respect) != MAX(credor_respect)
 
 def get_pidgin_inconsistency_sqlstrs() -> dict[str, str]:
     return {
-        "pidgin_label": PIDLAB_INCONSISTENCY_SQLSTR,
-        "pidgin_name": PIDNAM_INCONSISTENCY_SQLSTR,
-        "pidgin_road": PIDROA_INCONSISTENCY_SQLSTR,
-        "pidgin_tag": PIDTAG_INCONSISTENCY_SQLSTR,
+        "pidgin_label": PIDLABE_INCONSISTENCY_SQLSTR,
+        "pidgin_name": PIDNAME_INCONSISTENCY_SQLSTR,
+        "pidgin_road": PIDROAD_INCONSISTENCY_SQLSTR,
+        "pidgin_tag": PIDTAGG_INCONSISTENCY_SQLSTR,
     }
 
 
@@ -364,7 +364,7 @@ def get_bud_inconsistency_sqlstrs() -> dict[str, str]:
     }
 
 
-PIDLAB_SET_INCONSISTENCY_ERROR_MESSAGE_SQLSTR = """WITH inconsistency_rows AS (
+PIDLABE_SET_INCONSISTENCY_ERROR_MESSAGE_SQLSTR = """WITH inconsistency_rows AS (
 SELECT otx_label
 FROM pidgin_label_raw
 GROUP BY otx_label
@@ -379,7 +379,7 @@ FROM inconsistency_rows
 WHERE inconsistency_rows.otx_label = pidgin_label_raw.otx_label
 ;
 """
-PIDNAM_SET_INCONSISTENCY_ERROR_MESSAGE_SQLSTR = """WITH inconsistency_rows AS (
+PIDNAME_SET_INCONSISTENCY_ERROR_MESSAGE_SQLSTR = """WITH inconsistency_rows AS (
 SELECT otx_name
 FROM pidgin_name_raw
 GROUP BY otx_name
@@ -394,7 +394,7 @@ FROM inconsistency_rows
 WHERE inconsistency_rows.otx_name = pidgin_name_raw.otx_name
 ;
 """
-PIDROA_SET_INCONSISTENCY_ERROR_MESSAGE_SQLSTR = """WITH inconsistency_rows AS (
+PIDROAD_SET_INCONSISTENCY_ERROR_MESSAGE_SQLSTR = """WITH inconsistency_rows AS (
 SELECT otx_road
 FROM pidgin_road_raw
 GROUP BY otx_road
@@ -409,7 +409,7 @@ FROM inconsistency_rows
 WHERE inconsistency_rows.otx_road = pidgin_road_raw.otx_road
 ;
 """
-PIDTAG_SET_INCONSISTENCY_ERROR_MESSAGE_SQLSTR = """WITH inconsistency_rows AS (
+PIDTAGG_SET_INCONSISTENCY_ERROR_MESSAGE_SQLSTR = """WITH inconsistency_rows AS (
 SELECT otx_tag
 FROM pidgin_tag_raw
 GROUP BY otx_tag
@@ -794,10 +794,10 @@ GROUP BY face_name, event_int, fisc_tag, owner_name_ERASE
 
 def get_pidgin_update_inconsist_error_message_sqlstrs() -> dict[str, str]:
     return {
-        "pidgin_label": PIDLAB_SET_INCONSISTENCY_ERROR_MESSAGE_SQLSTR,
-        "pidgin_name": PIDNAM_SET_INCONSISTENCY_ERROR_MESSAGE_SQLSTR,
-        "pidgin_road": PIDROA_SET_INCONSISTENCY_ERROR_MESSAGE_SQLSTR,
-        "pidgin_tag": PIDTAG_SET_INCONSISTENCY_ERROR_MESSAGE_SQLSTR,
+        "pidgin_label": PIDLABE_SET_INCONSISTENCY_ERROR_MESSAGE_SQLSTR,
+        "pidgin_name": PIDNAME_SET_INCONSISTENCY_ERROR_MESSAGE_SQLSTR,
+        "pidgin_road": PIDROAD_SET_INCONSISTENCY_ERROR_MESSAGE_SQLSTR,
+        "pidgin_tag": PIDTAGG_SET_INCONSISTENCY_ERROR_MESSAGE_SQLSTR,
     }
 
 
@@ -828,28 +828,28 @@ def get_bud_put_update_inconsist_error_message_sqlstrs() -> dict[str, str]:
     }
 
 
-PIDLAB_AGG_INSERT_SQLSTR = """INSERT INTO pidgin_label_agg (otx_label, inx_label, otx_bridge, inx_bridge, unknown_word)
+PIDLABE_AGG_INSERT_SQLSTR = """INSERT INTO pidgin_label_agg (otx_label, inx_label, otx_bridge, inx_bridge, unknown_word)
 SELECT otx_label, MAX(inx_label), MAX(otx_bridge), MAX(inx_bridge), MAX(unknown_word)
 FROM pidgin_label_raw
 WHERE error_message IS NULL
 GROUP BY otx_label
 ;
 """
-PIDNAM_AGG_INSERT_SQLSTR = """INSERT INTO pidgin_name_agg (otx_name, inx_name, otx_bridge, inx_bridge, unknown_word)
+PIDNAME_AGG_INSERT_SQLSTR = """INSERT INTO pidgin_name_agg (otx_name, inx_name, otx_bridge, inx_bridge, unknown_word)
 SELECT otx_name, MAX(inx_name), MAX(otx_bridge), MAX(inx_bridge), MAX(unknown_word)
 FROM pidgin_name_raw
 WHERE error_message IS NULL
 GROUP BY otx_name
 ;
 """
-PIDROA_AGG_INSERT_SQLSTR = """INSERT INTO pidgin_road_agg (otx_road, inx_road, otx_bridge, inx_bridge, unknown_word)
+PIDROAD_AGG_INSERT_SQLSTR = """INSERT INTO pidgin_road_agg (otx_road, inx_road, otx_bridge, inx_bridge, unknown_word)
 SELECT otx_road, MAX(inx_road), MAX(otx_bridge), MAX(inx_bridge), MAX(unknown_word)
 FROM pidgin_road_raw
 WHERE error_message IS NULL
 GROUP BY otx_road
 ;
 """
-PIDTAG_AGG_INSERT_SQLSTR = """INSERT INTO pidgin_tag_agg (otx_tag, inx_tag, otx_bridge, inx_bridge, unknown_word)
+PIDTAGG_AGG_INSERT_SQLSTR = """INSERT INTO pidgin_tag_agg (otx_tag, inx_tag, otx_bridge, inx_bridge, unknown_word)
 SELECT otx_tag, MAX(inx_tag), MAX(otx_bridge), MAX(inx_bridge), MAX(unknown_word)
 FROM pidgin_tag_raw
 WHERE error_message IS NULL
@@ -981,10 +981,10 @@ GROUP BY face_name, event_int, fisc_tag, owner_name
 
 def get_pidgin_insert_agg_from_raw_sqlstrs() -> dict[str, str]:
     return {
-        "pidgin_label": PIDLAB_AGG_INSERT_SQLSTR,
-        "pidgin_name": PIDNAM_AGG_INSERT_SQLSTR,
-        "pidgin_road": PIDROA_AGG_INSERT_SQLSTR,
-        "pidgin_tag": PIDTAG_AGG_INSERT_SQLSTR,
+        "pidgin_label": PIDLABE_AGG_INSERT_SQLSTR,
+        "pidgin_name": PIDNAME_AGG_INSERT_SQLSTR,
+        "pidgin_road": PIDROAD_AGG_INSERT_SQLSTR,
+        "pidgin_tag": PIDTAGG_AGG_INSERT_SQLSTR,
     }
 
 

--- a/src/a18_etl_toolbox/transformers.py
+++ b/src/a18_etl_toolbox/transformers.py
@@ -179,8 +179,8 @@ def get_inx_obj(class_type, x_row) -> str:
     return x_row[CLASS_TYPES[class_type]["inx_obj"]]
 
 
-def etl_sound_df_to_yell_raw_db(conn: sqlite3_Connection, sound_dir: str):
-    for ref in get_all_idea_dataframes(sound_dir):
+def etl_mud_df_to_yell_raw_db(conn: sqlite3_Connection, mud_dir: str):
+    for ref in get_all_idea_dataframes(mud_dir):
         x_file_path = create_path(ref.file_dir, ref.filename)
         df = pandas_read_excel(x_file_path, ref.sheet_name)
         idea_sorting_columns = get_default_sorted_list(set(df.columns))

--- a/src/a19_world_logic/test/test_world_.py
+++ b/src/a19_world_logic/test/test_world_.py
@@ -30,7 +30,7 @@ def test_WorldUnit_Exists():
     assert not x_world._syntax_inz_dir
     assert not x_world._world_dir
     assert not x_world._mud_dir
-    assert not x_world._yell_dir
+    assert not x_world._brick_dir
     assert not x_world._fisc_mstr_dir
     assert not x_world._fiscunits
     assert not x_world._pidgin_events
@@ -45,7 +45,7 @@ def test_WorldUnit_set_mud_dir_SetsCorrectDirsAndFiles(env_dir_setup_cleanup):
     assert fizz_world._world_dir is None
     assert fizz_world._syntax_otz_dir is None
     assert fizz_world._mud_dir is None
-    assert fizz_world._yell_dir is None
+    assert fizz_world._brick_dir is None
     assert fizz_world._fisc_mstr_dir is None
     assert os_path_exists(x_mud_dir) is False
 
@@ -56,7 +56,7 @@ def test_WorldUnit_set_mud_dir_SetsCorrectDirsAndFiles(env_dir_setup_cleanup):
     assert fizz_world._world_dir is None
     assert fizz_world._syntax_otz_dir is None
     assert fizz_world._mud_dir == x_mud_dir
-    assert fizz_world._yell_dir is None
+    assert fizz_world._brick_dir is None
     assert fizz_world._fisc_mstr_dir is None
     assert os_path_exists(x_mud_dir)
 
@@ -69,20 +69,20 @@ def test_WorldUnit_set_world_dirs_SetsCorrectDirsAndFiles(env_dir_setup_cleanup)
     x_syntax_otz_dir = create_path(x_world_dir, "syntax_otz")
     x_syntax_inz_dir = create_path(x_world_dir, "syntax_inz")
     x_mud_dir = create_path(x_world_dir, "mud")
-    x_yell_dir = create_path(x_world_dir, "yell")
+    x_brick_dir = create_path(x_world_dir, "brick")
     x_fisc_mstr_dir = create_path(x_world_dir, "fisc_mstr")
 
     assert not fizz_world._world_dir
     assert not fizz_world._syntax_otz_dir
     assert not fizz_world._syntax_inz_dir
     assert not fizz_world._mud_dir
-    assert not fizz_world._yell_dir
+    assert not fizz_world._brick_dir
     assert not fizz_world._fisc_mstr_dir
     assert os_path_exists(x_world_dir) is False
     assert os_path_exists(x_syntax_otz_dir) is False
     assert os_path_exists(x_syntax_inz_dir) is False
     assert os_path_exists(x_mud_dir) is False
-    assert os_path_exists(x_yell_dir) is False
+    assert os_path_exists(x_brick_dir) is False
     assert os_path_exists(x_fisc_mstr_dir) is False
 
     # WHEN
@@ -93,12 +93,12 @@ def test_WorldUnit_set_world_dirs_SetsCorrectDirsAndFiles(env_dir_setup_cleanup)
     assert fizz_world._syntax_otz_dir == x_syntax_otz_dir
     assert fizz_world._syntax_inz_dir == x_syntax_inz_dir
     assert not fizz_world._mud_dir
-    assert fizz_world._yell_dir == x_yell_dir
+    assert fizz_world._brick_dir == x_brick_dir
     assert os_path_exists(x_world_dir)
     assert os_path_exists(x_syntax_otz_dir)
     assert os_path_exists(x_syntax_inz_dir)
     assert os_path_exists(x_mud_dir) is False
-    assert os_path_exists(x_yell_dir)
+    assert os_path_exists(x_brick_dir)
     assert os_path_exists(x_fisc_mstr_dir)
 
 

--- a/src/a19_world_logic/test/test_world_.py
+++ b/src/a19_world_logic/test/test_world_.py
@@ -29,36 +29,36 @@ def test_WorldUnit_Exists():
     assert not x_world._syntax_otz_dir
     assert not x_world._syntax_inz_dir
     assert not x_world._world_dir
-    assert not x_world._sound_dir
+    assert not x_world._mud_dir
     assert not x_world._yell_dir
     assert not x_world._fisc_mstr_dir
     assert not x_world._fiscunits
     assert not x_world._pidgin_events
 
 
-def test_WorldUnit_set_sound_dir_SetsCorrectDirsAndFiles(env_dir_setup_cleanup):
+def test_WorldUnit_set_mud_dir_SetsCorrectDirsAndFiles(env_dir_setup_cleanup):
     # ESTABLISH
     fizz_world = WorldUnit("fizz")
     x_example_dir = create_path(worlds_dir(), "example_dir")
-    x_sound_dir = create_path(x_example_dir, "sound")
+    x_mud_dir = create_path(x_example_dir, "mud")
 
     assert fizz_world._world_dir is None
     assert fizz_world._syntax_otz_dir is None
-    assert fizz_world._sound_dir is None
+    assert fizz_world._mud_dir is None
     assert fizz_world._yell_dir is None
     assert fizz_world._fisc_mstr_dir is None
-    assert os_path_exists(x_sound_dir) is False
+    assert os_path_exists(x_mud_dir) is False
 
     # WHEN
-    fizz_world.set_sound_dir(x_sound_dir)
+    fizz_world.set_mud_dir(x_mud_dir)
 
     # THEN
     assert fizz_world._world_dir is None
     assert fizz_world._syntax_otz_dir is None
-    assert fizz_world._sound_dir == x_sound_dir
+    assert fizz_world._mud_dir == x_mud_dir
     assert fizz_world._yell_dir is None
     assert fizz_world._fisc_mstr_dir is None
-    assert os_path_exists(x_sound_dir)
+    assert os_path_exists(x_mud_dir)
 
 
 def test_WorldUnit_set_world_dirs_SetsCorrectDirsAndFiles(env_dir_setup_cleanup):
@@ -68,20 +68,20 @@ def test_WorldUnit_set_world_dirs_SetsCorrectDirsAndFiles(env_dir_setup_cleanup)
     x_world_dir = create_path(worlds_dir(), fizz_str)
     x_syntax_otz_dir = create_path(x_world_dir, "syntax_otz")
     x_syntax_inz_dir = create_path(x_world_dir, "syntax_inz")
-    x_sound_dir = create_path(x_world_dir, "sound")
+    x_mud_dir = create_path(x_world_dir, "mud")
     x_yell_dir = create_path(x_world_dir, "yell")
     x_fisc_mstr_dir = create_path(x_world_dir, "fisc_mstr")
 
     assert not fizz_world._world_dir
     assert not fizz_world._syntax_otz_dir
     assert not fizz_world._syntax_inz_dir
-    assert not fizz_world._sound_dir
+    assert not fizz_world._mud_dir
     assert not fizz_world._yell_dir
     assert not fizz_world._fisc_mstr_dir
     assert os_path_exists(x_world_dir) is False
     assert os_path_exists(x_syntax_otz_dir) is False
     assert os_path_exists(x_syntax_inz_dir) is False
-    assert os_path_exists(x_sound_dir) is False
+    assert os_path_exists(x_mud_dir) is False
     assert os_path_exists(x_yell_dir) is False
     assert os_path_exists(x_fisc_mstr_dir) is False
 
@@ -92,12 +92,12 @@ def test_WorldUnit_set_world_dirs_SetsCorrectDirsAndFiles(env_dir_setup_cleanup)
     assert fizz_world._world_dir == x_world_dir
     assert fizz_world._syntax_otz_dir == x_syntax_otz_dir
     assert fizz_world._syntax_inz_dir == x_syntax_inz_dir
-    assert not fizz_world._sound_dir
+    assert not fizz_world._mud_dir
     assert fizz_world._yell_dir == x_yell_dir
     assert os_path_exists(x_world_dir)
     assert os_path_exists(x_syntax_otz_dir)
     assert os_path_exists(x_syntax_inz_dir)
-    assert os_path_exists(x_sound_dir) is False
+    assert os_path_exists(x_mud_dir) is False
     assert os_path_exists(x_yell_dir)
     assert os_path_exists(x_fisc_mstr_dir)
 
@@ -105,7 +105,7 @@ def test_WorldUnit_set_world_dirs_SetsCorrectDirsAndFiles(env_dir_setup_cleanup)
 def test_worldunit_shop_ReturnsObj_WithParameters(env_dir_setup_cleanup):
     # ESTABLISH
     worlds2_dir = create_path(worlds_dir(), "worlds2")
-    example_sound_dir = create_path(worlds_dir(), "example_sound")
+    example_mud_dir = create_path(worlds_dir(), "example_mud")
     five_world_id = "five"
     world2_time_nigh = 55
     accord45_str = "accord45"
@@ -116,7 +116,7 @@ def test_worldunit_shop_ReturnsObj_WithParameters(env_dir_setup_cleanup):
     x_world = worldunit_shop(
         world_id=five_world_id,
         worlds_dir=worlds2_dir,
-        sound_dir=example_sound_dir,
+        mud_dir=example_mud_dir,
         world_time_nigh=world2_time_nigh,
         timeconversions=world2timeconversions,
         _fiscunits=world2_fiscunits,
@@ -126,7 +126,7 @@ def test_worldunit_shop_ReturnsObj_WithParameters(env_dir_setup_cleanup):
     world_dir = create_path(worlds2_dir, x_world.world_id)
     assert x_world.world_id == five_world_id
     assert x_world.worlds_dir == worlds2_dir
-    assert x_world._sound_dir == example_sound_dir
+    assert x_world._mud_dir == example_mud_dir
     assert x_world.world_time_nigh == world2_time_nigh
     assert x_world.timeconversions == world2timeconversions
     assert x_world._events == {}
@@ -149,7 +149,7 @@ def test_worldunit_shop_ReturnsObj_WithoutParameters(env_dir_setup_cleanup):
     assert x_world.world_time_nigh == 0
     assert x_world.timeconversions == {}
     assert x_world._events == {}
-    assert x_world._sound_dir == create_path(x_world._world_dir, "sound")
+    assert x_world._mud_dir == create_path(x_world._world_dir, "mud")
     assert x_world._syntax_otz_dir == create_path(world_dir, "syntax_otz")
     assert x_world._syntax_inz_dir == create_path(world_dir, "syntax_inz")
     assert x_world._fiscunits == set()

--- a/src/a19_world_logic/test_00_mud_to_brick/test_world_etl00_mud_to_brick_raw.py
+++ b/src/a19_world_logic/test_00_mud_to_brick/test_world_etl00_mud_to_brick_raw.py
@@ -7,7 +7,7 @@ from src.a00_data_toolbox.db_toolbox import (
 from src.a02_finance_logic._utils.strs_a02 import fisc_tag_str
 from src.a06_bud_logic._utils.str_a06 import face_name_str, event_int_str
 from src.a15_fisc_logic._utils.str_a15 import cumlative_minute_str, hour_tag_str
-from src.a17_idea_logic._utils.str_a17 import yell_raw_str
+from src.a17_idea_logic._utils.str_a17 import brick_raw_str
 from src.a17_idea_logic.idea_db_tool import upsert_sheet
 from src.a19_world_logic.world import worldunit_shop
 from src.a19_world_logic._utils.env_a19 import (
@@ -19,7 +19,7 @@ from os.path import exists as os_path_exists
 from sqlite3 import connect as sqlite3_connect
 
 
-def test_WorldUnit_mud_df_to_yell_raw_db_CreatesYellFiles(
+def test_WorldUnit_mud_df_to_brick_raw_db_CreatesBrickFiles(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -34,7 +34,7 @@ def test_WorldUnit_mud_df_to_yell_raw_db_CreatesYellFiles(
     hour7am = "7am"
     ex_filename = "fizzbuzz.xlsx"
     mud_file_path = create_path(fizz_world._mud_dir, ex_filename)
-    yell_file_path = create_path(fizz_world._yell_dir, "br00003.xlsx")
+    brick_file_path = create_path(fizz_world._brick_dir, "br00003.xlsx")
     idea_columns = [
         face_name_str(),
         event_int_str(),
@@ -64,15 +64,15 @@ def test_WorldUnit_mud_df_to_yell_raw_db_CreatesYellFiles(
     upsert_sheet(mud_file_path, br00003_ex1_str, df1)
     upsert_sheet(mud_file_path, br00003_ex2_str, df2)
     upsert_sheet(mud_file_path, br00003_ex3_str, df3)
-    assert os_path_exists(yell_file_path) is False
+    assert os_path_exists(brick_file_path) is False
 
     with sqlite3_connect(":memory:") as db_conn:
         cursor = db_conn.cursor()
-        br00003_tablename = f"{yell_raw_str()}_br00003"
+        br00003_tablename = f"{brick_raw_str()}_br00003"
         assert not db_table_exists(cursor, br00003_tablename)
 
         # WHEN
-        fizz_world.mud_df_to_yell_raw_db(db_conn)
+        fizz_world.mud_df_to_brick_raw_db(db_conn)
 
         # THEN
         assert db_table_exists(cursor, br00003_tablename)

--- a/src/a19_world_logic/test_00_mud_to_brick/test_world_etl01_brick_raw_brick_agg.py
+++ b/src/a19_world_logic/test_00_mud_to_brick/test_world_etl01_brick_raw_brick_agg.py
@@ -2,7 +2,7 @@ from src.a00_data_toolbox.file_toolbox import create_path
 from src.a02_finance_logic._utils.strs_a02 import fisc_tag_str
 from src.a06_bud_logic._utils.str_a06 import face_name_str, event_int_str
 from src.a15_fisc_logic._utils.str_a15 import cumlative_minute_str, hour_tag_str
-from src.a17_idea_logic._utils.str_a17 import yell_agg_str, yell_raw_str
+from src.a17_idea_logic._utils.str_a17 import brick_agg_str, brick_raw_str
 from src.a17_idea_logic.idea_db_tool import get_sheet_names, upsert_sheet, sheet_exists
 from src.a19_world_logic.world import worldunit_shop
 from src.a19_world_logic._utils.env_a19 import (
@@ -13,7 +13,7 @@ from pandas import DataFrame, read_excel as pandas_read_excel
 from sqlite3 import connect as sqlite3_connect
 
 
-def test_WorldUnit_yell_raw_db_to_yell_agg_df_CreatesOtxSheets_Scenario0_GroupByWorks(
+def test_WorldUnit_brick_raw_db_to_brick_agg_df_CreatesOtxSheets_Scenario0_GroupByWorks(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -27,7 +27,7 @@ def test_WorldUnit_yell_raw_db_to_yell_agg_df_CreatesOtxSheets_Scenario0_GroupBy
     hour7am = "7am"
     ex_filename = "fizzbuzz.xlsx"
     mud_file_path = create_path(fizz_world._mud_dir, ex_filename)
-    yell_file_path = create_path(fizz_world._yell_dir, "br00003.xlsx")
+    brick_file_path = create_path(fizz_world._brick_dir, "br00003.xlsx")
     idea_columns = [
         face_name_str(),
         event_int_str(),
@@ -43,13 +43,13 @@ def test_WorldUnit_yell_raw_db_to_yell_agg_df_CreatesOtxSheets_Scenario0_GroupBy
     upsert_sheet(mud_file_path, "example1_br00003", df1)
     with sqlite3_connect(":memory:") as db_conn:
         cursor = db_conn.cursor()
-        fizz_world.mud_df_to_yell_raw_db(db_conn)
+        fizz_world.mud_df_to_brick_raw_db(db_conn)
 
         # WHEN
-        fizz_world.yell_raw_db_to_yell_agg_df(db_conn, cursor)
+        fizz_world.brick_raw_db_to_brick_agg_df(db_conn, cursor)
 
     # THEN
-    gen_otx_df = pandas_read_excel(yell_file_path, sheet_name=yell_agg_str())
+    gen_otx_df = pandas_read_excel(brick_file_path, sheet_name=brick_agg_str())
     ex_otx_df = DataFrame([row1, row2], columns=idea_columns)
     print(f"{gen_otx_df.columns=}")
     assert len(ex_otx_df.columns) == len(gen_otx_df.columns)
@@ -58,10 +58,10 @@ def test_WorldUnit_yell_raw_db_to_yell_agg_df_CreatesOtxSheets_Scenario0_GroupBy
     assert len(ex_otx_df) == len(gen_otx_df)
     assert len(gen_otx_df) == 2
     assert ex_otx_df.to_csv() == gen_otx_df.to_csv()
-    assert get_sheet_names(yell_file_path) == [yell_agg_str()]
+    assert get_sheet_names(brick_file_path) == [brick_agg_str()]
 
 
-def test_WorldUnit_yell_raw_db_to_yell_agg_df_CreatesOtxSheets_Scenario1_GroupByOnlyNonConflictingRecords(
+def test_WorldUnit_brick_raw_db_to_brick_agg_df_CreatesOtxSheets_Scenario1_GroupByOnlyNonConflictingRecords(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -92,17 +92,17 @@ def test_WorldUnit_yell_raw_db_to_yell_agg_df_CreatesOtxSheets_Scenario1_GroupBy
     upsert_sheet(mud_file_path, "example1_br00003", df1)
     with sqlite3_connect(":memory:") as db_conn:
         cursor = db_conn.cursor()
-        fizz_world.mud_df_to_yell_raw_db(db_conn)
-        br00003_agg_file_path = create_path(fizz_world._yell_dir, "br00003.xlsx")
-        assert sheet_exists(br00003_agg_file_path, yell_agg_str()) is False
+        fizz_world.mud_df_to_brick_raw_db(db_conn)
+        br00003_agg_file_path = create_path(fizz_world._brick_dir, "br00003.xlsx")
+        assert sheet_exists(br00003_agg_file_path, brick_agg_str()) is False
 
         # WHEN
-        fizz_world.yell_raw_db_to_yell_agg_df(db_conn, cursor)
+        fizz_world.brick_raw_db_to_brick_agg_df(db_conn, cursor)
 
     # THEN
-    assert sheet_exists(br00003_agg_file_path, yell_agg_str())
+    assert sheet_exists(br00003_agg_file_path, brick_agg_str())
     gen_br00003_agg_df = pandas_read_excel(
-        br00003_agg_file_path, sheet_name=yell_agg_str()
+        br00003_agg_file_path, sheet_name=brick_agg_str()
     )
     ex_otx_df = DataFrame([row1, row4], columns=idea_columns)
     # print(f"{gen_otx_df.columns=}")
@@ -114,4 +114,4 @@ def test_WorldUnit_yell_raw_db_to_yell_agg_df_CreatesOtxSheets_Scenario1_GroupBy
     assert len(gen_br00003_agg_df) == len(ex_otx_df)
     assert len(gen_br00003_agg_df) == 2
     assert gen_br00003_agg_df.to_csv() == ex_otx_df.to_csv()
-    assert get_sheet_names(br00003_agg_file_path) == [yell_agg_str()]
+    assert get_sheet_names(br00003_agg_file_path) == [brick_agg_str()]

--- a/src/a19_world_logic/test_00_mud_to_yell/test_world_etl00_mud_to_yell_raw.py
+++ b/src/a19_world_logic/test_00_mud_to_yell/test_world_etl00_mud_to_yell_raw.py
@@ -19,7 +19,7 @@ from os.path import exists as os_path_exists
 from sqlite3 import connect as sqlite3_connect
 
 
-def test_WorldUnit_sound_df_to_yell_raw_db_CreatesYellFiles(
+def test_WorldUnit_mud_df_to_yell_raw_db_CreatesYellFiles(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -33,7 +33,7 @@ def test_WorldUnit_sound_df_to_yell_raw_db_CreatesYellFiles(
     hour6am = "6am"
     hour7am = "7am"
     ex_filename = "fizzbuzz.xlsx"
-    sound_file_path = create_path(fizz_world._sound_dir, ex_filename)
+    mud_file_path = create_path(fizz_world._mud_dir, ex_filename)
     yell_file_path = create_path(fizz_world._yell_dir, "br00003.xlsx")
     idea_columns = [
         face_name_str(),
@@ -61,9 +61,9 @@ def test_WorldUnit_sound_df_to_yell_raw_db_CreatesYellFiles(
     br00003_ex1_str = "example1_br00003"
     br00003_ex2_str = "example2_br00003"
     br00003_ex3_str = "example3_br00003"
-    upsert_sheet(sound_file_path, br00003_ex1_str, df1)
-    upsert_sheet(sound_file_path, br00003_ex2_str, df2)
-    upsert_sheet(sound_file_path, br00003_ex3_str, df3)
+    upsert_sheet(mud_file_path, br00003_ex1_str, df1)
+    upsert_sheet(mud_file_path, br00003_ex2_str, df2)
+    upsert_sheet(mud_file_path, br00003_ex3_str, df3)
     assert os_path_exists(yell_file_path) is False
 
     with sqlite3_connect(":memory:") as db_conn:
@@ -72,7 +72,7 @@ def test_WorldUnit_sound_df_to_yell_raw_db_CreatesYellFiles(
         assert not db_table_exists(cursor, br00003_tablename)
 
         # WHEN
-        fizz_world.sound_df_to_yell_raw_db(db_conn)
+        fizz_world.mud_df_to_yell_raw_db(db_conn)
 
         # THEN
         assert db_table_exists(cursor, br00003_tablename)
@@ -95,7 +95,7 @@ ORDER BY sheet_name, {event_int_str()}, {cumlative_minute_str()};"""
         file = ex_filename
         e1 = event_1
         e2 = event_2
-        s_dir = create_path(fizz_world._sound_dir, ".")
+        s_dir = create_path(fizz_world._mud_dir, ".")
         m_360 = minute_360
         m_420 = minute_420
         br3_ex1 = br00003_ex1_str

--- a/src/a19_world_logic/test_00_mud_to_yell/test_world_etl01_yell_raw_yell_agg.py
+++ b/src/a19_world_logic/test_00_mud_to_yell/test_world_etl01_yell_raw_yell_agg.py
@@ -26,7 +26,7 @@ def test_WorldUnit_yell_raw_db_to_yell_agg_df_CreatesOtxSheets_Scenario0_GroupBy
     hour6am = "6am"
     hour7am = "7am"
     ex_filename = "fizzbuzz.xlsx"
-    sound_file_path = create_path(fizz_world._sound_dir, ex_filename)
+    mud_file_path = create_path(fizz_world._mud_dir, ex_filename)
     yell_file_path = create_path(fizz_world._yell_dir, "br00003.xlsx")
     idea_columns = [
         face_name_str(),
@@ -40,10 +40,10 @@ def test_WorldUnit_yell_raw_db_to_yell_agg_df_CreatesOtxSheets_Scenario0_GroupBy
     row2 = [sue_str, event_1, accord23_str, minute_420, hour7am]
     row3 = [sue_str, event_1, accord23_str, minute_420, hour7am]
     df1 = DataFrame([row1, row2, row3], columns=idea_columns)
-    upsert_sheet(sound_file_path, "example1_br00003", df1)
+    upsert_sheet(mud_file_path, "example1_br00003", df1)
     with sqlite3_connect(":memory:") as db_conn:
         cursor = db_conn.cursor()
-        fizz_world.sound_df_to_yell_raw_db(db_conn)
+        fizz_world.mud_df_to_yell_raw_db(db_conn)
 
         # WHEN
         fizz_world.yell_raw_db_to_yell_agg_df(db_conn, cursor)
@@ -75,7 +75,7 @@ def test_WorldUnit_yell_raw_db_to_yell_agg_df_CreatesOtxSheets_Scenario1_GroupBy
     hour7am = "7am"
     hour8am = "8am"
     ex_filename = "fizzbuzz.xlsx"
-    sound_file_path = create_path(fizz_world._sound_dir, ex_filename)
+    mud_file_path = create_path(fizz_world._mud_dir, ex_filename)
     idea_columns = [
         face_name_str(),
         event_int_str(),
@@ -89,10 +89,10 @@ def test_WorldUnit_yell_raw_db_to_yell_agg_df_CreatesOtxSheets_Scenario1_GroupBy
     row3 = [sue_str, event3, accord23_str, minute_420, hour8am]
     row4 = [sue_str, event7, accord23_str, minute_420, hour8am]
     df1 = DataFrame([row1, row2, row3, row4], columns=idea_columns)
-    upsert_sheet(sound_file_path, "example1_br00003", df1)
+    upsert_sheet(mud_file_path, "example1_br00003", df1)
     with sqlite3_connect(":memory:") as db_conn:
         cursor = db_conn.cursor()
-        fizz_world.sound_df_to_yell_raw_db(db_conn)
+        fizz_world.mud_df_to_yell_raw_db(db_conn)
         br00003_agg_file_path = create_path(fizz_world._yell_dir, "br00003.xlsx")
         assert sheet_exists(br00003_agg_file_path, yell_agg_str()) is False
 

--- a/src/a19_world_logic/test_03_pidgin/test_world_etl03_00_brick_agg_to_pidgin_raw.py
+++ b/src/a19_world_logic/test_03_pidgin/test_world_etl03_00_brick_agg_to_pidgin_raw.py
@@ -14,13 +14,13 @@ from src.a16_pidgin_logic._utils.str_a16 import (
     otx_label_str,
     unknown_word_str,
 )
-from src.a17_idea_logic._utils.str_a17 import yell_agg_str
+from src.a17_idea_logic._utils.str_a17 import brick_agg_str
 from src.a17_idea_logic.idea_db_tool import (
     upsert_sheet,
     sheet_exists,
     _get_pidgen_idea_format_filenames,
 )
-from src.a18_etl_toolbox.tran_path import create_yell_pidgin_path
+from src.a18_etl_toolbox.tran_path import create_brick_pidgin_path
 from src.a18_etl_toolbox.pidgin_agg import PidginPrimeColumns
 from src.a19_world_logic.world import worldunit_shop
 from src.a19_world_logic._utils.env_a19 import (
@@ -49,7 +49,9 @@ def test_get_pidgen_idea_format_filenames_ReturnsObj():
     }
 
 
-def test_WorldUnit_yell_agg_df_to_yell_pidgin_raw_df_CreatesFile(env_dir_setup_cleanup):
+def test_WorldUnit_brick_agg_df_to_brick_pidgin_raw_df_CreatesFile(
+    env_dir_setup_cleanup,
+):
     # ESTABLISH
     fizz_world = worldunit_shop("fizz", worlds_dir())
     bob_str = "Bob"
@@ -63,7 +65,7 @@ def test_WorldUnit_yell_agg_df_to_yell_pidgin_raw_df_CreatesFile(env_dir_setup_c
     event1 = 1
     event2 = 2
     event5 = 5
-    br00113_file_path = create_path(fizz_world._yell_dir, "br00113.xlsx")
+    br00113_file_path = create_path(fizz_world._brick_dir, "br00113.xlsx")
     br00113_columns = [
         face_name_str(),
         event_int_str(),
@@ -73,7 +75,7 @@ def test_WorldUnit_yell_agg_df_to_yell_pidgin_raw_df_CreatesFile(env_dir_setup_c
         otx_name_str(),
         inx_name_str(),
     ]
-    br00043_file_path = create_path(fizz_world._yell_dir, "br00043.xlsx")
+    br00043_file_path = create_path(fizz_world._brick_dir, "br00043.xlsx")
     br00043_columns = [
         face_name_str(),
         event_int_str(),
@@ -90,13 +92,13 @@ def test_WorldUnit_yell_agg_df_to_yell_pidgin_raw_df_CreatesFile(env_dir_setup_c
     yao1 = [yao_str, event1, yao_str, yao_inx, rdx, rdx, ukx]
     br00113_rows = [sue0, sue1]
     br00113_df = DataFrame(br00113_rows, columns=br00113_columns)
-    upsert_sheet(br00113_file_path, yell_agg_str(), br00113_df)
+    upsert_sheet(br00113_file_path, brick_agg_str(), br00113_df)
     br00043_df = [sue2, sue3, yao1]
     br00043_df = DataFrame(br00043_df, columns=br00043_columns)
-    upsert_sheet(br00043_file_path, yell_agg_str(), br00043_df)
-    pidgin_path = create_yell_pidgin_path(fizz_world._yell_dir)
+    upsert_sheet(br00043_file_path, brick_agg_str(), br00043_df)
+    pidgin_path = create_brick_pidgin_path(fizz_world._brick_dir)
 
-    br00115_file_path = create_path(fizz_world._yell_dir, "br00115.xlsx")
+    br00115_file_path = create_path(fizz_world._brick_dir, "br00115.xlsx")
     br00115_columns = [
         face_name_str(),
         event_int_str(),
@@ -106,7 +108,7 @@ def test_WorldUnit_yell_agg_df_to_yell_pidgin_raw_df_CreatesFile(env_dir_setup_c
         otx_label_str(),
         inx_label_str(),
     ]
-    br00042_file_path = create_path(fizz_world._yell_dir, "br00042.xlsx")
+    br00042_file_path = create_path(fizz_world._brick_dir, "br00042.xlsx")
     br00042_columns = [
         face_name_str(),
         event_int_str(),
@@ -123,12 +125,12 @@ def test_WorldUnit_yell_agg_df_to_yell_pidgin_raw_df_CreatesFile(env_dir_setup_c
     yao1 = [yao_str, event1, yao_str, yao_inx, rdx, rdx, ukx]
     br00115_rows = [sue0, sue1]
     br00115_df = DataFrame(br00115_rows, columns=br00115_columns)
-    upsert_sheet(br00115_file_path, yell_agg_str(), br00115_df)
+    upsert_sheet(br00115_file_path, brick_agg_str(), br00115_df)
     b40_rows = [sue2, sue3, yao1]
     br00042_df = DataFrame(b40_rows, columns=br00042_columns)
-    upsert_sheet(br00042_file_path, yell_agg_str(), br00042_df)
+    upsert_sheet(br00042_file_path, brick_agg_str(), br00042_df)
 
-    br00116_file_path = create_path(fizz_world._yell_dir, "br00116.xlsx")
+    br00116_file_path = create_path(fizz_world._brick_dir, "br00116.xlsx")
     br00116_columns = [
         face_name_str(),
         event_int_str(),
@@ -138,7 +140,7 @@ def test_WorldUnit_yell_agg_df_to_yell_pidgin_raw_df_CreatesFile(env_dir_setup_c
         otx_tag_str(),
         inx_tag_str(),
     ]
-    br00044_file_path = create_path(fizz_world._yell_dir, "br00044.xlsx")
+    br00044_file_path = create_path(fizz_world._brick_dir, "br00044.xlsx")
     br00044_columns = [
         face_name_str(),
         event_int_str(),
@@ -155,12 +157,12 @@ def test_WorldUnit_yell_agg_df_to_yell_pidgin_raw_df_CreatesFile(env_dir_setup_c
     yao1 = [yao_str, event1, yao_str, yao_inx, rdx, rdx, ukx]
     br00116_rows = [sue0, sue1]
     br00116_df = DataFrame(br00116_rows, columns=br00116_columns)
-    upsert_sheet(br00116_file_path, yell_agg_str(), br00116_df)
+    upsert_sheet(br00116_file_path, brick_agg_str(), br00116_df)
     br00044_rows = [sue2, sue3, yao1]
     br00044_df = DataFrame(br00044_rows, columns=br00044_columns)
-    upsert_sheet(br00044_file_path, yell_agg_str(), br00044_df)
+    upsert_sheet(br00044_file_path, brick_agg_str(), br00044_df)
 
-    br00117_file_path = create_path(fizz_world._yell_dir, "br00117.xlsx")
+    br00117_file_path = create_path(fizz_world._brick_dir, "br00117.xlsx")
     br00117_columns = [
         face_name_str(),
         event_int_str(),
@@ -170,7 +172,7 @@ def test_WorldUnit_yell_agg_df_to_yell_pidgin_raw_df_CreatesFile(env_dir_setup_c
         otx_road_str(),
         inx_road_str(),
     ]
-    br00045_file_path = create_path(fizz_world._yell_dir, "br00045.xlsx")
+    br00045_file_path = create_path(fizz_world._brick_dir, "br00045.xlsx")
     br00045_columns = [
         face_name_str(),
         event_int_str(),
@@ -187,16 +189,16 @@ def test_WorldUnit_yell_agg_df_to_yell_pidgin_raw_df_CreatesFile(env_dir_setup_c
     yao1 = [yao_str, event1, yao_str, yao_inx, rdx, rdx, ukx]
     b117_rows = [sue0, sue1]
     br00117_df = DataFrame(b117_rows, columns=br00117_columns)
-    upsert_sheet(br00117_file_path, yell_agg_str(), br00117_df)
+    upsert_sheet(br00117_file_path, brick_agg_str(), br00117_df)
     br00045_rows = [sue2, sue3, yao1]
     br00045_df = DataFrame(br00045_rows, columns=br00045_columns)
-    upsert_sheet(br00045_file_path, yell_agg_str(), br00045_df)
+    upsert_sheet(br00045_file_path, brick_agg_str(), br00045_df)
 
     fizz_world._events = {event2: sue_str, event5: sue_str}
     assert os_path_exists(pidgin_path) is False
 
     # WHEN
-    fizz_world.yell_agg_df_to_yell_pidgin_raw_df()
+    fizz_world.brick_agg_df_to_brick_pidgin_raw_df()
 
     # THEN
     assert os_path_exists(pidgin_path)

--- a/src/a19_world_logic/test_03_pidgin/test_world_etl03_01_brick_pidgin_raw_to_pidgin_agg.py
+++ b/src/a19_world_logic/test_03_pidgin/test_world_etl03_01_brick_pidgin_raw_to_pidgin_agg.py
@@ -1,5 +1,5 @@
 from src.a17_idea_logic.idea_db_tool import upsert_sheet, sheet_exists
-from src.a18_etl_toolbox.tran_path import create_yell_pidgin_path
+from src.a18_etl_toolbox.tran_path import create_brick_pidgin_path
 from src.a18_etl_toolbox.pidgin_agg import PidginPrimeColumns
 from src.a19_world_logic.world import worldunit_shop
 from src.a19_world_logic._utils.env_a19 import (
@@ -73,7 +73,7 @@ def test_WorldUnit_pidgin_raw_to_name_agg_Scenario0_CreatesFileWithAllDimens(
     e1_tag_rows = [e1_tag0, e1_tag1]
     raw_tag_df = DataFrame(e1_tag_rows, columns=tag_raw_columns)
 
-    pidgin_path = create_yell_pidgin_path(fizz_world._yell_dir)
+    pidgin_path = create_brick_pidgin_path(fizz_world._brick_dir)
     upsert_sheet(pidgin_path, name_raw_str, raw_name_df)
     upsert_sheet(pidgin_path, label_raw_str, raw_label_df)
     upsert_sheet(pidgin_path, road_raw_str, raw_road_df)
@@ -89,7 +89,7 @@ def test_WorldUnit_pidgin_raw_to_name_agg_Scenario0_CreatesFileWithAllDimens(
     assert sheet_exists(pidgin_path, tag_agg_str) is False
 
     # WHEN
-    fizz_world.yell_pidgin_raw_df_to_pidgin_agg_df()
+    fizz_world.brick_pidgin_raw_df_to_pidgin_agg_df()
 
     # THEN
     assert os_path_exists(pidgin_path)

--- a/src/a19_world_logic/test_03_pidgin/test_world_etl03_02_brick_pidgin_agg_to_otz_face_pidgins.py
+++ b/src/a19_world_logic/test_03_pidgin/test_world_etl03_02_brick_pidgin_agg_to_otz_face_pidgins.py
@@ -15,7 +15,7 @@ from src.a16_pidgin_logic._utils.str_a16 import (
 )
 from src.a17_idea_logic.idea_db_tool import sheet_exists, upsert_sheet
 from src.a18_etl_toolbox.tran_path import (
-    create_yell_pidgin_path,
+    create_brick_pidgin_path,
     create_syntax_otx_pidgin_path,
 )
 from src.a18_etl_toolbox.pidgin_agg import PidginPrimeColumns
@@ -29,7 +29,7 @@ from pandas.testing import assert_frame_equal as pandas_testing_assert_frame_equ
 from os.path import exists as os_path_exists
 
 
-def test_WorldUnit_yell_pidgin_agg_df_to_otz_face_pidgin_agg_df_Scenario1_AllMapDimens(
+def test_WorldUnit_brick_pidgin_agg_df_to_otz_face_pidgin_agg_df_Scenario1_AllMapDimens(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -101,7 +101,7 @@ def test_WorldUnit_yell_pidgin_agg_df_to_otz_face_pidgin_agg_df_Scenario1_AllMap
     e1_tag_rows = [e1_tag0, e1_tag1]
     e1_tag_agg_df = DataFrame(e1_tag_rows, columns=tag_file_columns)
 
-    agg_pidgin_path = create_yell_pidgin_path(fizz_world._yell_dir)
+    agg_pidgin_path = create_brick_pidgin_path(fizz_world._brick_dir)
     upsert_sheet(agg_pidgin_path, name_agg_str, e1_name_agg_df)
     upsert_sheet(agg_pidgin_path, label_agg_str, e1_label_agg_df)
     upsert_sheet(agg_pidgin_path, road_agg_str, e1_road_agg_df)
@@ -112,7 +112,7 @@ def test_WorldUnit_yell_pidgin_agg_df_to_otz_face_pidgin_agg_df_Scenario1_AllMap
     assert os_path_exists(sue_pidgin_file_path) is False
 
     # WHEN
-    fizz_world.yell_pidgin_agg_df_to_otz_face_pidgin_agg_df()
+    fizz_world.brick_pidgin_agg_df_to_otz_face_pidgin_agg_df()
 
     # THEN
     assert os_path_exists(sue_dir)

--- a/src/a19_world_logic/test_04_ideas_pidgined/test_world_etl04_00_brick_agg_to_brick_valid.py
+++ b/src/a19_world_logic/test_04_ideas_pidgined/test_world_etl04_00_brick_agg_to_brick_valid.py
@@ -2,7 +2,7 @@ from src.a00_data_toolbox.file_toolbox import create_path
 from src.a02_finance_logic._utils.strs_a02 import fisc_tag_str
 from src.a06_bud_logic._utils.str_a06 import face_name_str, event_int_str
 from src.a15_fisc_logic._utils.str_a15 import cumlative_minute_str, hour_tag_str
-from src.a17_idea_logic._utils.str_a17 import yell_valid_str, yell_agg_str
+from src.a17_idea_logic._utils.str_a17 import brick_valid_str, brick_agg_str
 from src.a17_idea_logic.idea_db_tool import sheet_exists, upsert_sheet
 from src.a19_world_logic.world import worldunit_shop
 from src.a19_world_logic._utils.env_a19 import (
@@ -15,7 +15,7 @@ from pandas.testing import (
 from pandas import DataFrame, read_excel as pandas_read_excel
 
 
-def test_WorldUnit_yell_agg_non_pidgin_ideas_to_yell_valid_CreatesSheets_Scenario0(
+def test_WorldUnit_brick_agg_non_pidgin_ideas_to_brick_valid_CreatesSheets_Scenario0(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -45,28 +45,30 @@ def test_WorldUnit_yell_agg_non_pidgin_ideas_to_yell_valid_CreatesSheets_Scenari
     fizz_world.set_event(event9, yao_str)
     legitimate_events = {event1, event9}
     assert set(fizz_world._events.keys()) == legitimate_events
-    yell_file_path = create_path(fizz_world._yell_dir, "br00003.xlsx")
-    yell_agg_df = DataFrame([row1, row2, row3, row4], columns=br00003_columns)
-    upsert_sheet(yell_file_path, yell_agg_str(), yell_agg_df)
-    assert sheet_exists(yell_file_path, yell_valid_str()) is False
+    brick_file_path = create_path(fizz_world._brick_dir, "br00003.xlsx")
+    brick_agg_df = DataFrame([row1, row2, row3, row4], columns=br00003_columns)
+    upsert_sheet(brick_file_path, brick_agg_str(), brick_agg_df)
+    assert sheet_exists(brick_file_path, brick_valid_str()) is False
 
     # WHEN
-    fizz_world.yell_agg_non_pidgin_ideas_to_yell_valid()
+    fizz_world.brick_agg_non_pidgin_ideas_to_brick_valid()
 
     # THEN
-    assert sheet_exists(yell_file_path, yell_valid_str())
-    gen_yell_valid_df = pandas_read_excel(yell_file_path, sheet_name=yell_valid_str())
-    print(f"{gen_yell_valid_df.columns=}")
-    example_yell_valid_df = DataFrame([row1, row2, row4], columns=br00003_columns)
-    assert len(gen_yell_valid_df.columns) == len(example_yell_valid_df.columns)
-    assert list(gen_yell_valid_df.columns) == list(example_yell_valid_df.columns)
-    assert len(gen_yell_valid_df) > 0
-    assert len(gen_yell_valid_df) == 3
-    assert len(gen_yell_valid_df) == len(example_yell_valid_df)
-    pandas_assert_frame_equal(gen_yell_valid_df, example_yell_valid_df)
+    assert sheet_exists(brick_file_path, brick_valid_str())
+    gen_brick_valid_df = pandas_read_excel(
+        brick_file_path, sheet_name=brick_valid_str()
+    )
+    print(f"{gen_brick_valid_df.columns=}")
+    example_brick_valid_df = DataFrame([row1, row2, row4], columns=br00003_columns)
+    assert len(gen_brick_valid_df.columns) == len(example_brick_valid_df.columns)
+    assert list(gen_brick_valid_df.columns) == list(example_brick_valid_df.columns)
+    assert len(gen_brick_valid_df) > 0
+    assert len(gen_brick_valid_df) == 3
+    assert len(gen_brick_valid_df) == len(example_brick_valid_df)
+    pandas_assert_frame_equal(gen_brick_valid_df, example_brick_valid_df)
 
 
-# def test_WorldUnit_yell_agg_non_pidgin_ideas_to_yell_valid_CreatesSheets_Scenario1(
+# def test_WorldUnit_brick_agg_non_pidgin_ideas_to_brick_valid_CreatesSheets_Scenario1(
 #     env_dir_setup_cleanup,
 # ):
 #     # ESTABLISH
@@ -83,9 +85,9 @@ def test_WorldUnit_yell_agg_non_pidgin_ideas_to_yell_valid_CreatesSheets_Scenari
 #     hour7am = "7am"
 #     ex_filename = "fizzbuzz.xlsx"
 #     mud_dir = create_path(get_module_temp_dir(), "mud")
-#     yell_dir = create_path(get_module_temp_dir(), "yell")
+#     brick_dir = create_path(get_module_temp_dir(), "brick")
 #     mud_file_path = create_path(mud_dir, ex_filename)
-#     yell_file_path = create_path(yell_dir, "br00003.xlsx")
+#     brick_file_path = create_path(brick_dir, "br00003.xlsx")
 #     idea_columns = [
 #         face_name_str(),
 #         event_int_str(),
@@ -101,13 +103,13 @@ def test_WorldUnit_yell_agg_non_pidgin_ideas_to_yell_valid_CreatesSheets_Scenari
 #     row5 = [bob_str, event3, accord23_str, hour7am, minute_420]
 #     df1 = DataFrame([row1, row2, row3, row4, row5], columns=idea_columns)
 #     upsert_sheet(mud_file_path, "example1_br00003", df1)
-#     etl_yell_raw_db_to_yell_agg_df(yell_dir)
+#     etl_brick_raw_db_to_brick_agg_df(brick_dir)
 
 #     # WHEN
-#     etl_yell_agg_non_pidgin_ideas_to_yell_valid(yell_dir)
+#     etl_brick_agg_non_pidgin_ideas_to_brick_valid(brick_dir)
 
 #     # THEN
-#     gen_otx_events_df = pandas_read_excel(yell_file_path, sheet_name="yell_valid")
+#     gen_otx_events_df = pandas_read_excel(brick_file_path, sheet_name="brick_valid")
 #     print(f"{gen_otx_events_df.columns=}")
 #     events_otx_columns = [face_name_str(), event_int_str(), "error_message"]
 #     bob_row = [bob_str, event3, ""]

--- a/src/a19_world_logic/test_04_ideas_pidgined/test_world_etl04_00_yell_agg_to_yell_valid.py
+++ b/src/a19_world_logic/test_04_ideas_pidgined/test_world_etl04_00_yell_agg_to_yell_valid.py
@@ -82,9 +82,9 @@ def test_WorldUnit_yell_agg_non_pidgin_ideas_to_yell_valid_CreatesSheets_Scenari
 #     hour6am = "6am"
 #     hour7am = "7am"
 #     ex_filename = "fizzbuzz.xlsx"
-#     sound_dir = create_path(get_module_temp_dir(), "sound")
+#     mud_dir = create_path(get_module_temp_dir(), "mud")
 #     yell_dir = create_path(get_module_temp_dir(), "yell")
-#     sound_file_path = create_path(sound_dir, ex_filename)
+#     mud_file_path = create_path(mud_dir, ex_filename)
 #     yell_file_path = create_path(yell_dir, "br00003.xlsx")
 #     idea_columns = [
 #         face_name_str(),
@@ -100,7 +100,7 @@ def test_WorldUnit_yell_agg_non_pidgin_ideas_to_yell_valid_CreatesSheets_Scenari
 #     row4 = [yao_str, event9, accord23_str, hour7am, minute_420]
 #     row5 = [bob_str, event3, accord23_str, hour7am, minute_420]
 #     df1 = DataFrame([row1, row2, row3, row4, row5], columns=idea_columns)
-#     upsert_sheet(sound_file_path, "example1_br00003", df1)
+#     upsert_sheet(mud_file_path, "example1_br00003", df1)
 #     etl_yell_raw_db_to_yell_agg_df(yell_dir)
 
 #     # WHEN

--- a/src/a19_world_logic/test_04_ideas_pidgined/test_world_etl04_01_brick_ideas_to_otz_face_ideas.py
+++ b/src/a19_world_logic/test_04_ideas_pidgined/test_world_etl04_01_brick_ideas_to_otz_face_ideas.py
@@ -2,7 +2,7 @@ from src.a00_data_toolbox.file_toolbox import create_path
 from src.a02_finance_logic._utils.strs_a02 import fisc_tag_str
 from src.a06_bud_logic._utils.str_a06 import face_name_str, event_int_str
 from src.a15_fisc_logic._utils.str_a15 import cumlative_minute_str, hour_tag_str
-from src.a17_idea_logic._utils.str_a17 import yell_valid_str
+from src.a17_idea_logic._utils.str_a17 import brick_valid_str
 from src.a17_idea_logic.idea_db_tool import get_sheet_names, upsert_sheet, sheet_exists
 from src.a19_world_logic.world import worldunit_shop
 from src.a19_world_logic._utils.env_a19 import (
@@ -13,7 +13,7 @@ from pandas import DataFrame, read_excel as pandas_read_excel
 from sqlite3 import connect as sqlite3_connect
 
 
-def test_WorldUnit_yell_ideas_to_otz_face_ideas_CreatesOtxSheets_Scenario0_GroupByWorks(
+def test_WorldUnit_brick_ideas_to_otz_face_ideas_CreatesOtxSheets_Scenario0_GroupByWorks(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -35,28 +35,28 @@ def test_WorldUnit_yell_ideas_to_otz_face_ideas_CreatesOtxSheets_Scenario0_Group
     accord23_str = "accord23"
     row1 = [sue_str, event3, accord23_str, hour6am, minute_360]
     row2 = [sue_str, event3, accord23_str, hour7am, minute_420]
-    br00003_yell_agg_df = DataFrame([row1, row2], columns=idea_columns)
-    br00003_agg_file_path = create_path(fizz_world._yell_dir, "br00003.xlsx")
-    upsert_sheet(br00003_agg_file_path, yell_valid_str(), br00003_yell_agg_df)
-    assert sheet_exists(br00003_agg_file_path, yell_valid_str())
+    br00003_brick_agg_df = DataFrame([row1, row2], columns=idea_columns)
+    br00003_agg_file_path = create_path(fizz_world._brick_dir, "br00003.xlsx")
+    upsert_sheet(br00003_agg_file_path, brick_valid_str(), br00003_brick_agg_df)
+    assert sheet_exists(br00003_agg_file_path, brick_valid_str())
     sue_dir = create_path(fizz_world._syntax_otz_dir, sue_str)
     sue_br00003_filepath = create_path(sue_dir, "br00003.xlsx")
-    assert sheet_exists(sue_br00003_filepath, yell_valid_str()) is False
+    assert sheet_exists(sue_br00003_filepath, brick_valid_str()) is False
 
     # WHEN
-    fizz_world.yell_ideas_to_otz_face_ideas()
+    fizz_world.brick_ideas_to_otz_face_ideas()
 
     # THEN
-    assert sheet_exists(sue_br00003_filepath, yell_valid_str())
-    assert get_sheet_names(sue_br00003_filepath) == [yell_valid_str()]
+    assert sheet_exists(sue_br00003_filepath, brick_valid_str())
+    assert get_sheet_names(sue_br00003_filepath) == [brick_valid_str()]
     sue_br3_agg_df = pandas_read_excel(
-        br00003_agg_file_path, sheet_name=yell_valid_str()
+        br00003_agg_file_path, sheet_name=brick_valid_str()
     )
     print(f"{sue_br3_agg_df.columns=}")
 
-    assert len(sue_br3_agg_df.columns) == len(br00003_yell_agg_df.columns)
-    assert list(sue_br3_agg_df.columns) == list(br00003_yell_agg_df.columns)
+    assert len(sue_br3_agg_df.columns) == len(br00003_brick_agg_df.columns)
+    assert list(sue_br3_agg_df.columns) == list(br00003_brick_agg_df.columns)
     assert len(sue_br3_agg_df) > 0
-    assert len(sue_br3_agg_df) == len(br00003_yell_agg_df)
+    assert len(sue_br3_agg_df) == len(br00003_brick_agg_df)
     assert len(sue_br3_agg_df) == 2
-    assert sue_br3_agg_df.to_csv() == br00003_yell_agg_df.to_csv()
+    assert sue_br3_agg_df.to_csv() == br00003_brick_agg_df.to_csv()

--- a/src/a19_world_logic/test_04_ideas_pidgined/test_world_etl04_02_otz_face_ideas_to_otz_event_ideas.py
+++ b/src/a19_world_logic/test_04_ideas_pidgined/test_world_etl04_02_otz_face_ideas_to_otz_event_ideas.py
@@ -2,7 +2,7 @@ from src.a00_data_toolbox.file_toolbox import create_path
 from src.a02_finance_logic._utils.strs_a02 import fisc_tag_str
 from src.a06_bud_logic._utils.str_a06 import face_name_str, event_int_str
 from src.a15_fisc_logic._utils.str_a15 import cumlative_minute_str, hour_tag_str
-from src.a17_idea_logic._utils.str_a17 import yell_valid_str
+from src.a17_idea_logic._utils.str_a17 import brick_valid_str
 from src.a17_idea_logic.idea_db_tool import upsert_sheet, sheet_exists
 from src.a19_world_logic.world import worldunit_shop
 from src.a19_world_logic._utils.env_a19 import (
@@ -49,8 +49,8 @@ def test_WorldUnit_otz_face_ideas_to_otz_event_otx_ideas_CreatesFaceIdeaSheets_S
     zia_dir = create_path(fizz_world._syntax_otz_dir, zia_str)
     sue_br00003_filepath = create_path(sue_dir, br00003_filename)
     zia_br00003_filepath = create_path(zia_dir, br00003_filename)
-    upsert_sheet(sue_br00003_filepath, yell_valid_str(), example_sue_df)
-    upsert_sheet(zia_br00003_filepath, yell_valid_str(), example_zia_df)
+    upsert_sheet(sue_br00003_filepath, brick_valid_str(), example_sue_df)
+    upsert_sheet(zia_br00003_filepath, brick_valid_str(), example_zia_df)
 
     event3_dir = create_path(sue_dir, event3)
     event7_dir = create_path(zia_dir, event7)
@@ -58,20 +58,20 @@ def test_WorldUnit_otz_face_ideas_to_otz_event_otx_ideas_CreatesFaceIdeaSheets_S
     event3_br00003_filepath = create_path(event3_dir, br00003_filename)
     event7_br00003_filepath = create_path(event7_dir, br00003_filename)
     event9_br00003_filepath = create_path(event9_dir, br00003_filename)
-    assert sheet_exists(event3_br00003_filepath, yell_valid_str()) is False
-    assert sheet_exists(event7_br00003_filepath, yell_valid_str()) is False
-    assert sheet_exists(event9_br00003_filepath, yell_valid_str()) is False
+    assert sheet_exists(event3_br00003_filepath, brick_valid_str()) is False
+    assert sheet_exists(event7_br00003_filepath, brick_valid_str()) is False
+    assert sheet_exists(event9_br00003_filepath, brick_valid_str()) is False
 
     # WHEN
     fizz_world.otz_face_ideas_to_otz_event_otx_ideas()
 
     # THEN
-    assert sheet_exists(event3_br00003_filepath, yell_valid_str())
-    assert sheet_exists(event7_br00003_filepath, yell_valid_str())
-    assert sheet_exists(event9_br00003_filepath, yell_valid_str())
-    gen_event3_df = pandas_read_excel(event3_br00003_filepath, yell_valid_str())
-    gen_event7_df = pandas_read_excel(event7_br00003_filepath, yell_valid_str())
-    gen_event9_df = pandas_read_excel(event9_br00003_filepath, yell_valid_str())
+    assert sheet_exists(event3_br00003_filepath, brick_valid_str())
+    assert sheet_exists(event7_br00003_filepath, brick_valid_str())
+    assert sheet_exists(event9_br00003_filepath, brick_valid_str())
+    gen_event3_df = pandas_read_excel(event3_br00003_filepath, brick_valid_str())
+    gen_event7_df = pandas_read_excel(event7_br00003_filepath, brick_valid_str())
+    gen_event9_df = pandas_read_excel(event9_br00003_filepath, brick_valid_str())
     example_event3_df = DataFrame([sue0, sue1], columns=idea_columns)
     example_event7_df = DataFrame([zia0], columns=idea_columns)
     example_event9_df = DataFrame([zia1, zia2], columns=idea_columns)

--- a/src/a19_world_logic/test_04_ideas_pidgined/test_world_etl04_03_otz_event_ideas_to_otz_event_inx_ideas.py
+++ b/src/a19_world_logic/test_04_ideas_pidgined/test_world_etl04_03_otz_event_ideas_to_otz_event_inx_ideas.py
@@ -9,7 +9,7 @@ from src.a06_bud_logic._utils.str_a06 import (
 )
 from src.a16_pidgin_logic._utils.str_a16 import pidgin_filename
 from src.a16_pidgin_logic.pidgin import pidginunit_shop
-from src.a17_idea_logic._utils.str_a17 import yell_valid_str
+from src.a17_idea_logic._utils.str_a17 import brick_valid_str
 from src.a17_idea_logic.idea_db_tool import upsert_sheet, sheet_exists
 from src.a19_world_logic.world import worldunit_shop
 from src.a19_world_logic._utils.env_a19 import (
@@ -22,7 +22,7 @@ from pandas.testing import (
 from pandas import DataFrame, read_excel as pandas_read_excel
 
 
-def test_etl_otz_event_ideas_to_yell_events_Scenario0_NoPidginUnit(
+def test_etl_otz_event_ideas_to_brick_events_Scenario0_NoPidginUnit(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -47,19 +47,19 @@ def test_etl_otz_event_ideas_to_yell_events_Scenario0_NoPidginUnit(
     fizz_world._pidgin_events = {}
     sue_otz_dir = create_path(fizz_world._syntax_otz_dir, sue_otx)
     otz_e3_dir = create_path(sue_otz_dir, event3)
-    yell_e3_br00011_path = create_path(otz_e3_dir, br00011_filename)
-    print(f"{yell_e3_br00011_path=}")
-    upsert_sheet(yell_e3_br00011_path, yell_valid_str(), e3_accord23_df)
-    print(f"{yell_valid_str()=}")
+    brick_e3_br00011_path = create_path(otz_e3_dir, br00011_filename)
+    print(f"{brick_e3_br00011_path=}")
+    upsert_sheet(brick_e3_br00011_path, brick_valid_str(), e3_accord23_df)
+    print(f"{brick_valid_str()=}")
     inx_str = "inx"
-    assert sheet_exists(yell_e3_br00011_path, inx_str) is False
+    assert sheet_exists(brick_e3_br00011_path, inx_str) is False
 
     # WHEN
     fizz_world.otz_event_ideas_to_inz_events()
 
     # THEN
-    assert sheet_exists(yell_e3_br00011_path, inx_str)
-    e3_inx_df = pandas_read_excel(yell_e3_br00011_path, sheet_name=inx_str)
+    assert sheet_exists(brick_e3_br00011_path, inx_str)
+    e3_inx_df = pandas_read_excel(brick_e3_br00011_path, sheet_name=inx_str)
     sue_i0 = [sue_otx, event3, accord23_str, bob_otx, bob_otx]
     sue_i1 = [sue_otx, event3, accord23_str, yao_otx, bob_otx]
     sue_i2 = [sue_otx, event3, accord23_str, yao_otx, yao_otx]
@@ -67,7 +67,7 @@ def test_etl_otz_event_ideas_to_yell_events_Scenario0_NoPidginUnit(
     pandas_assert_frame_equal(e3_inx_df, example_e3_inx_df)
 
 
-def test_etl_otz_event_ideas_to_yell_events_Scenario1_MultpleFaceNames_CreatesEventInxSheets(
+def test_etl_otz_event_ideas_to_brick_events_Scenario1_MultpleFaceNames_CreatesEventInxSheets(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -114,16 +114,16 @@ def test_etl_otz_event_ideas_to_yell_events_Scenario1_MultpleFaceNames_CreatesEv
     otz_e3_dir = create_path(sue_otz_dir, event3)
     otz_e7_dir = create_path(zia_otz_dir, event7)
     otz_e9_dir = create_path(zia_otz_dir, event9)
-    yell_e3_br00011_path = create_path(otz_e3_dir, br00011_filename)
-    yell_e7_br00011_path = create_path(otz_e7_dir, br00011_filename)
-    yell_e9_br00011_path = create_path(otz_e9_dir, br00011_filename)
-    print(f"{yell_e3_br00011_path=}")
-    print(f"{yell_e7_br00011_path=}")
-    print(f"{yell_e9_br00011_path=}")
-    upsert_sheet(yell_e3_br00011_path, yell_valid_str(), e3_accord23_df)
-    upsert_sheet(yell_e7_br00011_path, yell_valid_str(), e7_accord23_df)
-    upsert_sheet(yell_e9_br00011_path, yell_valid_str(), e9_accord23_df)
-    print(f"{yell_valid_str()=}")
+    brick_e3_br00011_path = create_path(otz_e3_dir, br00011_filename)
+    brick_e7_br00011_path = create_path(otz_e7_dir, br00011_filename)
+    brick_e9_br00011_path = create_path(otz_e9_dir, br00011_filename)
+    print(f"{brick_e3_br00011_path=}")
+    print(f"{brick_e7_br00011_path=}")
+    print(f"{brick_e9_br00011_path=}")
+    upsert_sheet(brick_e3_br00011_path, brick_valid_str(), e3_accord23_df)
+    upsert_sheet(brick_e7_br00011_path, brick_valid_str(), e7_accord23_df)
+    upsert_sheet(brick_e9_br00011_path, brick_valid_str(), e9_accord23_df)
+    print(f"{brick_valid_str()=}")
     inx_str = "inx"
     e3_pidginunit = pidginunit_shop(sue_otx, event3)
     e7_pidginunit = pidginunit_shop(zia_otx, event7)
@@ -141,20 +141,20 @@ def test_etl_otz_event_ideas_to_yell_events_Scenario1_MultpleFaceNames_CreatesEv
     save_file(otz_e3_dir, pidgin_filename(), e3_pidginunit.get_json())
     save_file(otz_e7_dir, pidgin_filename(), e7_pidginunit.get_json())
     save_file(otz_e9_dir, pidgin_filename(), e9_pidginunit.get_json())
-    assert sheet_exists(yell_e3_br00011_path, inx_str) is False
-    assert sheet_exists(yell_e7_br00011_path, inx_str) is False
-    assert sheet_exists(yell_e9_br00011_path, inx_str) is False
+    assert sheet_exists(brick_e3_br00011_path, inx_str) is False
+    assert sheet_exists(brick_e7_br00011_path, inx_str) is False
+    assert sheet_exists(brick_e9_br00011_path, inx_str) is False
 
     # WHEN
     fizz_world.otz_event_ideas_to_inz_events()
 
     # THEN
-    assert sheet_exists(yell_e3_br00011_path, inx_str)
-    assert sheet_exists(yell_e7_br00011_path, inx_str)
-    assert sheet_exists(yell_e9_br00011_path, inx_str)
-    e3_inx_df = pandas_read_excel(yell_e3_br00011_path, sheet_name=inx_str)
-    e7_inx_df = pandas_read_excel(yell_e7_br00011_path, sheet_name=inx_str)
-    e9_inx_df = pandas_read_excel(yell_e9_br00011_path, sheet_name=inx_str)
+    assert sheet_exists(brick_e3_br00011_path, inx_str)
+    assert sheet_exists(brick_e7_br00011_path, inx_str)
+    assert sheet_exists(brick_e9_br00011_path, inx_str)
+    e3_inx_df = pandas_read_excel(brick_e3_br00011_path, sheet_name=inx_str)
+    e7_inx_df = pandas_read_excel(brick_e7_br00011_path, sheet_name=inx_str)
+    e9_inx_df = pandas_read_excel(brick_e9_br00011_path, sheet_name=inx_str)
     sue_i0 = [sue_inx, event3, accord23_str, bob0_inx, bob0_inx]
     sue_i1 = [sue_inx, event3, accord23_str, yao0_inx, bob0_inx]
     sue_i2 = [sue_inx, event3, accord23_str, yao0_inx, yao0_inx]

--- a/src/a19_world_logic/test_etl_pipeline/test_world_mud_to_fisc_unit.py
+++ b/src/a19_world_logic/test_etl_pipeline/test_world_mud_to_fisc_unit.py
@@ -26,7 +26,7 @@ from pandas import DataFrame
 from os.path import exists as os_path_exists
 
 
-def test_WorldUnit_sound_to_standings_Scenario0_DeletesPreviousFiles(
+def test_WorldUnit_mud_to_standings_Scenario0_DeletesPreviousFiles(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -47,7 +47,7 @@ def test_WorldUnit_sound_to_standings_Scenario0_DeletesPreviousFiles(
     assert count_dirs_files(fizz_world.worlds_dir) == 9
 
     # WHEN
-    fizz_world.sound_to_standings(store_tracing_files=True)
+    fizz_world.mud_to_standings(store_tracing_files=True)
 
     # THEN
     assert os_path_exists(testing2_path)
@@ -55,7 +55,7 @@ def test_WorldUnit_sound_to_standings_Scenario0_DeletesPreviousFiles(
     assert count_dirs_files(fizz_world.worlds_dir) == 23
 
 
-def test_WorldUnit_sound_to_standings_Scenario1_CreatesFiles(env_dir_setup_cleanup):
+def test_WorldUnit_mud_to_standings_Scenario1_CreatesFiles(env_dir_setup_cleanup):
     # ESTABLISH
     fizz_str = "fizz"
     fizz_world = worldunit_shop(fizz_str, worlds_dir())
@@ -68,7 +68,7 @@ def test_WorldUnit_sound_to_standings_Scenario1_CreatesFiles(env_dir_setup_clean
     hour6am = "6am"
     hour7am = "7am"
     ex_filename = "fizzbuzz.xlsx"
-    sound_file_path = create_path(fizz_world._sound_dir, ex_filename)
+    mud_file_path = create_path(fizz_world._mud_dir, ex_filename)
     br00003_columns = [
         face_name_str(),
         event_int_str(),
@@ -92,7 +92,7 @@ def test_WorldUnit_sound_to_standings_Scenario1_CreatesFiles(env_dir_setup_clean
     br1row0 = [sue_str, event_2, accord23_str, sue_str, tp37, sue_quota, sue_celldepth]
     br00001_1df = DataFrame([br1row0], columns=br00001_columns)
     br00001_ex0_str = "example0_br00001"
-    upsert_sheet(sound_file_path, br00001_ex0_str, br00001_1df)
+    upsert_sheet(mud_file_path, br00001_ex0_str, br00001_1df)
 
     br3row0 = [sue_str, event_1, minute_360, accord23_str, hour6am]
     br3row1 = [sue_str, event_1, minute_420, accord23_str, hour7am]
@@ -101,8 +101,8 @@ def test_WorldUnit_sound_to_standings_Scenario1_CreatesFiles(env_dir_setup_clean
     br00003_3df = DataFrame([br3row1, br3row0, br3row2], columns=br00003_columns)
     br00003_ex1_str = "example1_br00003"
     br00003_ex3_str = "example3_br00003"
-    upsert_sheet(sound_file_path, br00003_ex1_str, br00003_1df)
-    upsert_sheet(sound_file_path, br00003_ex3_str, br00003_3df)
+    upsert_sheet(mud_file_path, br00003_ex1_str, br00003_1df)
+    upsert_sheet(mud_file_path, br00003_ex3_str, br00003_3df)
     br00011_columns = [
         face_name_str(),
         event_int_str(),
@@ -112,7 +112,7 @@ def test_WorldUnit_sound_to_standings_Scenario1_CreatesFiles(env_dir_setup_clean
     ]
     br00011_rows = [[sue_str, event_2, accord23_str, sue_str, sue_str]]
     br00011_df = DataFrame(br00011_rows, columns=br00011_columns)
-    upsert_sheet(sound_file_path, "br00011_ex3", br00011_df)
+    upsert_sheet(mud_file_path, "br00011_ex3", br00011_df)
     mstr_dir = fizz_world._fisc_mstr_dir
     wrong_a23_fisc_dir = create_path(mstr_dir, accord23_str)
     assert os_path_exists(wrong_a23_fisc_dir) is False
@@ -121,7 +121,7 @@ def test_WorldUnit_sound_to_standings_Scenario1_CreatesFiles(env_dir_setup_clean
     a23_sue_gut_path = create_gut_path(mstr_dir, accord23_str, sue_str)
     a23_sue_job_path = create_job_path(mstr_dir, accord23_str, sue_str)
     sue37_mandate_path = deal_mandate(mstr_dir, accord23_str, sue_str, tp37)
-    assert os_path_exists(sound_file_path)
+    assert os_path_exists(mud_file_path)
     assert not os_path_exists(yell_file_path)
     assert not os_path_exists(a23_json_path)
     assert not os_path_exists(a23_sue_gut_path)
@@ -130,11 +130,11 @@ def test_WorldUnit_sound_to_standings_Scenario1_CreatesFiles(env_dir_setup_clean
     assert count_dirs_files(fizz_world.worlds_dir) == 7
 
     # WHEN
-    fizz_world.sound_to_standings(store_tracing_files=True)
+    fizz_world.mud_to_standings(store_tracing_files=True)
 
     # THEN
     assert os_path_exists(wrong_a23_fisc_dir) is False
-    assert os_path_exists(sound_file_path)
+    assert os_path_exists(mud_file_path)
     assert os_path_exists(yell_file_path)
     assert sheet_exists(yell_file_path, yell_raw_str())
     assert os_path_exists(yell_file_path)
@@ -145,7 +145,7 @@ def test_WorldUnit_sound_to_standings_Scenario1_CreatesFiles(env_dir_setup_clean
     assert count_dirs_files(fizz_world.worlds_dir) == 81
 
 
-def test_WorldUnit_sound_to_standings_Senario2_WhenNoFiscBricks_ote1_IsStillCreated(
+def test_WorldUnit_mud_to_standings_Senario2_WhenNoFiscBricks_ote1_IsStillCreated(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -154,7 +154,7 @@ def test_WorldUnit_sound_to_standings_Senario2_WhenNoFiscBricks_ote1_IsStillCrea
     sue_str = "Sue"
     event_2 = 2
     ex_filename = "fizzbuzz.xlsx"
-    sound_file_path = create_path(fizz_world._sound_dir, ex_filename)
+    mud_file_path = create_path(fizz_world._mud_dir, ex_filename)
     accord23_str = "accord23"
     br00011_columns = [
         face_name_str(),
@@ -165,19 +165,19 @@ def test_WorldUnit_sound_to_standings_Senario2_WhenNoFiscBricks_ote1_IsStillCrea
     ]
     br00011_rows = [[sue_str, event_2, accord23_str, sue_str, sue_str]]
     br00011_df = DataFrame(br00011_rows, columns=br00011_columns)
-    upsert_sheet(sound_file_path, "br00011_ex3", br00011_df)
+    upsert_sheet(mud_file_path, "br00011_ex3", br00011_df)
     fisc_mstr = fizz_world._fisc_mstr_dir
     a23_ote1_csv_path = create_fisc_ote1_csv_path(fisc_mstr, accord23_str)
     assert os_path_exists(a23_ote1_csv_path) is False
 
     # WHEN
-    fizz_world.sound_to_standings()
+    fizz_world.mud_to_standings()
 
     # THEN
     assert os_path_exists(a23_ote1_csv_path)
 
 
-# def test_WorldUnit_sound_to_standings_CreatesYellFiles(env_dir_setup_cleanup):
+# def test_WorldUnit_mud_to_standings_CreatesYellFiles(env_dir_setup_cleanup):
 #     # ESTABLISH
 #     fizz_str = "fizz"
 #     fizz_world = worldunit_shop(fizz_str, worlds_dir())
@@ -190,7 +190,7 @@ def test_WorldUnit_sound_to_standings_Senario2_WhenNoFiscBricks_ote1_IsStillCrea
 #     hour6am = "6am"
 #     hour7am = "7am"
 #     ex_filename = "fizzbuzz.xlsx"
-#     sound_file_path = create_path(fizz_world._sound_dir, ex_filename)
+#     mud_file_path = create_path(fizz_world._mud_dir, ex_filename)
 #     br00003_columns = [
 #         face_name_str(),
 #         event_int_str(),
@@ -206,8 +206,8 @@ def test_WorldUnit_sound_to_standings_Senario2_WhenNoFiscBricks_ote1_IsStillCrea
 #     df3 = DataFrame([row2, row1, row3], columns=br00003_columns)
 #     br00003_ex1_str = "example1_br00003"
 #     br00003_ex3_str = "example3_br00003"
-#     upsert_sheet(sound_file_path, br00003_ex1_str, df1)
-#     upsert_sheet(sound_file_path, br00003_ex3_str, df3)
+#     upsert_sheet(mud_file_path, br00003_ex1_str, df1)
+#     upsert_sheet(mud_file_path, br00003_ex3_str, df3)
 #     br00011_columns = [
 #         face_name_str(),
 #         event_int_str(),
@@ -217,23 +217,23 @@ def test_WorldUnit_sound_to_standings_Senario2_WhenNoFiscBricks_ote1_IsStillCrea
 #     ]
 #     br00011_rows = [[sue_str, event_2, accord23_str, sue_str, sue_str]]
 #     br00011_df = DataFrame(br00011_rows, columns=br00011_columns)
-#     upsert_sheet(sound_file_path, "br00011_ex3", br00011_df)
+#     upsert_sheet(mud_file_path, "br00011_ex3", br00011_df)
 #     mstr_dir = fizz_world._mstr_dir
 #     fiscs_dir = create_path(mstr_dir, "fiscs")
 #     a23_json_path = create_fisc_json_path(mstr_dir, accord23_str)
 #     a23_sue_gut_path = create_gut_path(fiscs_dir, accord23_str, sue_str)
 #     a23_sue_job_path = create_job_path(fiscs_dir, accord23_str, sue_str)
-#     assert os_path_exists(sound_file_path)
+#     assert os_path_exists(mud_file_path)
 #     assert os_path_exists(a23_json_path) is False
 #     assert os_path_exists(a23_sue_gut_path) is False
 #     assert os_path_exists(a23_sue_job_path) is False
 
 #     # WHEN
-#     fizz_world.sound_to_standings()
+#     fizz_world.mud_to_standings()
 
 #     # THEN
 #     yell_file_path = create_path(fizz_world._yell_dir, "br00003.xlsx")
-#     assert os_path_exists(sound_file_path)
+#     assert os_path_exists(mud_file_path)
 #     assert os_path_exists(yell_file_path)
 #     assert os_path_exists(a23_json_path)
 #     assert os_path_exists(a23_sue_gut_path)

--- a/src/a19_world_logic/test_etl_pipeline/test_world_mud_to_fisc_unit.py
+++ b/src/a19_world_logic/test_etl_pipeline/test_world_mud_to_fisc_unit.py
@@ -26,7 +26,7 @@ from pandas import DataFrame
 from os.path import exists as os_path_exists
 
 
-def test_WorldUnit_mud_to_standings_Scenario0_DeletesPreviousFiles(
+def test_WorldUnit_mud_to_stances_Scenario0_DeletesPreviousFiles(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -47,7 +47,7 @@ def test_WorldUnit_mud_to_standings_Scenario0_DeletesPreviousFiles(
     assert count_dirs_files(fizz_world.worlds_dir) == 9
 
     # WHEN
-    fizz_world.mud_to_standings(store_tracing_files=True)
+    fizz_world.mud_to_stances(store_tracing_files=True)
 
     # THEN
     assert os_path_exists(testing2_path)
@@ -55,7 +55,7 @@ def test_WorldUnit_mud_to_standings_Scenario0_DeletesPreviousFiles(
     assert count_dirs_files(fizz_world.worlds_dir) == 23
 
 
-def test_WorldUnit_mud_to_standings_Scenario1_CreatesFiles(env_dir_setup_cleanup):
+def test_WorldUnit_mud_to_stances_Scenario1_CreatesFiles(env_dir_setup_cleanup):
     # ESTABLISH
     fizz_str = "fizz"
     fizz_world = worldunit_shop(fizz_str, worlds_dir())
@@ -130,7 +130,7 @@ def test_WorldUnit_mud_to_standings_Scenario1_CreatesFiles(env_dir_setup_cleanup
     assert count_dirs_files(fizz_world.worlds_dir) == 7
 
     # WHEN
-    fizz_world.mud_to_standings(store_tracing_files=True)
+    fizz_world.mud_to_stances(store_tracing_files=True)
 
     # THEN
     assert os_path_exists(wrong_a23_fisc_dir) is False
@@ -145,7 +145,7 @@ def test_WorldUnit_mud_to_standings_Scenario1_CreatesFiles(env_dir_setup_cleanup
     assert count_dirs_files(fizz_world.worlds_dir) == 81
 
 
-def test_WorldUnit_mud_to_standings_Senario2_WhenNoFiscIdeas_ote1_IsStillCreated(
+def test_WorldUnit_mud_to_stances_Senario2_WhenNoFiscIdeas_ote1_IsStillCreated(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -171,13 +171,13 @@ def test_WorldUnit_mud_to_standings_Senario2_WhenNoFiscIdeas_ote1_IsStillCreated
     assert os_path_exists(a23_ote1_csv_path) is False
 
     # WHEN
-    fizz_world.mud_to_standings()
+    fizz_world.mud_to_stances()
 
     # THEN
     assert os_path_exists(a23_ote1_csv_path)
 
 
-# def test_WorldUnit_mud_to_standings_CreatesYellFiles(env_dir_setup_cleanup):
+# def test_WorldUnit_mud_to_stances_CreatesYellFiles(env_dir_setup_cleanup):
 #     # ESTABLISH
 #     fizz_str = "fizz"
 #     fizz_world = worldunit_shop(fizz_str, worlds_dir())
@@ -229,7 +229,7 @@ def test_WorldUnit_mud_to_standings_Senario2_WhenNoFiscIdeas_ote1_IsStillCreated
 #     assert os_path_exists(a23_sue_job_path) is False
 
 #     # WHEN
-#     fizz_world.mud_to_standings()
+#     fizz_world.mud_to_stances()
 
 #     # THEN
 #     yell_file_path = create_path(fizz_world._yell_dir, "br00003.xlsx")

--- a/src/a19_world_logic/test_etl_pipeline/test_world_mud_to_fisc_unit.py
+++ b/src/a19_world_logic/test_etl_pipeline/test_world_mud_to_fisc_unit.py
@@ -145,7 +145,7 @@ def test_WorldUnit_mud_to_standings_Scenario1_CreatesFiles(env_dir_setup_cleanup
     assert count_dirs_files(fizz_world.worlds_dir) == 81
 
 
-def test_WorldUnit_mud_to_standings_Senario2_WhenNoFiscBricks_ote1_IsStillCreated(
+def test_WorldUnit_mud_to_standings_Senario2_WhenNoFiscIdeas_ote1_IsStillCreated(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH

--- a/src/a19_world_logic/test_etl_pipeline/test_world_mud_to_fisc_unit.py
+++ b/src/a19_world_logic/test_etl_pipeline/test_world_mud_to_fisc_unit.py
@@ -15,7 +15,7 @@ from src.a12_hub_tools.hub_path import (
     create_fisc_ote1_csv_path,
 )
 from src.a15_fisc_logic._utils.str_a15 import cumlative_minute_str, hour_tag_str
-from src.a17_idea_logic._utils.str_a17 import yell_agg_str, yell_raw_str
+from src.a17_idea_logic._utils.str_a17 import brick_agg_str, brick_raw_str
 from src.a17_idea_logic.idea_db_tool import upsert_sheet, sheet_exists
 from src.a19_world_logic.world import worldunit_shop
 from src.a19_world_logic._utils.env_a19 import (
@@ -116,13 +116,13 @@ def test_WorldUnit_mud_to_stances_Scenario1_CreatesFiles(env_dir_setup_cleanup):
     mstr_dir = fizz_world._fisc_mstr_dir
     wrong_a23_fisc_dir = create_path(mstr_dir, accord23_str)
     assert os_path_exists(wrong_a23_fisc_dir) is False
-    yell_file_path = create_path(fizz_world._yell_dir, "br00003.xlsx")
+    brick_file_path = create_path(fizz_world._brick_dir, "br00003.xlsx")
     a23_json_path = create_fisc_json_path(mstr_dir, accord23_str)
     a23_sue_gut_path = create_gut_path(mstr_dir, accord23_str, sue_str)
     a23_sue_job_path = create_job_path(mstr_dir, accord23_str, sue_str)
     sue37_mandate_path = deal_mandate(mstr_dir, accord23_str, sue_str, tp37)
     assert os_path_exists(mud_file_path)
-    assert not os_path_exists(yell_file_path)
+    assert not os_path_exists(brick_file_path)
     assert not os_path_exists(a23_json_path)
     assert not os_path_exists(a23_sue_gut_path)
     assert not os_path_exists(a23_sue_job_path)
@@ -135,9 +135,9 @@ def test_WorldUnit_mud_to_stances_Scenario1_CreatesFiles(env_dir_setup_cleanup):
     # THEN
     assert os_path_exists(wrong_a23_fisc_dir) is False
     assert os_path_exists(mud_file_path)
-    assert os_path_exists(yell_file_path)
-    assert sheet_exists(yell_file_path, yell_raw_str())
-    assert os_path_exists(yell_file_path)
+    assert os_path_exists(brick_file_path)
+    assert sheet_exists(brick_file_path, brick_raw_str())
+    assert os_path_exists(brick_file_path)
     assert os_path_exists(a23_json_path)
     assert os_path_exists(a23_sue_gut_path)
     assert os_path_exists(a23_sue_job_path)
@@ -177,7 +177,7 @@ def test_WorldUnit_mud_to_stances_Senario2_WhenNoFiscIdeas_ote1_IsStillCreated(
     assert os_path_exists(a23_ote1_csv_path)
 
 
-# def test_WorldUnit_mud_to_stances_CreatesYellFiles(env_dir_setup_cleanup):
+# def test_WorldUnit_mud_to_stances_CreatesBrickFiles(env_dir_setup_cleanup):
 #     # ESTABLISH
 #     fizz_str = "fizz"
 #     fizz_world = worldunit_shop(fizz_str, worlds_dir())
@@ -232,9 +232,9 @@ def test_WorldUnit_mud_to_stances_Senario2_WhenNoFiscIdeas_ote1_IsStillCreated(
 #     fizz_world.mud_to_stances()
 
 #     # THEN
-#     yell_file_path = create_path(fizz_world._yell_dir, "br00003.xlsx")
+#     brick_file_path = create_path(fizz_world._brick_dir, "br00003.xlsx")
 #     assert os_path_exists(mud_file_path)
-#     assert os_path_exists(yell_file_path)
+#     assert os_path_exists(brick_file_path)
 #     assert os_path_exists(a23_json_path)
 #     assert os_path_exists(a23_sue_gut_path)
 #     assert os_path_exists(a23_sue_job_path)

--- a/src/a19_world_logic/test_etl_pipeline/test_world_stance_export.py
+++ b/src/a19_world_logic/test_etl_pipeline/test_world_stance_export.py
@@ -23,7 +23,7 @@ def test_WorldUnit_create_stances_Senario0_EmptyWorld_CreatesFile(
     # ESTABLISH
     fizz_str = "fizz"
     fizz_world = worldunit_shop(fizz_str, worlds_dir())
-    fizz_world.sound_to_standings()
+    fizz_world.mud_to_standings()
     fizz_stance0001_path = create_stance0001_path(fizz_world._fisc_mstr_dir)
     assert os_path_exists(fizz_stance0001_path) is False
 
@@ -41,7 +41,7 @@ def test_WorldUnit_create_stances_Senario1_Add_CreatesFile(env_dir_setup_cleanup
     sue_str = "Sue"
     event_2 = 2
     ex_filename = "fizzbuzz.xlsx"
-    sound_file_path = create_path(fizz_world._sound_dir, ex_filename)
+    mud_file_path = create_path(fizz_world._mud_dir, ex_filename)
     accord23_str = "accord23"
     br00011_columns = [
         face_name_str(),
@@ -52,8 +52,8 @@ def test_WorldUnit_create_stances_Senario1_Add_CreatesFile(env_dir_setup_cleanup
     ]
     br00011_rows = [[sue_str, event_2, accord23_str, sue_str, sue_str]]
     br00011_df = DataFrame(br00011_rows, columns=br00011_columns)
-    upsert_sheet(sound_file_path, "br00011_ex3", br00011_df)
-    fizz_world.sound_to_standings()
+    upsert_sheet(mud_file_path, "br00011_ex3", br00011_df)
+    fizz_world.mud_to_standings()
     fizz_stance0001_path = create_stance0001_path(fizz_world._fisc_mstr_dir)
     assert os_path_exists(fizz_stance0001_path) is False
 
@@ -64,7 +64,7 @@ def test_WorldUnit_create_stances_Senario1_Add_CreatesFile(env_dir_setup_cleanup
     assert os_path_exists(fizz_stance0001_path)
 
 
-def test_WorldUnit_create_stances_Senario2_CreatedStanceCanBeSounddByOtherWorldUnit(
+def test_WorldUnit_create_stances_Senario2_CreatedStanceCanBeBricksForOtherWorldUnit(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -73,7 +73,7 @@ def test_WorldUnit_create_stances_Senario2_CreatedStanceCanBeSounddByOtherWorldU
     sue_str = "Sue"
     event_2 = 2
     ex_filename = "fizzbuzz.xlsx"
-    sound_file_path = create_path(fizz_world._sound_dir, ex_filename)
+    mud_file_path = create_path(fizz_world._mud_dir, ex_filename)
     accord23_str = "accord23"
     br00011_columns = [
         face_name_str(),
@@ -84,19 +84,19 @@ def test_WorldUnit_create_stances_Senario2_CreatedStanceCanBeSounddByOtherWorldU
     ]
     br00011_rows = [[sue_str, event_2, accord23_str, sue_str, sue_str]]
     br00011_df = DataFrame(br00011_rows, columns=br00011_columns)
-    upsert_sheet(sound_file_path, "br00011_ex3", br00011_df)
-    fizz_world.sound_to_standings()
+    upsert_sheet(mud_file_path, "br00011_ex3", br00011_df)
+    fizz_world.mud_to_standings()
     fizz_stance0001_path = create_stance0001_path(fizz_world._fisc_mstr_dir)
     fizz_world.create_stances()
     buzz_world = worldunit_shop("buzz", worlds_dir())
-    buzz_sound_st0001_path = create_path(buzz_world._fisc_mstr_dir, "buzz_sound.xlsx")
+    buzz_mud_st0001_path = create_path(buzz_world._fisc_mstr_dir, "buzz_mud.xlsx")
     set_dir(create_stances_dir_path(buzz_world._fisc_mstr_dir))
-    shutil_copy2(fizz_stance0001_path, dst=buzz_sound_st0001_path)
+    shutil_copy2(fizz_stance0001_path, dst=buzz_mud_st0001_path)
     # print(f" {pandas_read_excel(fizz_stance0001_path)=}")
-    # print(f"{pandas_read_excel(buzz_sound_st0001_path)=}")
-    print(f"{buzz_sound_st0001_path=}")
-    print(f"{get_sheet_names(buzz_sound_st0001_path)=}")
-    buzz_world.sound_to_standings()
+    # print(f"{pandas_read_excel(buzz_mud_st0001_path)=}")
+    print(f"{buzz_mud_st0001_path=}")
+    print(f"{get_sheet_names(buzz_mud_st0001_path)=}")
+    buzz_world.mud_to_standings()
     buzz_stance0001_path = create_stance0001_path(buzz_world._fisc_mstr_dir)
     assert os_path_exists(buzz_stance0001_path) is False
 
@@ -116,7 +116,7 @@ def test_WorldUnit_create_stances_Senario2_CreatedStanceCanBeSounddByOtherWorldU
         assert_frame_equal(fizz_sheet_df, buzz_sheet_df)
 
 
-# def test_WorldUnit_sound_to_standings_CreatesFiles(env_dir_setup_cleanup):
+# def test_WorldUnit_mud_to_standings_CreatesFiles(env_dir_setup_cleanup):
 #     # ESTABLISH
 #     fizz_str = "fizz"
 #     fizz_world = worldunit_shop(fizz_str, worlds_dir())
@@ -129,7 +129,7 @@ def test_WorldUnit_create_stances_Senario2_CreatedStanceCanBeSounddByOtherWorldU
 #     hour6am = "6am"
 #     hour7am = "7am"
 #     ex_filename = "fizzbuzz.xlsx"
-#     sound_file_path = create_path(fizz_world._sound_dir, ex_filename)
+#     mud_file_path = create_path(fizz_world._mud_dir, ex_filename)
 #     br00003_columns = [
 #         face_name_str(),
 #         event_int_str(),
@@ -153,7 +153,7 @@ def test_WorldUnit_create_stances_Senario2_CreatedStanceCanBeSounddByOtherWorldU
 #     br1row0 = [sue_str, event_2, accord23_str, sue_str, tp37, sue_quota, sue_celldepth]
 #     br00001_1df = DataFrame([br1row0], columns=br00001_columns)
 #     br00001_ex0_str = "example0_br00001"
-#     upsert_sheet(sound_file_path, br00001_ex0_str, br00001_1df)
+#     upsert_sheet(mud_file_path, br00001_ex0_str, br00001_1df)
 
 #     br3row0 = [sue_str, event_1, minute_360, accord23_str, hour6am]
 #     br3row1 = [sue_str, event_1, minute_420, accord23_str, hour7am]
@@ -162,8 +162,8 @@ def test_WorldUnit_create_stances_Senario2_CreatedStanceCanBeSounddByOtherWorldU
 #     br00003_3df = DataFrame([br3row1, br3row0, br3row2], columns=br00003_columns)
 #     br00003_ex1_str = "example1_br00003"
 #     br00003_ex3_str = "example3_br00003"
-#     upsert_sheet(sound_file_path, br00003_ex1_str, br00003_1df)
-#     upsert_sheet(sound_file_path, br00003_ex3_str, br00003_3df)
+#     upsert_sheet(mud_file_path, br00003_ex1_str, br00003_1df)
+#     upsert_sheet(mud_file_path, br00003_ex3_str, br00003_3df)
 #     br00011_columns = [
 #         face_name_str(),
 #         event_int_str(),
@@ -173,7 +173,7 @@ def test_WorldUnit_create_stances_Senario2_CreatedStanceCanBeSounddByOtherWorldU
 #     ]
 #     br00011_rows = [[sue_str, event_2, accord23_str, sue_str, sue_str]]
 #     br00011_df = DataFrame(br00011_rows, columns=br00011_columns)
-#     upsert_sheet(sound_file_path, "br00011_ex3", br00011_df)
+#     upsert_sheet(mud_file_path, "br00011_ex3", br00011_df)
 #     mstr_dir = fizz_world._fisc_mstr_dir
 #     wrong_a23_fisc_dir = create_path(mstr_dir, accord23_str)
 #     assert os_path_exists(wrong_a23_fisc_dir) is False
@@ -181,7 +181,7 @@ def test_WorldUnit_create_stances_Senario2_CreatedStanceCanBeSounddByOtherWorldU
 #     a23_sue_gut_path = create_gut_path(mstr_dir, accord23_str, sue_str)
 #     a23_sue_job_path = create_job_path(mstr_dir, accord23_str, sue_str)
 #     sue37_mandate_path = deal_mandate(mstr_dir, accord23_str, sue_str, tp37)
-#     assert os_path_exists(sound_file_path)
+#     assert os_path_exists(mud_file_path)
 #     assert os_path_exists(a23_json_path) is False
 #     assert os_path_exists(a23_sue_gut_path) is False
 #     assert os_path_exists(a23_sue_job_path) is False
@@ -189,12 +189,12 @@ def test_WorldUnit_create_stances_Senario2_CreatedStanceCanBeSounddByOtherWorldU
 #     assert count_dirs_files(fizz_world.worlds_dir) == 7
 
 #     # WHEN
-#     fizz_world.sound_to_standings()
+#     fizz_world.mud_to_standings()
 
 #     # THEN
 #     assert os_path_exists(wrong_a23_fisc_dir) is False
 #     yell_file_path = create_path(fizz_world._yell_dir, "br00003.xlsx")
-#     assert os_path_exists(sound_file_path)
+#     assert os_path_exists(mud_file_path)
 #     assert os_path_exists(yell_file_path)
 #     assert os_path_exists(a23_json_path)
 #     assert os_path_exists(a23_sue_gut_path)

--- a/src/a19_world_logic/test_etl_pipeline/test_world_stance_export.py
+++ b/src/a19_world_logic/test_etl_pipeline/test_world_stance_export.py
@@ -64,7 +64,7 @@ def test_WorldUnit_create_stances_Senario1_Add_CreatesFile(env_dir_setup_cleanup
     assert os_path_exists(fizz_stance0001_path)
 
 
-def test_WorldUnit_create_stances_Senario2_CreatedStanceCanBeBricksForOtherWorldUnit(
+def test_WorldUnit_create_stances_Senario2_CreatedStanceCanBeIdeasForOtherWorldUnit(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH

--- a/src/a19_world_logic/test_etl_pipeline/test_world_stance_export.py
+++ b/src/a19_world_logic/test_etl_pipeline/test_world_stance_export.py
@@ -23,7 +23,7 @@ def test_WorldUnit_create_stances_Senario0_EmptyWorld_CreatesFile(
     # ESTABLISH
     fizz_str = "fizz"
     fizz_world = worldunit_shop(fizz_str, worlds_dir())
-    fizz_world.mud_to_standings()
+    fizz_world.mud_to_stances()
     fizz_stance0001_path = create_stance0001_path(fizz_world._fisc_mstr_dir)
     assert os_path_exists(fizz_stance0001_path) is False
 
@@ -53,7 +53,7 @@ def test_WorldUnit_create_stances_Senario1_Add_CreatesFile(env_dir_setup_cleanup
     br00011_rows = [[sue_str, event_2, accord23_str, sue_str, sue_str]]
     br00011_df = DataFrame(br00011_rows, columns=br00011_columns)
     upsert_sheet(mud_file_path, "br00011_ex3", br00011_df)
-    fizz_world.mud_to_standings()
+    fizz_world.mud_to_stances()
     fizz_stance0001_path = create_stance0001_path(fizz_world._fisc_mstr_dir)
     assert os_path_exists(fizz_stance0001_path) is False
 
@@ -85,7 +85,7 @@ def test_WorldUnit_create_stances_Senario2_CreatedStanceCanBeIdeasForOtherWorldU
     br00011_rows = [[sue_str, event_2, accord23_str, sue_str, sue_str]]
     br00011_df = DataFrame(br00011_rows, columns=br00011_columns)
     upsert_sheet(mud_file_path, "br00011_ex3", br00011_df)
-    fizz_world.mud_to_standings()
+    fizz_world.mud_to_stances()
     fizz_stance0001_path = create_stance0001_path(fizz_world._fisc_mstr_dir)
     fizz_world.create_stances()
     buzz_world = worldunit_shop("buzz", worlds_dir())
@@ -96,7 +96,7 @@ def test_WorldUnit_create_stances_Senario2_CreatedStanceCanBeIdeasForOtherWorldU
     # print(f"{pandas_read_excel(buzz_mud_st0001_path)=}")
     print(f"{buzz_mud_st0001_path=}")
     print(f"{get_sheet_names(buzz_mud_st0001_path)=}")
-    buzz_world.mud_to_standings()
+    buzz_world.mud_to_stances()
     buzz_stance0001_path = create_stance0001_path(buzz_world._fisc_mstr_dir)
     assert os_path_exists(buzz_stance0001_path) is False
 
@@ -116,7 +116,7 @@ def test_WorldUnit_create_stances_Senario2_CreatedStanceCanBeIdeasForOtherWorldU
         assert_frame_equal(fizz_sheet_df, buzz_sheet_df)
 
 
-# def test_WorldUnit_mud_to_standings_CreatesFiles(env_dir_setup_cleanup):
+# def test_WorldUnit_mud_to_stances_CreatesFiles(env_dir_setup_cleanup):
 #     # ESTABLISH
 #     fizz_str = "fizz"
 #     fizz_world = worldunit_shop(fizz_str, worlds_dir())
@@ -189,7 +189,7 @@ def test_WorldUnit_create_stances_Senario2_CreatedStanceCanBeIdeasForOtherWorldU
 #     assert count_dirs_files(fizz_world.worlds_dir) == 7
 
 #     # WHEN
-#     fizz_world.mud_to_standings()
+#     fizz_world.mud_to_stances()
 
 #     # THEN
 #     assert os_path_exists(wrong_a23_fisc_dir) is False

--- a/src/a19_world_logic/test_etl_pipeline/test_world_stance_export.py
+++ b/src/a19_world_logic/test_etl_pipeline/test_world_stance_export.py
@@ -193,9 +193,9 @@ def test_WorldUnit_create_stances_Senario2_CreatedStanceCanBeIdeasForOtherWorldU
 
 #     # THEN
 #     assert os_path_exists(wrong_a23_fisc_dir) is False
-#     yell_file_path = create_path(fizz_world._yell_dir, "br00003.xlsx")
+#     brick_file_path = create_path(fizz_world._brick_dir, "br00003.xlsx")
 #     assert os_path_exists(mud_file_path)
-#     assert os_path_exists(yell_file_path)
+#     assert os_path_exists(brick_file_path)
 #     assert os_path_exists(a23_json_path)
 #     assert os_path_exists(a23_sue_gut_path)
 #     assert os_path_exists(a23_sue_job_path)

--- a/src/a19_world_logic/world.py
+++ b/src/a19_world_logic/world.py
@@ -15,23 +15,23 @@ from src.a01_word_logic.road import (
 from src.a15_fisc_logic.fisc import FiscUnit
 from src.a18_etl_toolbox.stance_tool import create_stance0001_file
 from src.a18_etl_toolbox.transformers import (
-    etl_mud_df_to_yell_raw_db,
-    etl_yell_raw_db_to_yell_agg_db,
-    etl_yell_raw_db_to_yell_raw_df,
-    etl_yell_agg_db_to_yell_agg_df,
-    etl_yell_raw_db_to_yell_agg_events_db,
-    etl_yell_agg_events_db_to_yell_valid_events_db,
-    etl_yell_agg_events_db_to_event_dict,
-    etl_yell_agg_non_pidgin_ideas_to_yell_valid,
-    etl_yell_pidgin_raw_df_to_pidgin_agg_df,
-    etl_yell_agg_df_to_yell_pidgin_raw_df,
-    etl_yell_pidgin_agg_df_to_otz_face_pidgin_agg_df,
+    etl_mud_df_to_brick_raw_db,
+    etl_brick_raw_db_to_brick_agg_db,
+    etl_brick_raw_db_to_brick_raw_df,
+    etl_brick_agg_db_to_brick_agg_df,
+    etl_brick_raw_db_to_brick_agg_events_db,
+    etl_brick_agg_events_db_to_brick_valid_events_db,
+    etl_brick_agg_events_db_to_event_dict,
+    etl_brick_agg_non_pidgin_ideas_to_brick_valid,
+    etl_brick_pidgin_raw_df_to_pidgin_agg_df,
+    etl_brick_agg_df_to_brick_pidgin_raw_df,
+    etl_brick_pidgin_agg_df_to_otz_face_pidgin_agg_df,
     etl_otz_face_pidgins_df_to_otz_event_pidgins_df,
     etl_otz_event_pidgins_to_otz_pidgin_csv_files,
     etl_otz_event_pidgins_csvs_to_otz_pidgin_jsons,
     etl_pidgin_jsons_inherit_younger_pidgins,
     get_pidgin_events_by_dirs,
-    etl_yell_ideas_to_otz_face_ideas,
+    etl_brick_ideas_to_otz_face_ideas,
     etl_otz_face_ideas_to_otz_event_otx_ideas,
     etl_otz_event_ideas_to_inz_events,
     etl_otz_inx_event_ideas_to_inz_faces,
@@ -75,7 +75,7 @@ class WorldUnit:
     _syntax_inz_dir: str = None
     _world_dir: str = None
     _mud_dir: str = None
-    _yell_dir: str = None
+    _brick_dir: str = None
     _fisc_mstr_dir: str = None
     _fiscunits: set[FiscTag] = None
     _events: dict[EventInt, FaceName] = None
@@ -105,40 +105,42 @@ class WorldUnit:
         self._world_dir = create_path(self.worlds_dir, self.world_id)
         self._syntax_otz_dir = create_path(self._world_dir, "syntax_otz")
         self._syntax_inz_dir = create_path(self._world_dir, "syntax_inz")
-        self._yell_dir = create_path(self._world_dir, "yell")
+        self._brick_dir = create_path(self._world_dir, "brick")
         self._fisc_mstr_dir = create_path(self._world_dir, "fisc_mstr")
         set_dir(self._world_dir)
         set_dir(self._syntax_otz_dir)
         set_dir(self._syntax_inz_dir)
-        set_dir(self._yell_dir)
+        set_dir(self._brick_dir)
         set_dir(self._fisc_mstr_dir)
 
     def get_timeconversions_dict(self) -> dict[TimeLineTag, TimeConversion]:
         return self.timeconversions
 
-    def mud_df_to_yell_raw_db(self, conn: sqlite3_Connection):
-        etl_mud_df_to_yell_raw_db(conn, self._mud_dir)
+    def mud_df_to_brick_raw_db(self, conn: sqlite3_Connection):
+        etl_mud_df_to_brick_raw_db(conn, self._mud_dir)
 
-    def yell_raw_db_to_yell_agg_df(
+    def brick_raw_db_to_brick_agg_df(
         self, conn: sqlite3_Connection, cursor: sqlite3_Cursor
     ):
-        etl_yell_raw_db_to_yell_agg_db(cursor)
-        etl_yell_agg_db_to_yell_agg_df(conn, self._yell_dir)
+        etl_brick_raw_db_to_brick_agg_db(cursor)
+        etl_brick_agg_db_to_brick_agg_df(conn, self._brick_dir)
 
-    def yell_agg_non_pidgin_ideas_to_yell_valid(self):
-        etl_yell_agg_non_pidgin_ideas_to_yell_valid(
-            self._yell_dir, set(self._events.keys())
+    def brick_agg_non_pidgin_ideas_to_brick_valid(self):
+        etl_brick_agg_non_pidgin_ideas_to_brick_valid(
+            self._brick_dir, set(self._events.keys())
         )
 
-    def yell_agg_df_to_yell_pidgin_raw_df(self):
-        etl_yell_agg_df_to_yell_pidgin_raw_df(set(self._events.keys()), self._yell_dir)
+    def brick_agg_df_to_brick_pidgin_raw_df(self):
+        etl_brick_agg_df_to_brick_pidgin_raw_df(
+            set(self._events.keys()), self._brick_dir
+        )
 
-    def yell_pidgin_raw_df_to_pidgin_agg_df(self):
-        etl_yell_pidgin_raw_df_to_pidgin_agg_df(self._yell_dir)
+    def brick_pidgin_raw_df_to_pidgin_agg_df(self):
+        etl_brick_pidgin_raw_df_to_pidgin_agg_df(self._brick_dir)
 
-    def yell_pidgin_agg_df_to_otz_face_pidgin_agg_df(self):
-        etl_yell_pidgin_agg_df_to_otz_face_pidgin_agg_df(
-            self._yell_dir, self._syntax_otz_dir
+    def brick_pidgin_agg_df_to_otz_face_pidgin_agg_df(self):
+        etl_brick_pidgin_agg_df_to_otz_face_pidgin_agg_df(
+            self._brick_dir, self._syntax_otz_dir
         )
 
     def pidgin_jsons_inherit_younger_pidgins(self):
@@ -156,8 +158,8 @@ class WorldUnit:
         etl_otz_event_pidgins_csvs_to_otz_pidgin_jsons(self._syntax_otz_dir)
         self._set_pidgin_events()
 
-    def yell_ideas_to_otz_face_ideas(self):
-        etl_yell_ideas_to_otz_face_ideas(self._yell_dir, self._syntax_otz_dir)
+    def brick_ideas_to_otz_face_ideas(self):
+        etl_brick_ideas_to_otz_face_ideas(self._brick_dir, self._syntax_otz_dir)
 
     def otz_face_ideas_to_otz_event_otx_ideas(self):
         etl_otz_face_ideas_to_otz_event_otx_ideas(self._syntax_otz_dir)
@@ -250,21 +252,21 @@ class WorldUnit:
 
             # collect excel file data into central location
             # grab all excel sheets that fit idea format
-            self.mud_df_to_yell_raw_db(db_conn)
+            self.mud_df_to_brick_raw_db(db_conn)
             # per idea filter to only non-conflicting idea data
-            self.yell_raw_db_to_yell_agg_df(db_conn, cursor)
+            self.brick_raw_db_to_brick_agg_df(db_conn, cursor)
 
             # identify all idea data that has conflicting face_name/event_int uniqueness
-            etl_yell_raw_db_to_yell_agg_events_db(cursor)
-            etl_yell_agg_events_db_to_yell_valid_events_db(cursor)
-            self._events = etl_yell_agg_events_db_to_event_dict(cursor)
+            etl_brick_raw_db_to_brick_agg_events_db(cursor)
+            etl_brick_agg_events_db_to_brick_valid_events_db(cursor)
+            self._events = etl_brick_agg_events_db_to_event_dict(cursor)
 
             # build pidgins
             # collect all pidgin data from all relevant valid ideas
-            self.yell_agg_df_to_yell_pidgin_raw_df()  # self._events.keys()
+            self.brick_agg_df_to_brick_pidgin_raw_df()  # self._events.keys()
             # per pidgin dimen filter to only non-conflicting pidgin data
-            self.yell_pidgin_raw_df_to_pidgin_agg_df()
-            self.yell_pidgin_agg_df_to_otz_face_pidgin_agg_df()
+            self.brick_pidgin_raw_df_to_pidgin_agg_df()
+            self.brick_pidgin_agg_df_to_otz_face_pidgin_agg_df()
             self.otz_face_pidgins_df_to_otz_event_pidgins_df()
             # per event create isolated pidgin.json
             self.otz_event_pidgins_csvs_to_otz_pidgin_jsons()  # self._pidgin_events
@@ -272,8 +274,8 @@ class WorldUnit:
             self.pidgin_jsons_inherit_younger_pidgins()  # self._pidgin_events
 
             # pidgins translate all fisc&bud ideas
-            self.yell_agg_non_pidgin_ideas_to_yell_valid()  # self._events.keys()
-            self.yell_ideas_to_otz_face_ideas()
+            self.brick_agg_non_pidgin_ideas_to_brick_valid()  # self._events.keys()
+            self.brick_ideas_to_otz_face_ideas()
             self.otz_face_ideas_to_otz_event_otx_ideas()
             self.otz_event_ideas_to_inz_events()  # self._pidgin_events
             self.otz_inx_event_ideas_to_inz_faces()
@@ -299,8 +301,8 @@ class WorldUnit:
             self.calc_fisc_deal_acct_mandate_net_ledgers()
 
             if store_tracing_files:
-                etl_yell_raw_db_to_yell_raw_df(db_conn, self._yell_dir)
-                # etl_yell_agg_db_to_yell_agg_df(db_conn, self._yell_dir)
+                etl_brick_raw_db_to_brick_raw_df(db_conn, self._brick_dir)
+                # etl_brick_agg_db_to_brick_agg_df(db_conn, self._brick_dir)
                 self.inz_faces_ideas_to_fisc_mstr_csvs(cursor)
 
     def create_stances(self):

--- a/src/a19_world_logic/world.py
+++ b/src/a19_world_logic/world.py
@@ -238,7 +238,7 @@ class WorldUnit:
         etl_set_cell_tree_cell_mandates(mstr_dir)
         etl_create_deal_mandate_ledgers(mstr_dir)
 
-    def mud_to_standings(
+    def mud_to_stances(
         self, store_tracing_files: bool = False
     ):  # sourcery skip: extract-method
         fisc_mstr_dir = create_path(self._world_dir, "fisc_mstr")

--- a/src/a19_world_logic/world.py
+++ b/src/a19_world_logic/world.py
@@ -251,7 +251,7 @@ class WorldUnit:
             # collect excel file data into central location
             # grab all excel sheets that fit idea format
             self.mud_df_to_yell_raw_db(db_conn)
-            # per idea brick filter to only non-conflicting idea data
+            # per idea filter to only non-conflicting idea data
             self.yell_raw_db_to_yell_agg_df(db_conn, cursor)
 
             # identify all idea data that has conflicting face_name/event_int uniqueness
@@ -260,7 +260,7 @@ class WorldUnit:
             self._events = etl_yell_agg_events_db_to_event_dict(cursor)
 
             # build pidgins
-            # collect all pidgin data from all relevant valid idea bricks
+            # collect all pidgin data from all relevant valid ideas
             self.yell_agg_df_to_yell_pidgin_raw_df()  # self._events.keys()
             # per pidgin dimen filter to only non-conflicting pidgin data
             self.yell_pidgin_raw_df_to_pidgin_agg_df()

--- a/src/a19_world_logic/world.py
+++ b/src/a19_world_logic/world.py
@@ -15,7 +15,7 @@ from src.a01_word_logic.road import (
 from src.a15_fisc_logic.fisc import FiscUnit
 from src.a18_etl_toolbox.stance_tool import create_stance0001_file
 from src.a18_etl_toolbox.transformers import (
-    etl_sound_df_to_yell_raw_db,
+    etl_mud_df_to_yell_raw_db,
     etl_yell_raw_db_to_yell_agg_db,
     etl_yell_raw_db_to_yell_raw_df,
     etl_yell_agg_db_to_yell_agg_df,
@@ -74,7 +74,7 @@ class WorldUnit:
     _syntax_otz_dir: str = None
     _syntax_inz_dir: str = None
     _world_dir: str = None
-    _sound_dir: str = None
+    _mud_dir: str = None
     _yell_dir: str = None
     _fisc_mstr_dir: str = None
     _fiscunits: set[FiscTag] = None
@@ -97,9 +97,9 @@ class WorldUnit:
     def _set_pidgin_events(self):
         self._pidgin_events = get_pidgin_events_by_dirs(self._syntax_otz_dir)
 
-    def set_sound_dir(self, x_dir: str):
-        self._sound_dir = x_dir
-        set_dir(self._sound_dir)
+    def set_mud_dir(self, x_dir: str):
+        self._mud_dir = x_dir
+        set_dir(self._mud_dir)
 
     def _set_world_dirs(self):
         self._world_dir = create_path(self.worlds_dir, self.world_id)
@@ -116,8 +116,8 @@ class WorldUnit:
     def get_timeconversions_dict(self) -> dict[TimeLineTag, TimeConversion]:
         return self.timeconversions
 
-    def sound_df_to_yell_raw_db(self, conn: sqlite3_Connection):
-        etl_sound_df_to_yell_raw_db(conn, self._sound_dir)
+    def mud_df_to_yell_raw_db(self, conn: sqlite3_Connection):
+        etl_mud_df_to_yell_raw_db(conn, self._mud_dir)
 
     def yell_raw_db_to_yell_agg_df(
         self, conn: sqlite3_Connection, cursor: sqlite3_Cursor
@@ -238,7 +238,7 @@ class WorldUnit:
         etl_set_cell_tree_cell_mandates(mstr_dir)
         etl_create_deal_mandate_ledgers(mstr_dir)
 
-    def sound_to_standings(
+    def mud_to_standings(
         self, store_tracing_files: bool = False
     ):  # sourcery skip: extract-method
         fisc_mstr_dir = create_path(self._world_dir, "fisc_mstr")
@@ -250,7 +250,7 @@ class WorldUnit:
 
             # collect excel file data into central location
             # grab all excel sheets that fit idea format
-            self.sound_df_to_yell_raw_db(db_conn)
+            self.mud_df_to_yell_raw_db(db_conn)
             # per idea brick filter to only non-conflicting idea data
             self.yell_raw_db_to_yell_agg_df(db_conn, cursor)
 
@@ -317,7 +317,7 @@ class WorldUnit:
 def worldunit_shop(
     world_id: WorldID,
     worlds_dir: str,
-    sound_dir: str = None,
+    mud_dir: str = None,
     world_time_nigh: TimeLinePoint = None,
     timeconversions: dict[TimeLineTag, TimeConversion] = None,
     _fiscunits: set[FiscTag] = None,
@@ -329,12 +329,12 @@ def worldunit_shop(
         timeconversions=get_empty_dict_if_None(timeconversions),
         _events={},
         _fiscunits=get_empty_set_if_None(_fiscunits),
-        _sound_dir=sound_dir,
+        _mud_dir=mud_dir,
         _pidgin_events={},
     )
     x_worldunit._set_world_dirs()
-    if not x_worldunit._sound_dir:
-        x_worldunit.set_sound_dir(create_path(x_worldunit._world_dir, "sound"))
+    if not x_worldunit._mud_dir:
+        x_worldunit.set_mud_dir(create_path(x_worldunit._world_dir, "mud"))
     return x_worldunit
 
 


### PR DESCRIPTION
## Summary by Sourcery

Rename 'yell' terminology to 'brick' across the project to improve clarity and consistency in naming conventions

New Features:
- Introduced 'brick' as a new terminology to replace 'yell' in various function and variable names

Enhancements:
- Systematically replaced 'yell' with 'brick' in function names, variable names, and file paths
- Updated test cases to reflect new naming convention