### PR TITLE
175 enable documentation process

### DIFF
--- a/src/a17_creed_logic/test_creed_db_tool/test_pandas_tool_sheet.py
+++ b/src/a17_creed_logic/test_creed_db_tool/test_pandas_tool_sheet.py
@@ -523,7 +523,7 @@ def test_update_all_face_name_event_int_columns_Scenario0_UpdatesValidSheet(
     for _ in range(5):
         ws1.append([event3, yao_str, "value4"])
 
-    ws2 = workbook.create_sheet(title=invalidsheet_str)
+    ws2 = workbook.create_sheet(invalidsheet_str)
     ws2.append(["wrong", "headers", "data"])
     for _ in range(5):
         ws2.append([event3, yao_str, "value3"])

--- a/src/a18_etl_toolbox/test_tran/test_sound_agg_tables2voice_raw_tables.py
+++ b/src/a18_etl_toolbox/test_tran/test_sound_agg_tables2voice_raw_tables.py
@@ -88,7 +88,7 @@ FROM {budawar_v_raw_put_tablename}
         ]
 
 
-def test_etl_sound_agg_tables_to_voice_raw_tables_PopulatesTable_Scenario0():
+def test_etl_sound_agg_tables_to_voice_raw_tables_Scenario0_AddRowsToTable():
     # ESTABLISH
     a23_str = "accord23"
     bob_str = "Bob"
@@ -150,6 +150,73 @@ FROM {budacct_v_raw_put_tablename}
         print(rows)
         assert rows == [
             (1, sue_str, a23_str, yao_str, yao_inx, 44.0, 22.0),
+            (2, yao_str, a23_str, bob_str, bob_str, 55.0, 22.0),
+            (5, sue_str, a23_str, bob_str, bob_str, 55.0, 22.0),
+            (7, bob_str, a23_str, bob_str, bob_str, 55.0, 66.0),
+        ]
+
+
+def test_etl_sound_agg_tables_to_voice_raw_tables_Scenario1_Populates_inx_Columns():
+    # ESTABLISH
+    a23_str = "accord23"
+    bob_str = "Bob"
+    sue_str = "Sue"
+    yao_str = "Yao"
+    event1 = 1
+    event2 = 2
+    event5 = 5
+    event7 = 7
+    x44_credit = 44
+    x55_credit = 55
+    x22_debtit = 22
+    x66_debtit = 66
+
+    with sqlite3_connect(":memory:") as db_conn:
+        cursor = db_conn.cursor()
+        create_sound_and_voice_tables(cursor)
+        budacct_s_agg_put_tablename = prime_tbl(bud_acctunit_str(), "s", "agg", "put")
+        print(f"{get_table_columns(cursor, budacct_s_agg_put_tablename)=}")
+        insert_into_clause = f"""INSERT INTO {budacct_s_agg_put_tablename} (
+  {event_int_str()}
+, {face_name_str()}
+, {fisc_word_str()}
+, {owner_name_str()}
+, {acct_name_str()}
+, {credit_belief_str()}
+, {debtit_belief_str()}
+)"""
+        values_clause = f"""
+VALUES
+  ({event1}, '{sue_str}', '{a23_str}','{yao_str}', '{yao_str}', {x44_credit}, {x22_debtit})
+, ({event2}, '{yao_str}', '{a23_str}','{bob_str}', '{bob_str}', {x55_credit}, {x22_debtit})
+, ({event5}, '{sue_str}', '{a23_str}','{bob_str}', '{bob_str}', {x55_credit}, {x22_debtit})
+, ({event7}, '{bob_str}', '{a23_str}','{bob_str}', '{bob_str}', {x55_credit}, {x66_debtit})
+;
+"""
+        cursor.execute(f"{insert_into_clause} {values_clause}")
+        assert get_row_count(cursor, budacct_s_agg_put_tablename) == 4
+        budacct_v_raw_put_tablename = prime_tbl(bud_acctunit_str(), "v", "raw", "put")
+        assert get_row_count(cursor, budacct_v_raw_put_tablename) == 0
+
+        # WHEN
+        etl_sound_agg_tables_to_voice_raw_tables(cursor)
+
+        # THEN
+        assert get_row_count(cursor, budacct_v_raw_put_tablename) == 4
+        select_sqlstr = f"""SELECT {event_int_str()}
+, {face_name_str()}_inx
+, {fisc_word_str()}_inx
+, {owner_name_str()}_inx
+, {acct_name_str()}_inx
+, {credit_belief_str()}
+, {debtit_belief_str()}
+FROM {budacct_v_raw_put_tablename}
+"""
+        cursor.execute(select_sqlstr)
+        rows = cursor.fetchall()
+        print(rows)
+        assert rows == [
+            (1, sue_str, a23_str, yao_str, yao_str, 44.0, 22.0),
             (2, yao_str, a23_str, bob_str, bob_str, 55.0, 22.0),
             (5, sue_str, a23_str, bob_str, bob_str, 55.0, 22.0),
             (7, bob_str, a23_str, bob_str, bob_str, 55.0, 66.0),

--- a/src/a18_etl_toolbox/test_tran/test_voice_raw_tables_pidgin_updates.py
+++ b/src/a18_etl_toolbox/test_tran/test_voice_raw_tables_pidgin_updates.py
@@ -47,6 +47,7 @@ from src.a18_etl_toolbox.tran_sqlstrs import (
     create_pidname_face_otx_event_sqlstr,
     create_pidlabe_face_otx_event_sqlstr,
     create_pidword_face_otx_event_sqlstr,
+    create_pidwayy_face_otx_event_sqlstr,
 )
 from sqlite3 import connect as sqlite3_connect
 
@@ -222,7 +223,7 @@ def test_create_pidword_face_otx_event_sqlstr_ReturnsObj_Scenario0_WordStr():
 
         # THEN
         static_select_pidword_sqlstr = """
-SELECT 
+SELECT
   raw_dim.rowid raw_rowid
 , raw_dim.event_int
 , raw_dim.face_name_otx
@@ -232,7 +233,7 @@ FROM fisc_timeline_hour_v_raw raw_dim
 LEFT JOIN pidgin_word_s_vld pid ON pid.face_name = raw_dim.face_name_otx
     AND pid.otx_word = raw_dim.hour_word_otx
     AND raw_dim.event_int >= pid.event_int
-GROUP BY 
+GROUP BY
   raw_dim.rowid
 , raw_dim.event_int
 , raw_dim.face_name_otx
@@ -257,106 +258,108 @@ GROUP BY
         ]
 
 
-# # TODO reactivate thie test changed to wayunit
-# def test_create_pidword_face_otx_event_sqlstr_ReturnsObj_Scenario0_WordStr():
-#     # ESTABLISH
-#     bob_otx = "Bob"
-#     yao_otx = "Yao"
-#     zia_otx = "Zia"
-#     hr7_otx = "hr7"
-#     hr7_inx = "Casita"
-#     bob_hr7_inx = ";bob_hr7Inx"
-#     hr8_otx = "hr8ts"
-#     hr8_inx1 = "hr8_v1"
-#     hr8_inx7 = "hr8_v7"
-#     hr2_otx = "hr2_v1"
-#     hr2_inx = "hr2_v2"
-#     event0 = 0
-#     event1 = 1
-#     event2 = 2
-#     event5 = 5
-#     event7 = 7
-#     event8 = 8
-#     event9 = 9
+def test_create_pidwayy_face_otx_event_sqlstr_ReturnsObj_Scenario0_WayStr():
+    # ESTABLISH
+    bob_otx = "Bob"
+    yao_otx = "Yao"
+    zia_otx = "Zia"
+    casa_way_otx = create_way("casa")
+    clean_way_otx = create_way(casa_way_otx, "clean")
+    dirty_way_otx = create_way(casa_way_otx, "dirty")
+    casa_way_inx = create_way("casita")
+    clean_way_inx1 = create_way(casa_way_inx, "clean1")
+    clean_way_inx7 = create_way(casa_way_inx, "clean7")
+    dirty_way_inx = create_way(casa_way_inx, "dirty")
+    sport_way_otx = create_way("sport")
+    bball_way_otx = create_way(sport_way_otx, "bball")
+    sport_way_inx = create_way("sport")
+    bball_way_inx = create_way(sport_way_otx, "basketball")
+    event0 = 0
+    event1 = 1
+    event2 = 2
+    event5 = 5
+    event7 = 7
+    event8 = 8
+    event9 = 9
 
-#     with sqlite3_connect(":memory:") as db_conn:
-#         cursor = db_conn.cursor()
-#         create_sound_and_voice_tables(cursor)
-#         fishour_dimen = fisc_timeline_hour_str()
-#         fishour_v_raw_tablename = prime_tbl(fishour_dimen, "v", "raw")
-#         print(f"{get_table_columns(cursor, fishour_v_raw_tablename)=}")
-#         insert_sqlstr = f"""INSERT INTO {fishour_v_raw_tablename}
-#         ({event_int_str()}, {face_name_str()}_otx, {hour_word_str()}_otx, {hour_word_str()}_inx)
-#         VALUES
-#           ({event0}, '{bob_otx}', '{hr8_otx}', NULL)
-#         , ({event1}, '{bob_otx}', '{hr8_otx}', NULL)
-#         , ({event2}, '{yao_otx}', '{hr2_otx}', NULL)
-#         , ({event5}, '{bob_otx}', '{hr8_otx}', NULL)
-#         , ({event7}, '{bob_otx}', '{hr8_otx}', NULL)
-#         , ({event9}, '{bob_otx}', '{hr8_otx}', NULL)
-#         ;
-#         """
-#         cursor.execute(insert_sqlstr)
+    with sqlite3_connect(":memory:") as db_conn:
+        cursor = db_conn.cursor()
+        create_sound_and_voice_tables(cursor)
+        budawar_put_dimen = bud_idea_awardlink_str()
+        budawar_put_v_raw_tablename = prime_tbl(budawar_put_dimen, "v", "raw", "put")
+        print(f"{get_table_columns(cursor, budawar_put_v_raw_tablename)=}")
+        insert_sqlstr = f"""INSERT INTO {budawar_put_v_raw_tablename}
+        ({event_int_str()}, {face_name_str()}_otx, {idea_way_str()}_otx, {idea_way_str()}_inx)
+        VALUES
+          ({event0}, '{bob_otx}', '{clean_way_otx}', NULL)
+        , ({event1}, '{bob_otx}', '{clean_way_otx}', NULL)
+        , ({event2}, '{yao_otx}', '{bball_way_otx}', NULL)
+        , ({event5}, '{bob_otx}', '{clean_way_otx}', NULL)
+        , ({event7}, '{bob_otx}', '{clean_way_otx}', NULL)
+        , ({event9}, '{bob_otx}', '{clean_way_otx}', NULL)
+        ;
+        """
+        cursor.execute(insert_sqlstr)
 
-#         pidword_dimen = pidgin_word_str()
-#         pidword_s_vld_tablename = prime_tbl(pidword_dimen, "s", "vld")
-#         # print(f"{pidword_s_vld_tablename=}")
-#         insert_pidword_sqlstr = f"""INSERT INTO {pidword_s_vld_tablename}
-#         ({event_int_str()}, {face_name_str()}, {otx_word_str()}, {inx_word_str()})
-#         VALUES
-#           ({event1}, '{bob_otx}', '{hr8_otx}', '{hr8_inx1}')
-#         , ({event2}, '{yao_otx}', '{hr2_otx}', '{hr2_inx}')
-#         , ({event7}, '{bob_otx}', '{hr8_otx}', '{hr8_inx7}')
-#         , ({event7}, '{bob_otx}', '{hr7_otx}', '{bob_hr7_inx}')
-#         , ({event8}, '{zia_otx}', '{hr7_otx}', '{hr7_inx}')
-#         ;
-#         """
-#         cursor.execute(insert_pidword_sqlstr)
+        pidwayy_dimen = pidgin_word_str()
+        pidwayy_s_vld_tablename = prime_tbl(pidwayy_dimen, "s", "vld")
+        # print(f"{pidwayy_s_vld_tablename=}")
+        insert_pidwayy_sqlstr = f"""INSERT INTO {pidwayy_s_vld_tablename}
+        ({event_int_str()}, {face_name_str()}, {otx_word_str()}, {inx_word_str()})
+        VALUES
+          ({event1}, '{bob_otx}', '{clean_way_otx}', '{clean_way_inx1}')
+        , ({event2}, '{yao_otx}', '{bball_way_otx}', '{bball_way_inx}')
+        , ({event7}, '{bob_otx}', '{bball_way_otx}', '{bball_way_inx}')
+        , ({event7}, '{bob_otx}', '{clean_way_otx}', '{clean_way_inx7}')
+        , ({event8}, '{zia_otx}', '{dirty_way_otx}', '{dirty_way_inx}')
+        ;
+        """
+        cursor.execute(insert_pidwayy_sqlstr)
 
-#         face_name_inx_count_sql = f"SELECT COUNT(*) FROM {fishour_v_raw_tablename} WHERE {face_name_str()}_inx IS NOT NULL"
-#         assert cursor.execute(face_name_inx_count_sql).fetchone()[0] == 0
+        face_name_inx_count_sql = f"SELECT COUNT(*) FROM {budawar_put_v_raw_tablename} WHERE {face_name_str()}_inx IS NOT NULL"
+        assert cursor.execute(face_name_inx_count_sql).fetchone()[0] == 0
 
-#         # WHEN
-#         pidname_face_otx_event_sqlstr = create_pidword_face_otx_event_sqlstr(
-#             fishour_v_raw_tablename, hour_word_str()
-#         )
-#         cursor.execute(pidname_face_otx_event_sqlstr)
+        # WHEN
+        pidname_face_otx_event_sqlstr = create_pidwayy_face_otx_event_sqlstr(
+            budawar_put_v_raw_tablename, idea_way_str()
+        )
+        cursor.execute(pidname_face_otx_event_sqlstr)
 
-#         # THEN
-#         static_select_pidword_sqlstr = """
-# SELECT
-#   raw_dim.rowid raw_rowid
-# , raw_dim.event_int
-# , raw_dim.face_name_otx
-# , raw_dim.hour_word_otx
-# , MAX(pid.event_int) pidgin_event_int
-# FROM fisc_timeline_hour_v_raw raw_dim
-# LEFT JOIN pidgin_word_s_vld pid ON pid.face_name = raw_dim.face_name_otx
-#     AND pid.otx_word = raw_dim.hour_word_otx
-#     AND raw_dim.event_int >= pid.event_int
-# GROUP BY
-#   raw_dim.rowid
-# , raw_dim.event_int
-# , raw_dim.face_name_otx
-# , raw_dim.hour_word_otx
-# """
+        # THEN
+        static_select_pidwayy_sqlstr = """
+SELECT
+  raw_dim.rowid raw_rowid
+, raw_dim.event_int
+, raw_dim.face_name_otx
+, raw_dim.idea_way_otx
+, MAX(pid.event_int) pidgin_event_int
+FROM bud_idea_awardlink_v_put_raw raw_dim
+LEFT JOIN pidgin_word_s_vld pid ON pid.face_name = raw_dim.face_name_otx
+    AND pid.otx_word = raw_dim.idea_way_otx
+    AND raw_dim.event_int >= pid.event_int
+GROUP BY
+  raw_dim.rowid
+, raw_dim.event_int
+, raw_dim.face_name_otx
+, raw_dim.idea_way_otx
+"""
 
-#         print(pidname_face_otx_event_sqlstr)
-#         print("")
-#         # print(static_select_pidword_sqlstr)
-#         assert static_select_pidword_sqlstr == pidname_face_otx_event_sqlstr
-#         cursor.execute(static_select_pidword_sqlstr)
-#         rows = cursor.fetchall()
-#         print(rows)
-#         # event5 does not link to event7 pidgin record's
-#         assert rows == [
-#             (1, event0, bob_otx, hr8_otx, None),
-#             (2, event1, bob_otx, hr8_otx, event1),
-#             (3, event2, yao_otx, hr2_otx, event2),
-#             (4, event5, bob_otx, hr8_otx, event1),
-#             (5, event7, bob_otx, hr8_otx, event7),
-#             (6, event9, bob_otx, hr8_otx, event7),
-#         ]
+        print(pidname_face_otx_event_sqlstr)
+        print("")
+        # print(static_select_pidwayy_sqlstr)
+        assert static_select_pidwayy_sqlstr == pidname_face_otx_event_sqlstr
+        cursor.execute(static_select_pidwayy_sqlstr)
+        rows = cursor.fetchall()
+        print(rows)
+        # event5 does not link to event7 pidgin record's
+        assert rows == [
+            (1, event0, bob_otx, clean_way_otx, None),
+            (2, event1, bob_otx, clean_way_otx, event1),
+            (3, event2, yao_otx, bball_way_otx, event2),
+            (4, event5, bob_otx, clean_way_otx, event1),
+            (5, event7, bob_otx, clean_way_otx, event7),
+            (6, event9, bob_otx, clean_way_otx, event7),
+        ]
 
 
 def test_create_pidname_face_otx_event_sqlstr_ReturnsObj_Scenario20_NameStr():

--- a/src/a18_etl_toolbox/test_tran/test_voice_raw_tables_pidgin_updates.py
+++ b/src/a18_etl_toolbox/test_tran/test_voice_raw_tables_pidgin_updates.py
@@ -43,7 +43,7 @@ from src.a16_pidgin_logic._utils.str_a16 import (
 from src.a18_etl_toolbox.tran_sqlstrs import (
     create_prime_tablename as prime_tbl,
     create_sound_and_voice_tables,
-    update_voice_raw_inx_name_col_sqlstr,
+    create_update_voice_raw_existing_inx_col_sqlstr,
     create_pidname_face_otx_event_sqlstr,
     create_pidlabe_face_otx_event_sqlstr,
     create_pidword_face_otx_event_sqlstr,
@@ -560,7 +560,7 @@ GROUP BY
         ]
 
 
-def test_update_voice_raw_inx_name_col_sqlstr_UpdatesTable_Scenario0_EmptyPidginTables():
+def test_create_update_voice_raw_existing_inx_col_sqlstr_UpdatesTable_Scenario0_EmptyPidginTables():
     # ESTABLISH
     bob_otx = "Bob"
     bob_inx = "Bobby"
@@ -595,8 +595,8 @@ VALUES
         assert cursor.execute(face_name_inx_count_sql).fetchone()[0] == 0
 
         # WHEN
-        update_sqlstr = update_voice_raw_inx_name_col_sqlstr(
-            budawar_v_raw_put_tablename, face_name_str()
+        update_sqlstr = create_update_voice_raw_existing_inx_col_sqlstr(
+            "name", budawar_v_raw_put_tablename, face_name_str()
         )
         print(update_sqlstr)
         cursor.execute(update_sqlstr)
@@ -615,7 +615,7 @@ VALUES
         ]
 
 
-def test_update_voice_raw_inx_name_col_sqlstr_UpdatesTable_Scenario1_FullPidginTables():
+def test_create_update_voice_raw_existing_inx_col_sqlstr_UpdatesTable_Scenario1_FullPidginTables():
     # ESTABLISH
     bob_otx = "Bob"
     bob_inx = "Bobby"
@@ -660,8 +660,8 @@ def test_update_voice_raw_inx_name_col_sqlstr_UpdatesTable_Scenario1_FullPidginT
         assert cursor.execute(face_name_inx_count_sql).fetchone()[0] == 0
 
         # WHEN
-        update_sqlstr = update_voice_raw_inx_name_col_sqlstr(
-            budawar_v_raw_put_tablename, face_name_str()
+        update_sqlstr = create_update_voice_raw_existing_inx_col_sqlstr(
+            "name", budawar_v_raw_put_tablename, face_name_str()
         )
         print(update_sqlstr)
         cursor.execute(update_sqlstr)
@@ -680,7 +680,7 @@ def test_update_voice_raw_inx_name_col_sqlstr_UpdatesTable_Scenario1_FullPidginT
         ]
 
 
-def test_update_voice_raw_inx_name_col_sqlstr_UpdatesTable_Scenario2_PartialPidginTables():
+def test_create_update_voice_raw_existing_inx_col_sqlstr_UpdatesTable_Scenario2_PartialPidginTables():
     # ESTABLISH
     bob_otx = "Bob"
     bob_inx = "Bobby"
@@ -722,8 +722,8 @@ def test_update_voice_raw_inx_name_col_sqlstr_UpdatesTable_Scenario2_PartialPidg
         assert cursor.execute(face_name_inx_count_sql).fetchone()[0] == 0
 
         # WHEN
-        update_sqlstr = update_voice_raw_inx_name_col_sqlstr(
-            budawar_v_raw_put_tablename, face_name_str()
+        update_sqlstr = create_update_voice_raw_existing_inx_col_sqlstr(
+            "name", budawar_v_raw_put_tablename, face_name_str()
         )
         print(update_sqlstr)
         cursor.execute(update_sqlstr)
@@ -741,7 +741,7 @@ def test_update_voice_raw_inx_name_col_sqlstr_UpdatesTable_Scenario2_PartialPidg
         ]
 
 
-def test_update_voice_raw_inx_name_col_sqlstr_UpdatesTable_Scenario3_Different_event_int_PidginMappings():
+def test_create_update_voice_raw_existing_inx_col_sqlstr_UpdatesTable_Scenario3_Different_event_int_PidginMappings():
     # ESTABLISH
     sue_otx = "Sue"
     sue_inx = "Suzy"
@@ -797,8 +797,8 @@ def test_update_voice_raw_inx_name_col_sqlstr_UpdatesTable_Scenario3_Different_e
         assert cursor.execute(face_name_inx_count_sql).fetchone()[0] == 0
 
         # WHEN
-        update_sqlstr = update_voice_raw_inx_name_col_sqlstr(
-            budawar_v_raw_put_tablename, face_name_str()
+        update_sqlstr = create_update_voice_raw_existing_inx_col_sqlstr(
+            "name", budawar_v_raw_put_tablename, face_name_str()
         )
         print(update_sqlstr)
         cursor.execute(update_sqlstr)
@@ -819,7 +819,7 @@ def test_update_voice_raw_inx_name_col_sqlstr_UpdatesTable_Scenario3_Different_e
         ]
 
 
-# def test_update_voice_raw_inx_name_col_sqlstr_UpdatesTable_Scenario11_():
+# def test_create_update_voice_raw_existing_inx_col_sqlstr_UpdatesTable_Scenario11_():
 #     # ESTABLISH
 #     a23_str = "accord23"
 #     bob_otx = "Bob"
@@ -883,7 +883,7 @@ def test_update_voice_raw_inx_name_col_sqlstr_UpdatesTable_Scenario3_Different_e
 #         assert cursor.execute(awardee_label_inx_count_sql).fetchone() == (0,)
 
 #         # WHEN
-#         update_sqlstr = update_voice_raw_inx_name_col_sqlstr(
+#         update_sqlstr = create_update_voice_raw_existing_inx_col_sqlstr(
 #             budawar_v_raw_put_tablename, face_name_str()
 #         )
 #         print(update_sqlstr)

--- a/src/a18_etl_toolbox/test_tran/test_voice_raw_tables_pidgin_updates.py
+++ b/src/a18_etl_toolbox/test_tran/test_voice_raw_tables_pidgin_updates.py
@@ -122,7 +122,7 @@ def test_create_pidlabe_face_otx_event_sqlstr_ReturnsObj_Scenario0_LabelStr():
 
         # THEN
         static_select_pidlabe_sqlstr = """
-SELECT 
+SELECT
   raw_dim.rowid raw_rowid
 , raw_dim.event_int
 , raw_dim.face_name_otx
@@ -132,7 +132,7 @@ FROM bud_idea_awardlink_v_put_raw raw_dim
 LEFT JOIN pidgin_label_s_vld pid ON pid.face_name = raw_dim.face_name_otx
     AND pid.otx_label = raw_dim.awardee_label_otx
     AND raw_dim.event_int >= pid.event_int
-GROUP BY 
+GROUP BY
   raw_dim.rowid
 , raw_dim.event_int
 , raw_dim.face_name_otx
@@ -301,11 +301,11 @@ def test_create_pidwayy_face_otx_event_sqlstr_ReturnsObj_Scenario0_WayStr():
         """
         cursor.execute(insert_sqlstr)
 
-        pidwayy_dimen = pidgin_word_str()
+        pidwayy_dimen = pidgin_way_str()
         pidwayy_s_vld_tablename = prime_tbl(pidwayy_dimen, "s", "vld")
         # print(f"{pidwayy_s_vld_tablename=}")
         insert_pidwayy_sqlstr = f"""INSERT INTO {pidwayy_s_vld_tablename}
-        ({event_int_str()}, {face_name_str()}, {otx_word_str()}, {inx_word_str()})
+        ({event_int_str()}, {face_name_str()}, {otx_way_str()}, {inx_way_str()})
         VALUES
           ({event1}, '{bob_otx}', '{clean_way_otx}', '{clean_way_inx1}')
         , ({event2}, '{yao_otx}', '{bball_way_otx}', '{bball_way_inx}')
@@ -334,8 +334,8 @@ SELECT
 , raw_dim.idea_way_otx
 , MAX(pid.event_int) pidgin_event_int
 FROM bud_idea_awardlink_v_put_raw raw_dim
-LEFT JOIN pidgin_word_s_vld pid ON pid.face_name = raw_dim.face_name_otx
-    AND pid.otx_word = raw_dim.idea_way_otx
+LEFT JOIN pidgin_way_s_vld pid ON pid.face_name = raw_dim.face_name_otx
+    AND pid.otx_way = raw_dim.idea_way_otx
     AND raw_dim.event_int >= pid.event_int
 GROUP BY
   raw_dim.rowid
@@ -362,7 +362,7 @@ GROUP BY
         ]
 
 
-def test_create_pidname_face_otx_event_sqlstr_ReturnsObj_Scenario20_NameStr():
+def test_create_pidname_face_otx_event_sqlstr_ReturnsObj_Scenario2_NameStr():
     # ESTABLISH
     sue_otx = "Sue"
     sue_inx = "Suzy"
@@ -425,7 +425,7 @@ def test_create_pidname_face_otx_event_sqlstr_ReturnsObj_Scenario20_NameStr():
 
         # THEN
         select_pidname_face_otx_event_sqlstr = """
-SELECT 
+SELECT
   raw_dim.rowid raw_rowid
 , raw_dim.event_int
 , raw_dim.face_name_otx
@@ -435,7 +435,7 @@ FROM bud_idea_awardlink_v_put_raw raw_dim
 LEFT JOIN pidgin_name_s_vld pid ON pid.face_name = raw_dim.face_name_otx
     AND pid.otx_name = raw_dim.face_name_otx
     AND raw_dim.event_int >= pid.event_int
-GROUP BY 
+GROUP BY
   raw_dim.rowid
 , raw_dim.event_int
 , raw_dim.face_name_otx
@@ -525,7 +525,7 @@ def test_create_pidname_face_otx_event_sqlstr_ReturnsObj_Scenario1_SelectsMostRe
 
         # THEN
         select_pidname_face_otx_event_sqlstr = """
-SELECT 
+SELECT
   raw_dim.rowid raw_rowid
 , raw_dim.event_int
 , raw_dim.face_name_otx
@@ -535,7 +535,7 @@ FROM bud_idea_awardlink_v_put_raw raw_dim
 LEFT JOIN pidgin_name_s_vld pid ON pid.face_name = raw_dim.face_name_otx
     AND pid.otx_name = raw_dim.owner_name_otx
     AND raw_dim.event_int >= pid.event_int
-GROUP BY 
+GROUP BY
   raw_dim.rowid
 , raw_dim.event_int
 , raw_dim.face_name_otx

--- a/src/a18_etl_toolbox/test_tran/test_voice_raw_tables_pidgin_updates.py
+++ b/src/a18_etl_toolbox/test_tran/test_voice_raw_tables_pidgin_updates.py
@@ -48,7 +48,9 @@ from src.a18_etl_toolbox.tran_sqlstrs import (
     create_pidlabe_face_otx_event_sqlstr,
     create_pidword_face_otx_event_sqlstr,
     create_pidwayy_face_otx_event_sqlstr,
+    create_update_voice_raw_empty_inx_col_sqlstr,
 )
+from src.a18_etl_toolbox.transformers import set_all_voice_raw_inx_columns
 from sqlite3 import connect as sqlite3_connect
 
 
@@ -560,62 +562,7 @@ GROUP BY
         ]
 
 
-def test_create_update_voice_raw_existing_inx_col_sqlstr_UpdatesTable_Scenario0_EmptyPidginTables():
-    # ESTABLISH
-    bob_otx = "Bob"
-    bob_inx = "Bobby"
-    sue_otx = "Sue"
-    sue_inx = "Suzy"
-    yao_otx = "Yao"
-    event1 = 1
-    event2 = 2
-    event5 = 5
-    event7 = 7
-
-    with sqlite3_connect(":memory:") as db_conn:
-        cursor = db_conn.cursor()
-        create_sound_and_voice_tables(cursor)
-        pidname_s_vld_tablename = prime_tbl(pidgin_name_str(), "s", "vld")
-        print(f"{pidname_s_vld_tablename=}")
-        print(f"{get_table_columns(cursor, pidname_s_vld_tablename)=}")
-
-        budawar_dimen = bud_idea_awardlink_str()
-        budawar_v_raw_put_tablename = prime_tbl(budawar_dimen, "v", "raw", "put")
-        print(f"{get_table_columns(cursor, budawar_v_raw_put_tablename)=}")
-        insert_face_name_only_sqlstr = f"""INSERT INTO {budawar_v_raw_put_tablename} ({event_int_str()}, {face_name_str()}_otx, {face_name_str()}_inx)
-VALUES
-  ({event1}, '{sue_otx}', NULL)
-, ({event2}, '{yao_otx}', NULL)
-, ({event5}, '{sue_otx}', NULL)
-, ({event7}, '{bob_otx}', NULL)
-;
-"""
-        cursor.execute(insert_face_name_only_sqlstr)
-        face_name_inx_count_sql = f"SELECT COUNT(*) FROM {budawar_v_raw_put_tablename} WHERE {face_name_str()}_inx IS NOT NULL"
-        assert cursor.execute(face_name_inx_count_sql).fetchone()[0] == 0
-
-        # WHEN
-        update_sqlstr = create_update_voice_raw_existing_inx_col_sqlstr(
-            "name", budawar_v_raw_put_tablename, face_name_str()
-        )
-        print(update_sqlstr)
-        cursor.execute(update_sqlstr)
-
-        # THEN
-        assert cursor.execute(face_name_inx_count_sql).fetchone()[0] == 4
-        select_face_name_only_sqlstr = f"""SELECT {event_int_str()}, {face_name_str()}_otx, {face_name_str()}_inx FROM {budawar_v_raw_put_tablename}"""
-        cursor.execute(select_face_name_only_sqlstr)
-        rows = cursor.fetchall()
-        print(rows)
-        assert rows == [
-            (1, sue_otx, sue_otx),
-            (2, yao_otx, yao_otx),
-            (5, sue_otx, sue_otx),
-            (7, bob_otx, bob_otx),
-        ]
-
-
-def test_create_update_voice_raw_existing_inx_col_sqlstr_UpdatesTable_Scenario1_FullPidginTables():
+def test_create_update_voice_raw_existing_inx_col_sqlstr_UpdatesTable_Scenario0_FullPidginTables():
     # ESTABLISH
     bob_otx = "Bob"
     bob_inx = "Bobby"
@@ -667,20 +614,20 @@ def test_create_update_voice_raw_existing_inx_col_sqlstr_UpdatesTable_Scenario1_
         cursor.execute(update_sqlstr)
 
         # THEN
-        assert cursor.execute(face_name_inx_count_sql).fetchone()[0] == 4
+        assert cursor.execute(face_name_inx_count_sql).fetchone()[0] == 3
         select_face_name_only_sqlstr = f"""SELECT {event_int_str()}, {face_name_str()}_otx, {face_name_str()}_inx FROM {budawar_v_raw_put_tablename}"""
         cursor.execute(select_face_name_only_sqlstr)
         rows = cursor.fetchall()
         print(rows)
         assert rows == [
             (1, sue_otx, sue_inx),
-            (2, yao_otx, yao_otx),
+            (2, yao_otx, None),
             (5, sue_otx, sue_inx),
             (7, bob_otx, bob_inx),
         ]
 
 
-def test_create_update_voice_raw_existing_inx_col_sqlstr_UpdatesTable_Scenario2_PartialPidginTables():
+def test_create_update_voice_raw_existing_inx_col_sqlstr_UpdatesTable_Scenario1_PartialPidginTables():
     # ESTABLISH
     bob_otx = "Bob"
     bob_inx = "Bobby"
@@ -736,12 +683,12 @@ def test_create_update_voice_raw_existing_inx_col_sqlstr_UpdatesTable_Scenario2_
         # event5 does not link to event7 pidgin record's
         assert rows == [
             (event1, sue_otx, sue_inx),
-            (event2, yao_otx, yao_otx),
-            (event5, bob_otx, bob_otx),
+            (event2, yao_otx, None),
+            (event5, bob_otx, None),
         ]
 
 
-def test_create_update_voice_raw_existing_inx_col_sqlstr_UpdatesTable_Scenario3_Different_event_int_PidginMappings():
+def test_create_update_voice_raw_existing_inx_col_sqlstr_UpdatesTable_Scenario2_Different_event_int_PidginMappings():
     # ESTABLISH
     sue_otx = "Sue"
     sue_inx = "Suzy"
@@ -810,7 +757,7 @@ def test_create_update_voice_raw_existing_inx_col_sqlstr_UpdatesTable_Scenario3_
         print(rows)
         # event5 does not link to event7 pidgin record's
         assert rows == [
-            (0, bob_otx, bob_otx),
+            (0, bob_otx, None),
             (1, bob_otx, bob_inx0),
             (2, yao_otx, yao_inx),
             (5, bob_otx, bob_inx0),
@@ -819,90 +766,130 @@ def test_create_update_voice_raw_existing_inx_col_sqlstr_UpdatesTable_Scenario3_
         ]
 
 
-# def test_create_update_voice_raw_existing_inx_col_sqlstr_UpdatesTable_Scenario11_():
-#     # ESTABLISH
-#     a23_str = "accord23"
-#     bob_otx = "Bob"
-#     bob_inx = "Bobby"
-#     sue_otx = "Sue"
-#     sue_inx = "Suzy"
-#     yao_otx = "Yao"
-#     yao_inx = "Yaoito"
-#     casa_way_otx = create_way(a23_str, "casa")
-#     casa_way_inx = create_way(a23_str, "casita")
-#     team_otx = "team12"
-#     team_inx = "teamAB"
-#     event1 = 1
-#     event2 = 2
-#     event5 = 5
-#     event7 = 7
-#     x44_give = 44
-#     x55_give = 55
-#     x22_take = 22
-#     x66_take = 66
+def test_create_update_voice_raw_empty_inx_col_sqlstr_UpdatesTable_Scenario0_EmptyPidginTables():
+    # ESTABLISH
+    bob_otx = "Bob"
+    bob_inx = "Bobby"
+    sue_otx = "Sue"
+    sue_inx = "Suzy"
+    yao_otx = "Yao"
+    event1 = 1
+    event2 = 2
+    event5 = 5
+    event7 = 7
 
-#     with sqlite3_connect(":memory:") as db_conn:
-#         cursor = db_conn.cursor()
-#         create_sound_and_voice_tables(cursor)
-#         budawar_dimen = bud_idea_awardlink_str()
-#         budawar_v_raw_put_tablename = prime_tbl(budawar_dimen, "v", "raw", "put")
-#         print(f"{get_table_columns(cursor, budawar_v_raw_put_tablename)=}")
-#         insert_into_clause = f"""INSERT INTO {budawar_v_raw_put_tablename} (
-#   {event_int_str()}
-# , {face_name_str()}_otx
-# , {face_name_str()}_inx
-# , {fisc_word_str()}_otx
-# , {fisc_word_str()}_inx
-# , {owner_name_str()}_otx
-# , {owner_name_str()}_inx
-# , {idea_way_str()}_otx
-# , {idea_way_str()}_inx
-# , {awardee_label_str()}_otx
-# , {awardee_label_str()}_inx
-# , {give_force_str()}
-# , {take_force_str()}
-# )"""
-#         values_clause = f"""
-# VALUES
-#   ({event1}, '{sue_otx}', NULL, '{a23_str}', NULL,'{yao_otx}', NULL, '{casa_way_otx}', NULL, '{team_otx}', NULL, {x44_give}, {x22_take})
-# , ({event2}, '{yao_otx}', NULL, '{a23_str}', NULL,'{bob_otx}', NULL, '{casa_way_otx}', NULL, '{team_otx}', NULL, {x55_give}, {x22_take})
-# , ({event5}, '{sue_otx}', NULL, '{a23_str}', NULL,'{bob_otx}', NULL, '{casa_way_otx}', NULL, '{team_otx}', NULL, {x55_give}, {x22_take})
-# , ({event7}, '{bob_otx}', NULL, '{a23_str}', NULL,'{bob_otx}', NULL, '{casa_way_otx}', NULL, '{team_otx}', NULL, {x55_give}, {x66_take})
-# ;
-# """
-#         cursor.execute(f"{insert_into_clause} {values_clause}")
-#         face_name_inx_count_sql = f"SELECT COUNT(*) FROM {budawar_v_raw_put_tablename} WHERE {face_name_str()}_inx IS NOT NULL"
-#         fisc_word_inx_count_sql = f"SELECT COUNT(*) FROM {budawar_v_raw_put_tablename} WHERE {fisc_word_str()}_inx IS NOT NULL"
-#         owner_name_inx_count_sql = f"SELECT COUNT(*) FROM {budawar_v_raw_put_tablename} WHERE {owner_name_str()}_inx IS NOT NULL"
-#         idea_way_inx_count_sql = f"SELECT COUNT(*) FROM {budawar_v_raw_put_tablename} WHERE {idea_way_str()}_inx IS NOT NULL"
-#         awardee_label_inx_count_sql = f"SELECT COUNT(*) FROM {budawar_v_raw_put_tablename} WHERE {awardee_label_str()}_inx IS NOT NULL"
-#         assert cursor.execute(face_name_inx_count_sql).fetchone() == (0,)
-#         assert cursor.execute(owner_name_inx_count_sql).fetchone() == (0,)
-#         assert cursor.execute(fisc_word_inx_count_sql).fetchone() == (0,)
-#         assert cursor.execute(idea_way_inx_count_sql).fetchone() == (0,)
-#         assert cursor.execute(awardee_label_inx_count_sql).fetchone() == (0,)
+    with sqlite3_connect(":memory:") as db_conn:
+        cursor = db_conn.cursor()
+        create_sound_and_voice_tables(cursor)
+        pidname_s_vld_tablename = prime_tbl(pidgin_name_str(), "s", "vld")
+        print(f"{pidname_s_vld_tablename=}")
+        print(f"{get_table_columns(cursor, pidname_s_vld_tablename)=}")
 
-#         # WHEN
-#         update_sqlstr = create_update_voice_raw_existing_inx_col_sqlstr(
-#             budawar_v_raw_put_tablename, face_name_str()
-#         )
-#         print(update_sqlstr)
-#         cursor.execute(update_sqlstr)
+        budawar_dimen = bud_idea_awardlink_str()
+        budawar_v_raw_put_tablename = prime_tbl(budawar_dimen, "v", "raw", "put")
+        print(f"{get_table_columns(cursor, budawar_v_raw_put_tablename)=}")
+        insert_face_name_only_sqlstr = f"""INSERT INTO {budawar_v_raw_put_tablename} ({event_int_str()}, {face_name_str()}_otx, {face_name_str()}_inx)
+VALUES
+  ({event1}, '{sue_otx}', '{sue_inx}')
+, ({event2}, '{yao_otx}', NULL)
+, ({event5}, '{sue_otx}', NULL)
+, ({event7}, '{bob_otx}', '{bob_inx}')
+;
+"""
+        cursor.execute(insert_face_name_only_sqlstr)
+        face_name_inx_count_sql = f"SELECT COUNT(*) FROM {budawar_v_raw_put_tablename} WHERE {face_name_str()}_inx IS NOT NULL"
+        assert cursor.execute(face_name_inx_count_sql).fetchone()[0] == 2
 
-#         # THEN
-#         assert cursor.execute(face_name_inx_count_sql).fetchone()[0] == 4
-#         assert cursor.execute(owner_name_inx_count_sql).fetchone()[0] == 0
-#         assert cursor.execute(awardee_label_inx_count_sql).fetchone()[0] == 0
-#         assert cursor.execute(fisc_word_inx_count_sql).fetchone()[0] == 0
-#         assert cursor.execute(idea_way_inx_count_sql).fetchone()[0] == 0
-#         select_face_name_only_sqlstr = f"""SELECT {event_int_str()}, {face_name_str()}_otx, {face_name_str()}_inx FROM {budawar_v_raw_put_tablename}"""
-#         cursor.execute(select_face_name_only_sqlstr)
-#         rows = cursor.fetchall()
-#         print(rows)
-#         assert rows == [
-#             (1, sue_otx, sue_otx),
-#             (2, yao_otx, yao_otx),
-#             (5, sue_otx, sue_otx),
-#             (7, bob_otx, bob_otx),
-#         ]
-#         assert 1 == 2
+        # WHEN
+        update_sqlstr = create_update_voice_raw_empty_inx_col_sqlstr(
+            budawar_v_raw_put_tablename, face_name_str()
+        )
+        print(update_sqlstr)
+        cursor.execute(update_sqlstr)
+
+        # THEN
+        assert cursor.execute(face_name_inx_count_sql).fetchone()[0] == 4
+        select_face_name_only_sqlstr = f"""SELECT {event_int_str()}, {face_name_str()}_otx, {face_name_str()}_inx FROM {budawar_v_raw_put_tablename}"""
+        cursor.execute(select_face_name_only_sqlstr)
+        rows = cursor.fetchall()
+        print(rows)
+        assert rows == [
+            (1, sue_otx, sue_inx),
+            (2, yao_otx, yao_otx),
+            (5, sue_otx, sue_otx),
+            (7, bob_otx, bob_inx),
+        ]
+
+
+def test_set_all_voice_raw_inx_columns_Scenario0_empty_tables():
+    # ESTABLISH
+    sue_otx = "Sue"
+    sue_inx = "Suzy"
+    bob_sue_inx = "BobSuzInx"
+    bob_otx = "Bob"
+    bob_inx0 = "Bobby"
+    bob_inx7 = "Robert"
+    yao_otx = "Yao"
+    yao_inx = "Yaoito"
+    event0 = 0
+    event1 = 1
+    event2 = 2
+    event5 = 5
+    event7 = 7
+    event8 = 8
+    event9 = 9
+
+    with sqlite3_connect(":memory:") as db_conn:
+        cursor = db_conn.cursor()
+        create_sound_and_voice_tables(cursor)
+        budawar_dimen = bud_idea_awardlink_str()
+        budawar_v_raw_put_tablename = prime_tbl(budawar_dimen, "v", "raw", "put")
+        print(f"{get_table_columns(cursor, budawar_v_raw_put_tablename)=}")
+        insert_face_name_only_sqlstr = f"""INSERT INTO {budawar_v_raw_put_tablename}
+        ({event_int_str()}, {face_name_str()}_otx, {face_name_str()}_inx)
+        VALUES
+          ({event0}, '{bob_otx}', NULL)
+        , ({event1}, '{bob_otx}', NULL)
+        , ({event2}, '{yao_otx}', NULL)
+        , ({event5}, '{bob_otx}', NULL)
+        , ({event7}, '{bob_otx}', NULL)
+        , ({event9}, '{bob_otx}', NULL)
+        ;
+        """
+        cursor.execute(insert_face_name_only_sqlstr)
+
+        pidname_dimen = pidgin_name_str()
+        pidname_s_vld_tablename = prime_tbl(pidname_dimen, "s", "vld")
+        print(f"{pidname_s_vld_tablename=}")
+        insert_pidname_sqlstr = f"""INSERT INTO {pidname_s_vld_tablename}
+        ({event_int_str()}, {face_name_str()}, {otx_name_str()}, {inx_name_str()})
+        VALUES
+          ({event1}, '{bob_otx}', '{bob_otx}', '{bob_inx0}')
+        , ({event2}, '{yao_otx}', '{yao_otx}', '{yao_inx}')
+        , ({event7}, '{bob_otx}', '{bob_otx}', '{bob_inx7}')
+        , ({event7}, '{bob_otx}', '{sue_otx}', '{bob_sue_inx}')
+        , ({event8}, '{sue_otx}', '{sue_otx}', '{sue_inx}')
+        ;
+        """
+        cursor.execute(insert_pidname_sqlstr)
+
+        face_name_inx_count_sql = f"SELECT COUNT(*) FROM {budawar_v_raw_put_tablename} WHERE {face_name_str()}_inx IS NOT NULL"
+        assert cursor.execute(face_name_inx_count_sql).fetchone()[0] == 0
+
+        # WHEN
+        set_all_voice_raw_inx_columns(cursor)
+
+        # THEN
+        select_face_name_only_sqlstr = f"""SELECT {event_int_str()}, {face_name_str()}_otx, {face_name_str()}_inx FROM {budawar_v_raw_put_tablename}"""
+        cursor.execute(select_face_name_only_sqlstr)
+        rows = cursor.fetchall()
+        print(rows)
+        # event5 does not link to event7 pidgin record's
+        assert rows == [
+            (0, bob_otx, bob_otx),
+            (1, bob_otx, bob_inx0),
+            (2, yao_otx, yao_inx),
+            (5, bob_otx, bob_inx0),
+            (7, bob_otx, bob_inx7),
+            (9, bob_otx, bob_inx7),
+        ]

--- a/src/a18_etl_toolbox/tran_sqlstrs.py
+++ b/src/a18_etl_toolbox/tran_sqlstrs.py
@@ -785,84 +785,42 @@ def get_insert_into_voice_raw_sqlstrs() -> dict[str, str]:
     }
 
 
-def create_pidname_face_otx_event_sqlstr(table: str, column: str) -> str:
+def create_pidgin_face_otx_event_sqlstr(
+    pidgin_dimen: str, table: str, column: str
+) -> str:
     return f"""
-SELECT 
+SELECT
   raw_dim.rowid raw_rowid
 , raw_dim.event_int
 , raw_dim.face_name_otx
 , raw_dim.{column}_otx
 , MAX(pid.event_int) pidgin_event_int
 FROM {table} raw_dim
-LEFT JOIN pidgin_name_s_vld pid ON pid.face_name = raw_dim.face_name_otx
-    AND pid.otx_name = raw_dim.{column}_otx
+LEFT JOIN pidgin_{pidgin_dimen}_s_vld pid ON pid.face_name = raw_dim.face_name_otx
+    AND pid.otx_{pidgin_dimen} = raw_dim.{column}_otx
     AND raw_dim.event_int >= pid.event_int
-GROUP BY 
+GROUP BY
   raw_dim.rowid
 , raw_dim.event_int
 , raw_dim.face_name_otx
 , raw_dim.{column}_otx
 """
+
+
+def create_pidname_face_otx_event_sqlstr(table: str, column: str) -> str:
+    return create_pidgin_face_otx_event_sqlstr("name", table, column)
 
 
 def create_pidlabe_face_otx_event_sqlstr(table: str, column: str) -> str:
-    return f"""
-SELECT 
-  raw_dim.rowid raw_rowid
-, raw_dim.event_int
-, raw_dim.face_name_otx
-, raw_dim.{column}_otx
-, MAX(pid.event_int) pidgin_event_int
-FROM {table} raw_dim
-LEFT JOIN pidgin_label_s_vld pid ON pid.face_name = raw_dim.face_name_otx
-    AND pid.otx_label = raw_dim.{column}_otx
-    AND raw_dim.event_int >= pid.event_int
-GROUP BY 
-  raw_dim.rowid
-, raw_dim.event_int
-, raw_dim.face_name_otx
-, raw_dim.{column}_otx
-"""
+    return create_pidgin_face_otx_event_sqlstr("label", table, column)
 
 
 def create_pidword_face_otx_event_sqlstr(table: str, column: str) -> str:
-    return f"""
-SELECT
-  raw_dim.rowid raw_rowid
-, raw_dim.event_int
-, raw_dim.face_name_otx
-, raw_dim.{column}_otx
-, MAX(pid.event_int) pidgin_event_int
-FROM {table} raw_dim
-LEFT JOIN pidgin_word_s_vld pid ON pid.face_name = raw_dim.face_name_otx
-    AND pid.otx_word = raw_dim.{column}_otx
-    AND raw_dim.event_int >= pid.event_int
-GROUP BY
-  raw_dim.rowid
-, raw_dim.event_int
-, raw_dim.face_name_otx
-, raw_dim.{column}_otx
-"""
+    return create_pidgin_face_otx_event_sqlstr("word", table, column)
 
 
 def create_pidwayy_face_otx_event_sqlstr(table: str, column: str) -> str:
-    return f"""
-SELECT
-  raw_dim.rowid raw_rowid
-, raw_dim.event_int
-, raw_dim.face_name_otx
-, raw_dim.{column}_otx
-, MAX(pid.event_int) pidgin_event_int
-FROM {table} raw_dim
-LEFT JOIN pidgin_word_s_vld pid ON pid.face_name = raw_dim.face_name_otx
-    AND pid.otx_word = raw_dim.{column}_otx
-    AND raw_dim.event_int >= pid.event_int
-GROUP BY
-  raw_dim.rowid
-, raw_dim.event_int
-, raw_dim.face_name_otx
-, raw_dim.{column}_otx
-"""
+    return create_pidgin_face_otx_event_sqlstr("way", table, column)
 
 
 def update_voice_raw_inx_name_col_sqlstr(table: str, column: str) -> str:

--- a/src/a18_etl_toolbox/tran_sqlstrs.py
+++ b/src/a18_etl_toolbox/tran_sqlstrs.py
@@ -823,9 +823,11 @@ def create_pidwayy_face_otx_event_sqlstr(table: str, column: str) -> str:
     return create_pidgin_face_otx_event_sqlstr("way", table, column)
 
 
-def update_voice_raw_inx_name_col_sqlstr(table: str, column: str) -> str:
+def create_update_voice_raw_existing_inx_col_sqlstr(
+    pidgin_dimen: str, table: str, column: str
+) -> str:
     return f"""
-WITH pidname_face_otx_event AS (
+WITH pid_face_otx_event AS (
     SELECT 
     raw_dim.rowid raw_rowid
     , raw_dim.event_int
@@ -833,8 +835,8 @@ WITH pidname_face_otx_event AS (
     , raw_dim.{column}_otx
     , MAX(pid.event_int) pidgin_event_int
     FROM {table} raw_dim
-    LEFT JOIN pidgin_name_s_vld pid ON pid.face_name = raw_dim.face_name_otx
-        AND pid.otx_name = raw_dim.{column}_otx
+    LEFT JOIN pidgin_{pidgin_dimen}_s_vld pid ON pid.face_name = raw_dim.face_name_otx
+        AND pid.otx_{pidgin_dimen} = raw_dim.{column}_otx
         AND raw_dim.event_int >= pid.event_int
     GROUP BY 
     raw_dim.rowid
@@ -842,19 +844,19 @@ WITH pidname_face_otx_event AS (
     , raw_dim.face_name_otx
     , raw_dim.{column}_otx
 ),
-pidname_inx_names AS (
-    SELECT pid_foe.raw_rowid, pid_vld.inx_name
-    FROM pidname_face_otx_event pid_foe
-    LEFT JOIN pidgin_name_s_vld pid_vld
+pid_inx_strs AS (
+    SELECT pid_foe.raw_rowid, pid_vld.inx_{pidgin_dimen}
+    FROM pid_face_otx_event pid_foe
+    LEFT JOIN pidgin_{pidgin_dimen}_s_vld pid_vld
         ON pid_vld.face_name = pid_foe.face_name_otx
-        AND pid_vld.otx_name = pid_foe.{column}_otx
+        AND pid_vld.otx_{pidgin_dimen} = pid_foe.{column}_otx
         AND pid_vld.event_int = pid_foe.pidgin_event_int
 )
 UPDATE {table} as dim_v_raw
 SET {column}_inx = (
-    SELECT IFNULL(pidname_inx_names.inx_name, dim_v_raw.{column}_otx)
-    FROM pidname_inx_names
-    WHERE dim_v_raw.rowid = pidname_inx_names.raw_rowid
+    SELECT IFNULL(pid_inx_strs.inx_{pidgin_dimen}, dim_v_raw.{column}_otx)
+    FROM pid_inx_strs
+    WHERE dim_v_raw.rowid = pid_inx_strs.raw_rowid
 )
 ;
 """

--- a/src/a18_etl_toolbox/tran_sqlstrs.py
+++ b/src/a18_etl_toolbox/tran_sqlstrs.py
@@ -827,7 +827,7 @@ GROUP BY
 
 def create_pidword_face_otx_event_sqlstr(table: str, column: str) -> str:
     return f"""
-SELECT 
+SELECT
   raw_dim.rowid raw_rowid
 , raw_dim.event_int
 , raw_dim.face_name_otx
@@ -837,7 +837,27 @@ FROM {table} raw_dim
 LEFT JOIN pidgin_word_s_vld pid ON pid.face_name = raw_dim.face_name_otx
     AND pid.otx_word = raw_dim.{column}_otx
     AND raw_dim.event_int >= pid.event_int
-GROUP BY 
+GROUP BY
+  raw_dim.rowid
+, raw_dim.event_int
+, raw_dim.face_name_otx
+, raw_dim.{column}_otx
+"""
+
+
+def create_pidwayy_face_otx_event_sqlstr(table: str, column: str) -> str:
+    return f"""
+SELECT
+  raw_dim.rowid raw_rowid
+, raw_dim.event_int
+, raw_dim.face_name_otx
+, raw_dim.{column}_otx
+, MAX(pid.event_int) pidgin_event_int
+FROM {table} raw_dim
+LEFT JOIN pidgin_word_s_vld pid ON pid.face_name = raw_dim.face_name_otx
+    AND pid.otx_word = raw_dim.{column}_otx
+    AND raw_dim.event_int >= pid.event_int
+GROUP BY
   raw_dim.rowid
 , raw_dim.event_int
 , raw_dim.face_name_otx

--- a/src/a19_world_logic/test_etl_pipeline/test_world_mud_to_stances.py
+++ b/src/a19_world_logic/test_etl_pipeline/test_world_mud_to_stances.py
@@ -157,8 +157,8 @@ def test_WorldUnit_mud_to_stances_v2_with_cursor_Scenario3_br000113PopulatesTabl
         assert get_row_count(cursor, budunit_voice_put_raw) == 1
         assert get_row_count(cursor, budacct_voice_put_raw) == 1
         # assert get_row_count(cursor, fisunit_voice_agg) == 1
-        # assert get_row_count(cursor, budunit_voice_agg) == 1
-        # assert get_row_count(cursor, budacct_voice_agg) == 1
+        # assert get_row_count(cursor, budunit_voice_put_agg) == 1
+        # assert get_row_count(cursor, budacct_voice_put_agg) == 1
 
 
 # def test_WorldUnit_mud_to_stances_Scenario3_CreatesFiles(env_dir_setup_cleanup):


### PR DESCRIPTION
## Summary by Sourcery

Refactor pidgin event SQL generators into a single configurable function and add generic update utilities to populate index columns in voice_raw tables, then invoke them in the ETL pipeline and update tests to cover the new behavior

New Features:
- Introduce a generic create_pidgin_face_otx_event_sqlstr function to unify SQL generation for name, label, word, and way pidgin types
- Add create_update_voice_raw_existing_inx_col_sqlstr and create_update_voice_raw_empty_inx_col_sqlstr for targeted inx column updates
- Implement set_all_voice_raw_inx_columns and set_voice_raw_inx_column in transformers to bulk-populate all inx columns after ETL

Enhancements:
- Refactor specialized SQL string builders (create_pidname, create_pidlabe, create_pidword, create_pidwayy) to leverage the new generic function
- Update etl_sound_agg_tables_to_voice_raw_tables to invoke the new bulk inx-population step
- Clean up whitespace formatting in SQL snippets across tests

Tests:
- Rename and adjust existing tests to use the new generic SQL functions and update logic for inx columns
- Add new tests for the 'way' pidgin type and for populating inx columns in the ETL pipeline