### PR TITLE
175 enable documentation process

### DIFF
--- a/src/a00_data_toolbox/db_toolbox.py
+++ b/src/a00_data_toolbox/db_toolbox.py
@@ -446,6 +446,7 @@ def create_table2table_agg_insert_query(
     dst_columns_str = ", ".join(list(dst_columns))
     select_columns_str = None
     for dst_column in dst_columns:
+        print(f"{dst_column=}")
         if select_columns_str is None and dst_column in focus_cols_set:
             select_columns_str = f"{dst_column}"
         elif dst_column in focus_cols_set:

--- a/src/a00_data_toolbox/db_toolbox.py
+++ b/src/a00_data_toolbox/db_toolbox.py
@@ -446,7 +446,6 @@ def create_table2table_agg_insert_query(
     dst_columns_str = ", ".join(list(dst_columns))
     select_columns_str = None
     for dst_column in dst_columns:
-        print(f"{dst_column=}")
         if select_columns_str is None and dst_column in focus_cols_set:
             select_columns_str = f"{dst_column}"
         elif dst_column in focus_cols_set:

--- a/src/a00_data_toolbox/test/test_db_tool.py
+++ b/src/a00_data_toolbox/test/test_db_tool.py
@@ -452,7 +452,7 @@ def test_create_table_from_csv_ChangesDBState(
     assert columns == expected_columns
 
 
-def test_create_idea_table_from_csv_DoesNotEmptyTable(
+def test_create_table_from_csv_DoesNotEmptyTable(
     setup_database_and_csv: tuple[sqlite3_Connection, str, str],
 ):
     # ESTABLISH

--- a/src/a00_data_toolbox/test/test_dict_tool.py
+++ b/src/a00_data_toolbox/test/test_dict_tool.py
@@ -141,7 +141,7 @@ def test_del_in_nested_dict_CorrectSetsDict():
 
     # def get_from_nested_dict(d, keys, default=None):
     #     try:
-    #         return reduce(operator.getidea, keys, d)
+    #         return reduce(operator.get, keys, d)
     #     except (KeyError, TypeError):
     #         return default
     # These changes maintain the consistent interface while reducing code complexity and improving efficiency. The defaultdict approach eliminates the need for explicit nested dictionary creation, the simplified del_in_nested_dict is more readable and efficient, and the reduce-based get_from_nested_dict is more con_cise.

--- a/src/a02_finance_logic/deal.py
+++ b/src/a02_finance_logic/deal.py
@@ -143,8 +143,8 @@ class TranBook:
         return ["acct_name", "net_amount"]
 
     def _get_accts_net_array(self) -> list[list]:
-        x_ideas = self.get_accts_net_dict().items()
-        return [[acct_name, net_amount] for acct_name, net_amount in x_ideas]
+        x_concepts = self.get_accts_net_dict().items()
+        return [[acct_name, net_amount] for acct_name, net_amount in x_concepts]
 
     def get_accts_net_csv(self) -> str:
         return create_csv(self._get_accts_headers(), self._get_accts_net_array())

--- a/src/a18_etl_toolbox/test_/test_tran_sqlstrs_.py
+++ b/src/a18_etl_toolbox/test_/test_tran_sqlstrs_.py
@@ -90,8 +90,8 @@ from src.a18_etl_toolbox.tran_sqlstrs import (
     get_fisc_insert_agg_from_raw_sqlstrs,
     get_pidgin_insert_agg_from_raw_sqlstrs,
     FISUNIT_AGG_INSERT_SQLSTR,
-    get_idea_slabeleble_put_dimens,
-    IDEA_SLABELEBLE_DEL_DIMENS,
+    get_idea_stageble_put_dimens,
+    IDEA_STAGEBLE_DEL_DIMENS,
     CREATE_FISC_EVENT_TIME_AGG_SQLSTR,
     INSERT_FISC_EVENT_TIME_AGG_SQLSTR,
     UPDATE_ERROR_MESSAGE_FISC_EVENT_TIME_AGG_SQLSTR,
@@ -1019,7 +1019,7 @@ def test_get_bud_insert_del_agg_from_raw_sqlstrs_ReturnsObj():
             assert x_sqlstr == expected_table2table_agg_insert_sqlstr
 
 
-def test_get_idea_slabeleble_put_dimens_HasAll_idea_numbersForAll_dimens():
+def test_get_idea_stageble_put_dimens_HasAll_idea_numbersForAll_dimens():
     # sourcery skip: extract-method, no-loop-in-tests, no-conditionals-in-tests
     # ESTABLISH / WHEN
     # THEN
@@ -1076,14 +1076,14 @@ def test_get_idea_slabeleble_put_dimens_HasAll_idea_numbersForAll_dimens():
                     # check sqlstr is correct?
                     assert generated_sqlstr != ""
 
-    idea_slabeleble_dimen_list = sorted(list(expected_idea_slabelable_dimens))
+    idea_stageble_dimen_list = sorted(list(expected_idea_slabelable_dimens))
     print(f"{expected_idea_slabelable_dimens=}")
     assert idea_dimen_combo_checked_count == 680
     assert idea_raw2dimen_count == 109
-    assert get_idea_slabeleble_put_dimens() == expected_idea_slabelable_dimens
+    assert get_idea_stageble_put_dimens() == expected_idea_slabelable_dimens
 
 
-def test_IDEA_SLABELEBLE_DEL_DIMENS_HasAll_idea_numbersForAll_dimens():
+def test_IDEA_STAGEBLE_DEL_DIMENS_HasAll_idea_numbersForAll_dimens():
     # sourcery skip: extract-method, no-loop-in-tests, no-conditionals-in-tests
     # ESTABLISH / WHEN
     # THEN
@@ -1143,11 +1143,11 @@ def test_IDEA_SLABELEBLE_DEL_DIMENS_HasAll_idea_numbersForAll_dimens():
         for x_idea_number, slabelable_dimens in x_idea_slabelable_dimens.items()
         if slabelable_dimens != []
     }
-    idea_slabeleble_dimen_list = sorted(list(expected_idea_slabelable_dimens))
+    idea_stageble_dimen_list = sorted(list(expected_idea_slabelable_dimens))
     print(f"{expected_idea_slabelable_dimens=}")
     assert idea_dimen_combo_checked_count == 680
     assert idea_raw2dimen_count == 10
-    assert IDEA_SLABELEBLE_DEL_DIMENS == expected_idea_slabelable_dimens
+    assert IDEA_STAGEBLE_DEL_DIMENS == expected_idea_slabelable_dimens
 
 
 def test_CREATE_FISC_EVENT_TIME_AGG_SQLSTR_Exists():

--- a/src/a18_etl_toolbox/test_/test_tran_sqlstrs_prime.py
+++ b/src/a18_etl_toolbox/test_/test_tran_sqlstrs_prime.py
@@ -993,12 +993,12 @@ def test_get_insert_into_voice_raw_sqlstrs_ReturnsObj_BudDimens():
             v_del_raw_insert_select = f"{v_del_raw_insert_sql} {s_del_agg_select_sql}"
             # create_select_query(cursor=)
             abbv7 = get_dimen_abbv7(bud_dimen)
-            put_sqlstr_ref = f"INSERT_{abbv7.upper()}_VOICE_PUT_RAW_SQLSTR"
-            del_sqlstr_ref = f"INSERT_{abbv7.upper()}_VOICE_DEL_RAW_SQLSTR"
-            print(f'{put_sqlstr_ref}= "{v_put_raw_insert_select}"')
-            print(f'{del_sqlstr_ref}= "{v_del_raw_insert_select}"')
-            # print(f"{v_put_raw_tablename}: {put_sqlstr_ref},")
-            # print(f"{v_del_raw_tablename}: {del_sqlstr_ref},")
+            put_sqlstr_ref = f"INSERT_{abbv7.upper()}_VOICE_RAW_PUT_SQLSTR"
+            del_sqlstr_ref = f"INSERT_{abbv7.upper()}_VOICE_RAW_DEL_SQLSTR"
+            # print(f'{put_sqlstr_ref}= "{v_put_raw_insert_select}"')
+            # print(f'{del_sqlstr_ref}= "{v_del_raw_insert_select}"')
+            # print(f"""'{v_put_raw_tablename}': {put_sqlstr_ref},""")
+            # print(f"""'{v_del_raw_tablename}': {del_sqlstr_ref},""")
             assert insert_v_raw_sqlstrs.get(v_put_raw_tbl) == v_put_raw_insert_select
             assert insert_v_raw_sqlstrs.get(v_del_raw_tbl) == v_del_raw_insert_select
 

--- a/src/a18_etl_toolbox/test_tran/test_voice_raw_tables2voice_agg_tables.py
+++ b/src/a18_etl_toolbox/test_tran/test_voice_raw_tables2voice_agg_tables.py
@@ -1,0 +1,282 @@
+from src.a00_data_toolbox.db_toolbox import (
+    get_row_count,
+    get_table_columns,
+    create_table2table_agg_insert_query,
+)
+from src.a02_finance_logic._utils.strs_a02 import fisc_label_str, owner_name_str
+from src.a06_bud_logic._utils.str_a06 import (
+    bud_acctunit_str,
+    face_name_str,
+    event_int_str,
+    acct_name_str,
+    credit_belief_str,
+    debtit_belief_str,
+)
+from src.a15_fisc_logic.fisc_config import get_fisc_dimens
+from src.a15_fisc_logic._utils.str_a15 import fiscunit_str
+from src.a17_idea_logic.idea_config import get_idea_config_dict, get_default_sorted_list
+from src.a17_idea_logic._utils.str_a17 import idea_category_str
+from src.a18_etl_toolbox.tran_sqlstrs import (
+    get_dimen_abbv7,
+    create_prime_tablename as prime_tbl,
+    create_sound_and_voice_tables,
+    get_insert_into_voice_raw_sqlstrs,
+    get_insert_voice_agg_sqlstrs,
+)
+from src.a18_etl_toolbox.transformers import (
+    etl_sound_agg_tables_to_voice_raw_tables,
+)
+from sqlite3 import connect as sqlite3_connect
+
+
+def test_get_insert_voice_agg_sqlstrs_ReturnsObj_CheckFiscDimen():
+    # sourcery skip: extract-method, no-loop-in-tests
+    # ESTABLISH / WHEN
+    insert_voice_agg_sqlstrs = get_insert_voice_agg_sqlstrs()
+
+    # THEN
+    assert get_fisc_dimens().issubset(set(insert_voice_agg_sqlstrs.keys()))
+    idea_config = get_idea_config_dict()
+    idea_config = {
+        x_dimen: dimen_config
+        for x_dimen, dimen_config in idea_config.items()
+        if dimen_config.get(idea_category_str()) == "fisc"
+    }
+    with sqlite3_connect(":memory:") as fisc_db_conn:
+        cursor = fisc_db_conn.cursor()
+        create_sound_and_voice_tables(cursor)
+
+        for x_dimen in idea_config:
+            # print(f"{x_dimen} checking...")
+            raw_tablename = prime_tbl(x_dimen, "v", "raw")
+            agg_tablename = prime_tbl(x_dimen, "v", "agg")
+            raw_columns = get_table_columns(cursor, raw_tablename)
+            agg_columns = get_table_columns(cursor, agg_tablename)
+            raw_columns = {raw_col for raw_col in raw_columns if raw_col[-3:] != "otx"}
+            raw_columns.remove(f"{face_name_str()}_inx")
+            raw_columns.remove(event_int_str())
+            raw_columns.remove("error_message")
+            raw_columns = get_default_sorted_list(raw_columns)
+
+            raw_columns_str = ", ".join(raw_columns)
+            agg_columns_str = ", ".join(agg_columns)
+            # print(f"{raw_columns_str=}")
+            # print(f"{agg_columns_str=}")
+            expected_table2table_agg_insert_sqlstr = f"""
+INSERT INTO {agg_tablename} ({agg_columns_str})
+SELECT {raw_columns_str}
+WHERE error_message IS NULL
+FROM {raw_tablename}
+GROUP BY {raw_columns_str}
+"""
+            dimen_abbv7 = get_dimen_abbv7(x_dimen)
+            print(f'"{x_dimen}": {dimen_abbv7.upper()}_VOICE_AGG_INSERT_SQLSTR,')
+            # print(
+            #     f'{dimen_abbv7.upper()}_VOICE_AGG_INSERT_SQLSTR = """{expected_table2table_agg_insert_sqlstr}"""'
+            # )
+            gen_sqlstr = insert_voice_agg_sqlstrs.get(x_dimen)
+            assert gen_sqlstr == expected_table2table_agg_insert_sqlstr
+
+
+# def test_get_insert_into_voice_raw_sqlstrs_ReturnsObj_PopulatesTable_Scenario0():
+#     # ESTABLISH
+#     a23_str = "accord23"
+#     bob_str = "Bob"
+#     sue_str = "Sue"
+#     yao_str = "Yao"
+#     yao_inx = "Yaoito"
+#     event1 = 1
+#     event2 = 2
+#     event5 = 5
+#     event7 = 7
+#     x44_credit = 44
+#     x55_credit = 55
+#     x22_debtit = 22
+#     x66_debtit = 66
+
+#     with sqlite3_connect(":memory:") as db_conn:
+#         cursor = db_conn.cursor()
+#         create_sound_and_voice_tables(cursor)
+#         budaacct_s_agg_put_tablename = prime_tbl(bud_acctunit_str(), "s", "agg", "put")
+#         print(f"{get_table_columns(cursor, budaacct_s_agg_put_tablename)=}")
+#         insert_into_clause = f"""INSERT INTO {budaacct_s_agg_put_tablename} (
+#   {event_int_str()}
+# , {face_name_str()}
+# , {fisc_label_str()}
+# , {owner_name_str()}
+# , {acct_name_str()}
+# , {credit_belief_str()}
+# , {debtit_belief_str()}
+# )"""
+#         values_clause = f"""
+# VALUES
+#   ({event1}, '{sue_str}', '{a23_str}','{yao_str}', '{yao_inx}', {x44_credit}, {x22_debtit})
+# , ({event2}, '{yao_str}', '{a23_str}','{bob_str}', '{bob_str}', {x55_credit}, {x22_debtit})
+# , ({event5}, '{sue_str}', '{a23_str}','{bob_str}', '{bob_str}', {x55_credit}, {x22_debtit})
+# , ({event7}, '{bob_str}', '{a23_str}','{bob_str}', '{bob_str}', {x55_credit}, {x66_debtit})
+# ;
+# """
+#         cursor.execute(f"{insert_into_clause} {values_clause}")
+#         assert get_row_count(cursor, budaacct_s_agg_put_tablename) == 4
+#         budawar_v_raw_put_tablename = prime_tbl(bud_acctunit_str(), "v", "raw", "put")
+#         assert get_row_count(cursor, budawar_v_raw_put_tablename) == 0
+
+#         # WHEN
+#         sqlstr = get_insert_into_voice_raw_sqlstrs().get(budawar_v_raw_put_tablename)
+#         cursor.execute(sqlstr)
+
+#         # THEN
+#         assert get_row_count(cursor, budawar_v_raw_put_tablename) == 4
+#         select_sqlstr = f"""SELECT {event_int_str()}
+# , {face_name_str()}_otx
+# , {fisc_label_str()}_otx
+# , {owner_name_str()}_otx
+# , {acct_name_str()}_otx
+# , {credit_belief_str()}
+# , {debtit_belief_str()}
+# FROM {budawar_v_raw_put_tablename}
+# """
+#         cursor.execute(select_sqlstr)
+#         rows = cursor.fetchall()
+#         print(rows)
+#         assert rows == [
+#             (1, sue_str, a23_str, yao_str, yao_inx, 44.0, 22.0),
+#             (2, yao_str, a23_str, bob_str, bob_str, 55.0, 22.0),
+#             (5, sue_str, a23_str, bob_str, bob_str, 55.0, 22.0),
+#             (7, bob_str, a23_str, bob_str, bob_str, 55.0, 66.0),
+#         ]
+
+
+# def test_etl_sound_agg_tables_to_voice_raw_tables_Scenario0_AddRowsToTable():
+#     # ESTABLISH
+#     a23_str = "accord23"
+#     bob_str = "Bob"
+#     sue_str = "Sue"
+#     yao_str = "Yao"
+#     yao_inx = "Yaoito"
+#     event1 = 1
+#     event2 = 2
+#     event5 = 5
+#     event7 = 7
+#     x44_credit = 44
+#     x55_credit = 55
+#     x22_debtit = 22
+#     x66_debtit = 66
+
+#     with sqlite3_connect(":memory:") as db_conn:
+#         cursor = db_conn.cursor()
+#         create_sound_and_voice_tables(cursor)
+#         budacct_s_agg_put_tablename = prime_tbl(bud_acctunit_str(), "s", "agg", "put")
+#         print(f"{get_table_columns(cursor, budacct_s_agg_put_tablename)=}")
+#         insert_into_clause = f"""INSERT INTO {budacct_s_agg_put_tablename} (
+#   {event_int_str()}
+# , {face_name_str()}
+# , {fisc_label_str()}
+# , {owner_name_str()}
+# , {acct_name_str()}
+# , {credit_belief_str()}
+# , {debtit_belief_str()}
+# )"""
+#         values_clause = f"""
+# VALUES
+#   ({event1}, '{sue_str}', '{a23_str}','{yao_str}', '{yao_inx}', {x44_credit}, {x22_debtit})
+# , ({event2}, '{yao_str}', '{a23_str}','{bob_str}', '{bob_str}', {x55_credit}, {x22_debtit})
+# , ({event5}, '{sue_str}', '{a23_str}','{bob_str}', '{bob_str}', {x55_credit}, {x22_debtit})
+# , ({event7}, '{bob_str}', '{a23_str}','{bob_str}', '{bob_str}', {x55_credit}, {x66_debtit})
+# ;
+# """
+#         cursor.execute(f"{insert_into_clause} {values_clause}")
+#         assert get_row_count(cursor, budacct_s_agg_put_tablename) == 4
+#         budacct_v_raw_put_tablename = prime_tbl(bud_acctunit_str(), "v", "raw", "put")
+#         assert get_row_count(cursor, budacct_v_raw_put_tablename) == 0
+
+#         # WHEN
+#         etl_sound_agg_tables_to_voice_raw_tables(cursor)
+
+#         # THEN
+#         assert get_row_count(cursor, budacct_v_raw_put_tablename) == 4
+#         select_sqlstr = f"""SELECT {event_int_str()}
+# , {face_name_str()}_otx
+# , {fisc_label_str()}_otx
+# , {owner_name_str()}_otx
+# , {acct_name_str()}_otx
+# , {credit_belief_str()}
+# , {debtit_belief_str()}
+# FROM {budacct_v_raw_put_tablename}
+# """
+#         cursor.execute(select_sqlstr)
+#         rows = cursor.fetchall()
+#         print(rows)
+#         assert rows == [
+#             (1, sue_str, a23_str, yao_str, yao_inx, 44.0, 22.0),
+#             (2, yao_str, a23_str, bob_str, bob_str, 55.0, 22.0),
+#             (5, sue_str, a23_str, bob_str, bob_str, 55.0, 22.0),
+#             (7, bob_str, a23_str, bob_str, bob_str, 55.0, 66.0),
+#         ]
+
+
+# def test_etl_sound_agg_tables_to_voice_raw_tables_Scenario1_Populates_inx_Columns():
+#     # ESTABLISH
+#     a23_str = "accord23"
+#     bob_str = "Bob"
+#     sue_str = "Sue"
+#     yao_str = "Yao"
+#     event1 = 1
+#     event2 = 2
+#     event5 = 5
+#     event7 = 7
+#     x44_credit = 44
+#     x55_credit = 55
+#     x22_debtit = 22
+#     x66_debtit = 66
+
+#     with sqlite3_connect(":memory:") as db_conn:
+#         cursor = db_conn.cursor()
+#         create_sound_and_voice_tables(cursor)
+#         budacct_s_agg_put_tablename = prime_tbl(bud_acctunit_str(), "s", "agg", "put")
+#         print(f"{get_table_columns(cursor, budacct_s_agg_put_tablename)=}")
+#         insert_into_clause = f"""INSERT INTO {budacct_s_agg_put_tablename} (
+#   {event_int_str()}
+# , {face_name_str()}
+# , {fisc_label_str()}
+# , {owner_name_str()}
+# , {acct_name_str()}
+# , {credit_belief_str()}
+# , {debtit_belief_str()}
+# )"""
+#         values_clause = f"""
+# VALUES
+#   ({event1}, '{sue_str}', '{a23_str}','{yao_str}', '{yao_str}', {x44_credit}, {x22_debtit})
+# , ({event2}, '{yao_str}', '{a23_str}','{bob_str}', '{bob_str}', {x55_credit}, {x22_debtit})
+# , ({event5}, '{sue_str}', '{a23_str}','{bob_str}', '{bob_str}', {x55_credit}, {x22_debtit})
+# , ({event7}, '{bob_str}', '{a23_str}','{bob_str}', '{bob_str}', {x55_credit}, {x66_debtit})
+# ;
+# """
+#         cursor.execute(f"{insert_into_clause} {values_clause}")
+#         assert get_row_count(cursor, budacct_s_agg_put_tablename) == 4
+#         budacct_v_raw_put_tablename = prime_tbl(bud_acctunit_str(), "v", "raw", "put")
+#         assert get_row_count(cursor, budacct_v_raw_put_tablename) == 0
+
+#         # WHEN
+#         etl_sound_agg_tables_to_voice_raw_tables(cursor)
+
+#         # THEN
+#         assert get_row_count(cursor, budacct_v_raw_put_tablename) == 4
+#         select_sqlstr = f"""SELECT {event_int_str()}
+# , {face_name_str()}_inx
+# , {fisc_label_str()}_inx
+# , {owner_name_str()}_inx
+# , {acct_name_str()}_inx
+# , {credit_belief_str()}
+# , {debtit_belief_str()}
+# FROM {budacct_v_raw_put_tablename}
+# """
+#         cursor.execute(select_sqlstr)
+#         rows = cursor.fetchall()
+#         print(rows)
+#         assert rows == [
+#             (1, sue_str, a23_str, yao_str, yao_str, 44.0, 22.0),
+#             (2, yao_str, a23_str, bob_str, bob_str, 55.0, 22.0),
+#             (5, sue_str, a23_str, bob_str, bob_str, 55.0, 22.0),
+#             (7, bob_str, a23_str, bob_str, bob_str, 55.0, 66.0),
+#         ]

--- a/src/a18_etl_toolbox/test_tran/test_voice_raw_tables2voice_agg_tables.py
+++ b/src/a18_etl_toolbox/test_tran/test_voice_raw_tables2voice_agg_tables.py
@@ -20,12 +20,9 @@ from src.a18_etl_toolbox.tran_sqlstrs import (
     get_dimen_abbv7,
     create_prime_tablename as prime_tbl,
     create_sound_and_voice_tables,
-    get_insert_into_voice_raw_sqlstrs,
     get_insert_voice_agg_sqlstrs,
 )
-from src.a18_etl_toolbox.transformers import (
-    etl_sound_agg_tables_to_voice_raw_tables,
-)
+from src.a18_etl_toolbox.transformers import etl_voice_raw_tables_to_voice_agg_tables
 from sqlite3 import connect as sqlite3_connect
 
 
@@ -211,136 +208,69 @@ FROM {budacct_v_agg_put_tablename}
         ]
 
 
-# def test_etl_sound_agg_tables_to_voice_raw_tables_Scenario0_AddRowsToTable():
-#     # ESTABLISH
-#     a23_str = "accord23"
-#     bob_str = "Bob"
-#     sue_str = "Sue"
-#     yao_str = "Yao"
-#     yao_inx = "Yaoito"
-#     event1 = 1
-#     event2 = 2
-#     event5 = 5
-#     event7 = 7
-#     x44_credit = 44
-#     x55_credit = 55
-#     x22_debtit = 22
-#     x66_debtit = 66
+def test_etl_voice_raw_tables_to_voice_agg_tables_PopulatesTable_Scenario0():
+    # ESTABLISH
+    a23_str = "accord23"
+    bob_str = "Bob"
+    sue_str = "Sue"
+    yao_str = "Yao"
+    yao_inx = "Yaoito"
+    event1 = 1
+    event2 = 2
+    event5 = 5
+    event7 = 7
+    x44_credit = 44
+    x55_credit = 55
+    x22_debtit = 22
+    x66_debtit = 66
 
-#     with sqlite3_connect(":memory:") as db_conn:
-#         cursor = db_conn.cursor()
-#         create_sound_and_voice_tables(cursor)
-#         budacct_s_agg_put_tablename = prime_tbl(bud_acctunit_str(), "s", "agg", "put")
-#         print(f"{get_table_columns(cursor, budacct_s_agg_put_tablename)=}")
-#         insert_into_clause = f"""INSERT INTO {budacct_s_agg_put_tablename} (
-#   {event_int_str()}
-# , {face_name_str()}
-# , {fisc_label_str()}
-# , {owner_name_str()}
-# , {acct_name_str()}
-# , {credit_belief_str()}
-# , {debtit_belief_str()}
-# )"""
-#         values_clause = f"""
-# VALUES
-#   ({event1}, '{sue_str}', '{a23_str}','{yao_str}', '{yao_inx}', {x44_credit}, {x22_debtit})
-# , ({event2}, '{yao_str}', '{a23_str}','{bob_str}', '{bob_str}', {x55_credit}, {x22_debtit})
-# , ({event5}, '{sue_str}', '{a23_str}','{bob_str}', '{bob_str}', {x55_credit}, {x22_debtit})
-# , ({event7}, '{bob_str}', '{a23_str}','{bob_str}', '{bob_str}', {x55_credit}, {x66_debtit})
-# ;
-# """
-#         cursor.execute(f"{insert_into_clause} {values_clause}")
-#         assert get_row_count(cursor, budacct_s_agg_put_tablename) == 4
-#         budacct_v_raw_put_tablename = prime_tbl(bud_acctunit_str(), "v", "raw", "put")
-#         assert get_row_count(cursor, budacct_v_raw_put_tablename) == 0
+    with sqlite3_connect(":memory:") as db_conn:
+        cursor = db_conn.cursor()
+        create_sound_and_voice_tables(cursor)
+        budacct_v_raw_put_tablename = prime_tbl(bud_acctunit_str(), "v", "raw", "put")
+        print(f"{get_table_columns(cursor, budacct_v_raw_put_tablename)=}")
+        insert_into_clause = f"""INSERT INTO {budacct_v_raw_put_tablename} (
+  {event_int_str()}
+, {face_name_str()}_inx
+, {fisc_label_str()}_inx
+, {owner_name_str()}_inx
+, {acct_name_str()}_inx
+, {credit_belief_str()}
+, {debtit_belief_str()}
+)
+VALUES
+  ({event1}, '{sue_str}', '{a23_str}','{yao_str}', '{yao_inx}', {x44_credit}, {x22_debtit})
+, ({event2}, '{yao_str}', '{a23_str}','{bob_str}', '{bob_str}', {x55_credit}, {x22_debtit})
+, ({event5}, '{sue_str}', '{a23_str}','{bob_str}', '{bob_str}', {x55_credit}, {x22_debtit})
+, ({event7}, '{bob_str}', '{a23_str}','{bob_str}', '{bob_str}', {x55_credit}, {x66_debtit})
+, ({event7}, '{bob_str}', '{a23_str}','{bob_str}', '{bob_str}', {x55_credit}, {x66_debtit})
+;
+"""
+        cursor.execute(insert_into_clause)
+        assert get_row_count(cursor, budacct_v_raw_put_tablename) == 5
+        budacct_v_agg_put_tablename = prime_tbl(bud_acctunit_str(), "v", "agg", "put")
+        assert get_row_count(cursor, budacct_v_agg_put_tablename) == 0
 
-#         # WHEN
-#         etl_sound_agg_tables_to_voice_raw_tables(cursor)
+        # WHEN
+        etl_voice_raw_tables_to_voice_agg_tables(cursor)
 
-#         # THEN
-#         assert get_row_count(cursor, budacct_v_raw_put_tablename) == 4
-#         select_sqlstr = f"""SELECT {event_int_str()}
-# , {face_name_str()}_otx
-# , {fisc_label_str()}_otx
-# , {owner_name_str()}_otx
-# , {acct_name_str()}_otx
-# , {credit_belief_str()}
-# , {debtit_belief_str()}
-# FROM {budacct_v_raw_put_tablename}
-# """
-#         cursor.execute(select_sqlstr)
-#         rows = cursor.fetchall()
-#         print(rows)
-#         assert rows == [
-#             (1, sue_str, a23_str, yao_str, yao_inx, 44.0, 22.0),
-#             (2, yao_str, a23_str, bob_str, bob_str, 55.0, 22.0),
-#             (5, sue_str, a23_str, bob_str, bob_str, 55.0, 22.0),
-#             (7, bob_str, a23_str, bob_str, bob_str, 55.0, 66.0),
-#         ]
-
-
-# def test_etl_sound_agg_tables_to_voice_raw_tables_Scenario1_Populates_inx_Columns():
-#     # ESTABLISH
-#     a23_str = "accord23"
-#     bob_str = "Bob"
-#     sue_str = "Sue"
-#     yao_str = "Yao"
-#     event1 = 1
-#     event2 = 2
-#     event5 = 5
-#     event7 = 7
-#     x44_credit = 44
-#     x55_credit = 55
-#     x22_debtit = 22
-#     x66_debtit = 66
-
-#     with sqlite3_connect(":memory:") as db_conn:
-#         cursor = db_conn.cursor()
-#         create_sound_and_voice_tables(cursor)
-#         budacct_s_agg_put_tablename = prime_tbl(bud_acctunit_str(), "s", "agg", "put")
-#         print(f"{get_table_columns(cursor, budacct_s_agg_put_tablename)=}")
-#         insert_into_clause = f"""INSERT INTO {budacct_s_agg_put_tablename} (
-#   {event_int_str()}
-# , {face_name_str()}
-# , {fisc_label_str()}
-# , {owner_name_str()}
-# , {acct_name_str()}
-# , {credit_belief_str()}
-# , {debtit_belief_str()}
-# )"""
-#         values_clause = f"""
-# VALUES
-#   ({event1}, '{sue_str}', '{a23_str}','{yao_str}', '{yao_str}', {x44_credit}, {x22_debtit})
-# , ({event2}, '{yao_str}', '{a23_str}','{bob_str}', '{bob_str}', {x55_credit}, {x22_debtit})
-# , ({event5}, '{sue_str}', '{a23_str}','{bob_str}', '{bob_str}', {x55_credit}, {x22_debtit})
-# , ({event7}, '{bob_str}', '{a23_str}','{bob_str}', '{bob_str}', {x55_credit}, {x66_debtit})
-# ;
-# """
-#         cursor.execute(f"{insert_into_clause} {values_clause}")
-#         assert get_row_count(cursor, budacct_s_agg_put_tablename) == 4
-#         budacct_v_raw_put_tablename = prime_tbl(bud_acctunit_str(), "v", "raw", "put")
-#         assert get_row_count(cursor, budacct_v_raw_put_tablename) == 0
-
-#         # WHEN
-#         etl_sound_agg_tables_to_voice_raw_tables(cursor)
-
-#         # THEN
-#         assert get_row_count(cursor, budacct_v_raw_put_tablename) == 4
-#         select_sqlstr = f"""SELECT {event_int_str()}
-# , {face_name_str()}_inx
-# , {fisc_label_str()}_inx
-# , {owner_name_str()}_inx
-# , {acct_name_str()}_inx
-# , {credit_belief_str()}
-# , {debtit_belief_str()}
-# FROM {budacct_v_raw_put_tablename}
-# """
-#         cursor.execute(select_sqlstr)
-#         rows = cursor.fetchall()
-#         print(rows)
-#         assert rows == [
-#             (1, sue_str, a23_str, yao_str, yao_str, 44.0, 22.0),
-#             (2, yao_str, a23_str, bob_str, bob_str, 55.0, 22.0),
-#             (5, sue_str, a23_str, bob_str, bob_str, 55.0, 22.0),
-#             (7, bob_str, a23_str, bob_str, bob_str, 55.0, 66.0),
-#         ]
+        # THEN
+        assert get_row_count(cursor, budacct_v_agg_put_tablename) == 4
+        select_sqlstr = f"""SELECT {event_int_str()}
+, {face_name_str()}
+, {fisc_label_str()}
+, {owner_name_str()}
+, {acct_name_str()}
+, {credit_belief_str()}
+, {debtit_belief_str()}
+FROM {budacct_v_agg_put_tablename}
+"""
+        cursor.execute(select_sqlstr)
+        rows = cursor.fetchall()
+        print(rows)
+        assert rows == [
+            (event1, sue_str, a23_str, yao_str, yao_inx, 44.0, 22.0),
+            (event2, yao_str, a23_str, bob_str, bob_str, 55.0, 22.0),
+            (event5, sue_str, a23_str, bob_str, bob_str, 55.0, 22.0),
+            (event7, bob_str, a23_str, bob_str, bob_str, 55.0, 66.0),
+        ]

--- a/src/a18_etl_toolbox/test_tran/test_voice_raw_tables2voice_agg_tables.py
+++ b/src/a18_etl_toolbox/test_tran/test_voice_raw_tables2voice_agg_tables.py
@@ -65,15 +65,14 @@ def test_get_insert_voice_agg_sqlstrs_ReturnsObj_CheckFiscDimen():
             expected_table2table_agg_insert_sqlstr = f"""
 INSERT INTO {agg_tablename} ({agg_columns_str})
 SELECT {raw_columns_str}
-WHERE error_message IS NULL
 FROM {raw_tablename}
 GROUP BY {raw_columns_str}
 """
             dimen_abbv7 = get_dimen_abbv7(x_dimen)
-            print(f'"{x_dimen}": {dimen_abbv7.upper()}_VOICE_AGG_INSERT_SQLSTR,')
-            # print(
-            #     f'{dimen_abbv7.upper()}_VOICE_AGG_INSERT_SQLSTR = """{expected_table2table_agg_insert_sqlstr}"""'
-            # )
+            # print(f'"{x_dimen}": {dimen_abbv7.upper()}_VOICE_AGG_INSERT_SQLSTR,')
+            print(
+                f'{dimen_abbv7.upper()}_VOICE_AGG_INSERT_SQLSTR = """{expected_table2table_agg_insert_sqlstr}"""'
+            )
             gen_sqlstr = insert_voice_agg_sqlstrs.get(x_dimen)
             assert gen_sqlstr == expected_table2table_agg_insert_sqlstr
 
@@ -108,12 +107,11 @@ def test_get_insert_into_voice_raw_sqlstrs_ReturnsObj_BudDimens():
             v_agg_del_cols = get_table_columns(cursor, v_agg_del_tablename)
             v_raw_put_cols = {col for col in v_raw_put_cols if col[-3:] != "otx"}
             v_raw_del_cols = {col for col in v_raw_del_cols if col[-3:] != "otx"}
-            v_raw_put_cols.remove(f"{face_name_str()}_inx")
-            v_raw_del_cols.remove(f"{face_name_str()}_inx")
-            v_raw_put_cols.remove(event_int_str())
-            v_raw_del_cols.remove(event_int_str())
             v_raw_put_cols = get_default_sorted_list(v_raw_put_cols)
             v_raw_del_cols = get_default_sorted_list(v_raw_del_cols)
+            v_raw_put_columns_str = ", ".join(v_raw_put_cols)
+            v_raw_put_cols.remove("pidgin_event_int")
+            v_raw_del_cols.remove("pidgin_event_int")
             v_raw_put_columns_str = ", ".join(v_raw_put_cols)
             v_raw_del_columns_str = ", ".join(v_raw_del_cols)
             v_agg_put_columns_str = ", ".join(v_agg_put_cols)
@@ -121,97 +119,96 @@ def test_get_insert_into_voice_raw_sqlstrs_ReturnsObj_BudDimens():
             expected_agg_put_insert_sqlstr = f"""
 INSERT INTO {v_agg_put_tablename} ({v_agg_put_columns_str})
 SELECT {v_raw_put_columns_str}
-WHERE error_message IS NULL
 FROM {v_raw_put_tablename}
 GROUP BY {v_raw_put_columns_str}
 """
             expected_agg_del_insert_sqlstr = f"""
 INSERT INTO {v_agg_del_tablename} ({v_agg_del_columns_str})
 SELECT {v_raw_del_columns_str}
-WHERE error_message IS NULL
 FROM {v_raw_del_tablename}
 GROUP BY {v_raw_del_columns_str}
 """
             abbv7 = get_dimen_abbv7(bud_dimen)
             put_sqlstr_ref = f"INSERT_{abbv7.upper()}_VOICE_AGG_PUT_SQLSTR"
             del_sqlstr_ref = f"INSERT_{abbv7.upper()}_VOICE_AGG_DEL_SQLSTR"
-            # print(f'{put_sqlstr_ref}= """{expected_agg_put_insert_sqlstr}"""')
-            # print(f'{del_sqlstr_ref}= """{expected_agg_del_insert_sqlstr}"""')
-            print(f"'{v_agg_put_tablename}': {put_sqlstr_ref},")
-            print(f"'{v_agg_del_tablename}': {del_sqlstr_ref},")
+            print(f'{put_sqlstr_ref}= """{expected_agg_put_insert_sqlstr}"""')
+            print(f'{del_sqlstr_ref}= """{expected_agg_del_insert_sqlstr}"""')
+            # print(f"'{v_agg_put_tablename}': {put_sqlstr_ref},")
+            # print(f"'{v_agg_del_tablename}': {del_sqlstr_ref},")
             insert_v_agg_put_sqlstr = insert_voice_agg_sqlstrs.get(v_agg_put_tablename)
             insert_v_agg_del_sqlstr = insert_voice_agg_sqlstrs.get(v_agg_del_tablename)
             assert insert_v_agg_put_sqlstr == expected_agg_put_insert_sqlstr
             assert insert_v_agg_del_sqlstr == expected_agg_del_insert_sqlstr
 
 
-# def test_get_insert_into_voice_raw_sqlstrs_ReturnsObj_PopulatesTable_Scenario0():
-#     # ESTABLISH
-#     a23_str = "accord23"
-#     bob_str = "Bob"
-#     sue_str = "Sue"
-#     yao_str = "Yao"
-#     yao_inx = "Yaoito"
-#     event1 = 1
-#     event2 = 2
-#     event5 = 5
-#     event7 = 7
-#     x44_credit = 44
-#     x55_credit = 55
-#     x22_debtit = 22
-#     x66_debtit = 66
+def test_get_insert_voice_agg_sqlstrs_ReturnsObj_PopulatesTable_Scenario0():
+    # ESTABLISH
+    a23_str = "accord23"
+    bob_str = "Bob"
+    sue_str = "Sue"
+    yao_str = "Yao"
+    yao_inx = "Yaoito"
+    event1 = 1
+    event2 = 2
+    event5 = 5
+    event7 = 7
+    x44_credit = 44
+    x55_credit = 55
+    x22_debtit = 22
+    x66_debtit = 66
 
-#     with sqlite3_connect(":memory:") as db_conn:
-#         cursor = db_conn.cursor()
-#         create_sound_and_voice_tables(cursor)
-#         budaacct_s_agg_put_tablename = prime_tbl(bud_acctunit_str(), "s", "agg", "put")
-#         print(f"{get_table_columns(cursor, budaacct_s_agg_put_tablename)=}")
-#         insert_into_clause = f"""INSERT INTO {budaacct_s_agg_put_tablename} (
-#   {event_int_str()}
-# , {face_name_str()}
-# , {fisc_label_str()}
-# , {owner_name_str()}
-# , {acct_name_str()}
-# , {credit_belief_str()}
-# , {debtit_belief_str()}
-# )"""
-#         values_clause = f"""
-# VALUES
-#   ({event1}, '{sue_str}', '{a23_str}','{yao_str}', '{yao_inx}', {x44_credit}, {x22_debtit})
-# , ({event2}, '{yao_str}', '{a23_str}','{bob_str}', '{bob_str}', {x55_credit}, {x22_debtit})
-# , ({event5}, '{sue_str}', '{a23_str}','{bob_str}', '{bob_str}', {x55_credit}, {x22_debtit})
-# , ({event7}, '{bob_str}', '{a23_str}','{bob_str}', '{bob_str}', {x55_credit}, {x66_debtit})
-# ;
-# """
-#         cursor.execute(f"{insert_into_clause} {values_clause}")
-#         assert get_row_count(cursor, budaacct_s_agg_put_tablename) == 4
-#         budawar_v_raw_put_tablename = prime_tbl(bud_acctunit_str(), "v", "raw", "put")
-#         assert get_row_count(cursor, budawar_v_raw_put_tablename) == 0
+    with sqlite3_connect(":memory:") as db_conn:
+        cursor = db_conn.cursor()
+        create_sound_and_voice_tables(cursor)
+        budacct_v_raw_put_tablename = prime_tbl(bud_acctunit_str(), "v", "raw", "put")
+        print(f"{get_table_columns(cursor, budacct_v_raw_put_tablename)=}")
+        insert_into_clause = f"""INSERT INTO {budacct_v_raw_put_tablename} (
+  {event_int_str()}
+, {face_name_str()}_inx
+, {fisc_label_str()}_inx
+, {owner_name_str()}_inx
+, {acct_name_str()}_inx
+, {credit_belief_str()}
+, {debtit_belief_str()}
+)
+VALUES
+  ({event1}, '{sue_str}', '{a23_str}','{yao_str}', '{yao_inx}', {x44_credit}, {x22_debtit})
+, ({event2}, '{yao_str}', '{a23_str}','{bob_str}', '{bob_str}', {x55_credit}, {x22_debtit})
+, ({event5}, '{sue_str}', '{a23_str}','{bob_str}', '{bob_str}', {x55_credit}, {x22_debtit})
+, ({event7}, '{bob_str}', '{a23_str}','{bob_str}', '{bob_str}', {x55_credit}, {x66_debtit})
+, ({event7}, '{bob_str}', '{a23_str}','{bob_str}', '{bob_str}', {x55_credit}, {x66_debtit})
+;
+"""
+        cursor.execute(insert_into_clause)
+        assert get_row_count(cursor, budacct_v_raw_put_tablename) == 5
+        budacct_v_agg_put_tablename = prime_tbl(bud_acctunit_str(), "v", "agg", "put")
+        assert get_row_count(cursor, budacct_v_agg_put_tablename) == 0
 
-#         # WHEN
-#         sqlstr = get_insert_into_voice_raw_sqlstrs().get(budawar_v_raw_put_tablename)
-#         cursor.execute(sqlstr)
+        # WHEN
+        sqlstr = get_insert_voice_agg_sqlstrs().get(budacct_v_agg_put_tablename)
+        print(sqlstr)
+        cursor.execute(sqlstr)
 
-#         # THEN
-#         assert get_row_count(cursor, budawar_v_raw_put_tablename) == 4
-#         select_sqlstr = f"""SELECT {event_int_str()}
-# , {face_name_str()}_otx
-# , {fisc_label_str()}_otx
-# , {owner_name_str()}_otx
-# , {acct_name_str()}_otx
-# , {credit_belief_str()}
-# , {debtit_belief_str()}
-# FROM {budawar_v_raw_put_tablename}
-# """
-#         cursor.execute(select_sqlstr)
-#         rows = cursor.fetchall()
-#         print(rows)
-#         assert rows == [
-#             (1, sue_str, a23_str, yao_str, yao_inx, 44.0, 22.0),
-#             (2, yao_str, a23_str, bob_str, bob_str, 55.0, 22.0),
-#             (5, sue_str, a23_str, bob_str, bob_str, 55.0, 22.0),
-#             (7, bob_str, a23_str, bob_str, bob_str, 55.0, 66.0),
-#         ]
+        # THEN
+        assert get_row_count(cursor, budacct_v_agg_put_tablename) == 4
+        select_sqlstr = f"""SELECT {event_int_str()}
+, {face_name_str()}
+, {fisc_label_str()}
+, {owner_name_str()}
+, {acct_name_str()}
+, {credit_belief_str()}
+, {debtit_belief_str()}
+FROM {budacct_v_agg_put_tablename}
+"""
+        cursor.execute(select_sqlstr)
+        rows = cursor.fetchall()
+        print(rows)
+        assert rows == [
+            (event1, sue_str, a23_str, yao_str, yao_inx, 44.0, 22.0),
+            (event2, yao_str, a23_str, bob_str, bob_str, 55.0, 22.0),
+            (event5, sue_str, a23_str, bob_str, bob_str, 55.0, 22.0),
+            (event7, bob_str, a23_str, bob_str, bob_str, 55.0, 66.0),
+        ]
 
 
 # def test_etl_sound_agg_tables_to_voice_raw_tables_Scenario0_AddRowsToTable():

--- a/src/a18_etl_toolbox/tran_sqlstrs.py
+++ b/src/a18_etl_toolbox/tran_sqlstrs.py
@@ -1749,7 +1749,7 @@ def get_bud_insert_del_agg_from_raw_sqlstrs() -> dict[str, str]:
     }
 
 
-def get_idea_slabeleble_put_dimens() -> dict[str, list[str]]:
+def get_idea_stageble_put_dimens() -> dict[str, list[str]]:
     return {
         "br00000": ["fiscunit"],
         "br00001": ["budunit", "fisc_dealunit", "fiscunit"],
@@ -1800,7 +1800,7 @@ def get_idea_slabeleble_put_dimens() -> dict[str, list[str]]:
     }
 
 
-IDEA_SLABELEBLE_DEL_DIMENS = {
+IDEA_STAGEBLE_DEL_DIMENS = {
     "br00050": ["bud_acct_membership"],
     "br00051": ["bud_acctunit"],
     "br00052": ["bud_concept_awardlink"],

--- a/src/a18_etl_toolbox/tran_sqlstrs.py
+++ b/src/a18_etl_toolbox/tran_sqlstrs.py
@@ -730,26 +730,26 @@ INSERT_FISWEEK_VOICE_RAW_SQLSTR = "INSERT INTO fisc_timeline_weekday_v_raw (even
 INSERT_FISOFFI_VOICE_RAW_SQLSTR = "INSERT INTO fisc_timeoffi_v_raw (event_int, face_name_otx, fisc_label_otx, offi_time) SELECT event_int, face_name, fisc_label, offi_time FROM fisc_timeoffi_s_agg "
 INSERT_FISUNIT_VOICE_RAW_SQLSTR = "INSERT INTO fiscunit_v_raw (event_int, face_name_otx, fisc_label_otx, timeline_label_otx, c400_number, yr1_jan1_offset, monthday_distortion, fund_coin, penny, respect_bit, bridge, job_listen_rotations) SELECT event_int, face_name, fisc_label, timeline_label, c400_number, yr1_jan1_offset, monthday_distortion, fund_coin, penny, respect_bit, bridge, job_listen_rotations FROM fiscunit_s_agg "
 
-INSERT_BUDMEMB_VOICE_PUT_RAW_SQLSTR = "INSERT INTO bud_acct_membership_v_put_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, acct_name_otx, group_title_otx, credit_vote, debtit_vote) SELECT event_int, face_name, fisc_label, owner_name, acct_name, group_title, credit_vote, debtit_vote FROM bud_acct_membership_s_put_agg "
-INSERT_BUDMEMB_VOICE_DEL_RAW_SQLSTR = "INSERT INTO bud_acct_membership_v_del_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, acct_name_otx, group_title_ERASE_otx) SELECT event_int, face_name, fisc_label, owner_name, acct_name, group_title_ERASE FROM bud_acct_membership_s_del_agg "
-INSERT_BUDACCT_VOICE_PUT_RAW_SQLSTR = "INSERT INTO bud_acctunit_v_put_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, acct_name_otx, credit_belief, debtit_belief) SELECT event_int, face_name, fisc_label, owner_name, acct_name, credit_belief, debtit_belief FROM bud_acctunit_s_put_agg "
-INSERT_BUDACCT_VOICE_DEL_RAW_SQLSTR = "INSERT INTO bud_acctunit_v_del_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, acct_name_ERASE_otx) SELECT event_int, face_name, fisc_label, owner_name, acct_name_ERASE FROM bud_acctunit_s_del_agg "
-INSERT_BUDAWAR_VOICE_PUT_RAW_SQLSTR = "INSERT INTO bud_concept_awardlink_v_put_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, concept_way_otx, awardee_title_otx, give_force, take_force) SELECT event_int, face_name, fisc_label, owner_name, concept_way, awardee_title, give_force, take_force FROM bud_concept_awardlink_s_put_agg "
-INSERT_BUDAWAR_VOICE_DEL_RAW_SQLSTR = "INSERT INTO bud_concept_awardlink_v_del_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, concept_way_otx, awardee_title_ERASE_otx) SELECT event_int, face_name, fisc_label, owner_name, concept_way, awardee_title_ERASE FROM bud_concept_awardlink_s_del_agg "
-INSERT_BUDFACT_VOICE_PUT_RAW_SQLSTR = "INSERT INTO bud_concept_factunit_v_put_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, concept_way_otx, fcontext_otx, fbranch_otx, fopen, fnigh) SELECT event_int, face_name, fisc_label, owner_name, concept_way, fcontext, fbranch, fopen, fnigh FROM bud_concept_factunit_s_put_agg "
-INSERT_BUDFACT_VOICE_DEL_RAW_SQLSTR = "INSERT INTO bud_concept_factunit_v_del_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, concept_way_otx, fcontext_ERASE_otx) SELECT event_int, face_name, fisc_label, owner_name, concept_way, fcontext_ERASE FROM bud_concept_factunit_s_del_agg "
-INSERT_BUDHEAL_VOICE_PUT_RAW_SQLSTR = "INSERT INTO bud_concept_healerlink_v_put_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, concept_way_otx, healer_name_otx) SELECT event_int, face_name, fisc_label, owner_name, concept_way, healer_name FROM bud_concept_healerlink_s_put_agg "
-INSERT_BUDHEAL_VOICE_DEL_RAW_SQLSTR = "INSERT INTO bud_concept_healerlink_v_del_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, concept_way_otx, healer_name_ERASE_otx) SELECT event_int, face_name, fisc_label, owner_name, concept_way, healer_name_ERASE FROM bud_concept_healerlink_s_del_agg "
-INSERT_BUDPREM_VOICE_PUT_RAW_SQLSTR = "INSERT INTO bud_concept_reason_premiseunit_v_put_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, concept_way_otx, rcontext_otx, pbranch_otx, pnigh, popen, pdivisor) SELECT event_int, face_name, fisc_label, owner_name, concept_way, rcontext, pbranch, pnigh, popen, pdivisor FROM bud_concept_reason_premiseunit_s_put_agg "
-INSERT_BUDPREM_VOICE_DEL_RAW_SQLSTR = "INSERT INTO bud_concept_reason_premiseunit_v_del_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, concept_way_otx, rcontext_otx, pbranch_ERASE_otx) SELECT event_int, face_name, fisc_label, owner_name, concept_way, rcontext, pbranch_ERASE FROM bud_concept_reason_premiseunit_s_del_agg "
-INSERT_BUDREAS_VOICE_PUT_RAW_SQLSTR = "INSERT INTO bud_concept_reasonunit_v_put_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, concept_way_otx, rcontext_otx, rcontext_concept_active_requisite) SELECT event_int, face_name, fisc_label, owner_name, concept_way, rcontext, rcontext_concept_active_requisite FROM bud_concept_reasonunit_s_put_agg "
-INSERT_BUDREAS_VOICE_DEL_RAW_SQLSTR = "INSERT INTO bud_concept_reasonunit_v_del_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, concept_way_otx, rcontext_ERASE_otx) SELECT event_int, face_name, fisc_label, owner_name, concept_way, rcontext_ERASE FROM bud_concept_reasonunit_s_del_agg "
-INSERT_BUDLABO_VOICE_PUT_RAW_SQLSTR = "INSERT INTO bud_concept_laborlink_v_put_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, concept_way_otx, labor_title_otx) SELECT event_int, face_name, fisc_label, owner_name, concept_way, labor_title FROM bud_concept_laborlink_s_put_agg "
-INSERT_BUDLABO_VOICE_DEL_RAW_SQLSTR = "INSERT INTO bud_concept_laborlink_v_del_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, concept_way_otx, labor_title_ERASE_otx) SELECT event_int, face_name, fisc_label, owner_name, concept_way, labor_title_ERASE FROM bud_concept_laborlink_s_del_agg "
-INSERT_BUDCONC_VOICE_PUT_RAW_SQLSTR = "INSERT INTO bud_conceptunit_v_put_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, concept_way_otx, begin, close, addin, numor, denom, morph, gogo_want, stop_want, mass, pledge, problem_bool) SELECT event_int, face_name, fisc_label, owner_name, concept_way, begin, close, addin, numor, denom, morph, gogo_want, stop_want, mass, pledge, problem_bool FROM bud_conceptunit_s_put_agg "
-INSERT_BUDCONC_VOICE_DEL_RAW_SQLSTR = "INSERT INTO bud_conceptunit_v_del_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, concept_way_ERASE_otx) SELECT event_int, face_name, fisc_label, owner_name, concept_way_ERASE FROM bud_conceptunit_s_del_agg "
-INSERT_BUDUNIT_VOICE_PUT_RAW_SQLSTR = "INSERT INTO budunit_v_put_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, credor_respect, debtor_respect, fund_pool, max_tree_traverse, tally, fund_coin, penny, respect_bit) SELECT event_int, face_name, fisc_label, owner_name, credor_respect, debtor_respect, fund_pool, max_tree_traverse, tally, fund_coin, penny, respect_bit FROM budunit_s_put_agg "
-INSERT_BUDUNIT_VOICE_DEL_RAW_SQLSTR = "INSERT INTO budunit_v_del_raw (event_int, face_name_otx, fisc_label_otx, owner_name_ERASE_otx) SELECT event_int, face_name, fisc_label, owner_name_ERASE FROM budunit_s_del_agg "
+INSERT_BUDMEMB_VOICE_RAW_PUT_SQLSTR = "INSERT INTO bud_acct_membership_v_put_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, acct_name_otx, group_title_otx, credit_vote, debtit_vote) SELECT event_int, face_name, fisc_label, owner_name, acct_name, group_title, credit_vote, debtit_vote FROM bud_acct_membership_s_put_agg "
+INSERT_BUDMEMB_VOICE_RAW_DEL_SQLSTR = "INSERT INTO bud_acct_membership_v_del_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, acct_name_otx, group_title_ERASE_otx) SELECT event_int, face_name, fisc_label, owner_name, acct_name, group_title_ERASE FROM bud_acct_membership_s_del_agg "
+INSERT_BUDACCT_VOICE_RAW_PUT_SQLSTR = "INSERT INTO bud_acctunit_v_put_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, acct_name_otx, credit_belief, debtit_belief) SELECT event_int, face_name, fisc_label, owner_name, acct_name, credit_belief, debtit_belief FROM bud_acctunit_s_put_agg "
+INSERT_BUDACCT_VOICE_RAW_DEL_SQLSTR = "INSERT INTO bud_acctunit_v_del_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, acct_name_ERASE_otx) SELECT event_int, face_name, fisc_label, owner_name, acct_name_ERASE FROM bud_acctunit_s_del_agg "
+INSERT_BUDAWAR_VOICE_RAW_PUT_SQLSTR = "INSERT INTO bud_concept_awardlink_v_put_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, concept_way_otx, awardee_title_otx, give_force, take_force) SELECT event_int, face_name, fisc_label, owner_name, concept_way, awardee_title, give_force, take_force FROM bud_concept_awardlink_s_put_agg "
+INSERT_BUDAWAR_VOICE_RAW_DEL_SQLSTR = "INSERT INTO bud_concept_awardlink_v_del_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, concept_way_otx, awardee_title_ERASE_otx) SELECT event_int, face_name, fisc_label, owner_name, concept_way, awardee_title_ERASE FROM bud_concept_awardlink_s_del_agg "
+INSERT_BUDFACT_VOICE_RAW_PUT_SQLSTR = "INSERT INTO bud_concept_factunit_v_put_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, concept_way_otx, fcontext_otx, fbranch_otx, fopen, fnigh) SELECT event_int, face_name, fisc_label, owner_name, concept_way, fcontext, fbranch, fopen, fnigh FROM bud_concept_factunit_s_put_agg "
+INSERT_BUDFACT_VOICE_RAW_DEL_SQLSTR = "INSERT INTO bud_concept_factunit_v_del_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, concept_way_otx, fcontext_ERASE_otx) SELECT event_int, face_name, fisc_label, owner_name, concept_way, fcontext_ERASE FROM bud_concept_factunit_s_del_agg "
+INSERT_BUDHEAL_VOICE_RAW_PUT_SQLSTR = "INSERT INTO bud_concept_healerlink_v_put_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, concept_way_otx, healer_name_otx) SELECT event_int, face_name, fisc_label, owner_name, concept_way, healer_name FROM bud_concept_healerlink_s_put_agg "
+INSERT_BUDHEAL_VOICE_RAW_DEL_SQLSTR = "INSERT INTO bud_concept_healerlink_v_del_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, concept_way_otx, healer_name_ERASE_otx) SELECT event_int, face_name, fisc_label, owner_name, concept_way, healer_name_ERASE FROM bud_concept_healerlink_s_del_agg "
+INSERT_BUDPREM_VOICE_RAW_PUT_SQLSTR = "INSERT INTO bud_concept_reason_premiseunit_v_put_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, concept_way_otx, rcontext_otx, pbranch_otx, pnigh, popen, pdivisor) SELECT event_int, face_name, fisc_label, owner_name, concept_way, rcontext, pbranch, pnigh, popen, pdivisor FROM bud_concept_reason_premiseunit_s_put_agg "
+INSERT_BUDPREM_VOICE_RAW_DEL_SQLSTR = "INSERT INTO bud_concept_reason_premiseunit_v_del_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, concept_way_otx, rcontext_otx, pbranch_ERASE_otx) SELECT event_int, face_name, fisc_label, owner_name, concept_way, rcontext, pbranch_ERASE FROM bud_concept_reason_premiseunit_s_del_agg "
+INSERT_BUDREAS_VOICE_RAW_PUT_SQLSTR = "INSERT INTO bud_concept_reasonunit_v_put_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, concept_way_otx, rcontext_otx, rcontext_concept_active_requisite) SELECT event_int, face_name, fisc_label, owner_name, concept_way, rcontext, rcontext_concept_active_requisite FROM bud_concept_reasonunit_s_put_agg "
+INSERT_BUDREAS_VOICE_RAW_DEL_SQLSTR = "INSERT INTO bud_concept_reasonunit_v_del_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, concept_way_otx, rcontext_ERASE_otx) SELECT event_int, face_name, fisc_label, owner_name, concept_way, rcontext_ERASE FROM bud_concept_reasonunit_s_del_agg "
+INSERT_BUDLABO_VOICE_RAW_PUT_SQLSTR = "INSERT INTO bud_concept_laborlink_v_put_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, concept_way_otx, labor_title_otx) SELECT event_int, face_name, fisc_label, owner_name, concept_way, labor_title FROM bud_concept_laborlink_s_put_agg "
+INSERT_BUDLABO_VOICE_RAW_DEL_SQLSTR = "INSERT INTO bud_concept_laborlink_v_del_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, concept_way_otx, labor_title_ERASE_otx) SELECT event_int, face_name, fisc_label, owner_name, concept_way, labor_title_ERASE FROM bud_concept_laborlink_s_del_agg "
+INSERT_BUDCONC_VOICE_RAW_PUT_SQLSTR = "INSERT INTO bud_conceptunit_v_put_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, concept_way_otx, begin, close, addin, numor, denom, morph, gogo_want, stop_want, mass, pledge, problem_bool) SELECT event_int, face_name, fisc_label, owner_name, concept_way, begin, close, addin, numor, denom, morph, gogo_want, stop_want, mass, pledge, problem_bool FROM bud_conceptunit_s_put_agg "
+INSERT_BUDCONC_VOICE_RAW_DEL_SQLSTR = "INSERT INTO bud_conceptunit_v_del_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, concept_way_ERASE_otx) SELECT event_int, face_name, fisc_label, owner_name, concept_way_ERASE FROM bud_conceptunit_s_del_agg "
+INSERT_BUDUNIT_VOICE_RAW_PUT_SQLSTR = "INSERT INTO budunit_v_put_raw (event_int, face_name_otx, fisc_label_otx, owner_name_otx, credor_respect, debtor_respect, fund_pool, max_tree_traverse, tally, fund_coin, penny, respect_bit) SELECT event_int, face_name, fisc_label, owner_name, credor_respect, debtor_respect, fund_pool, max_tree_traverse, tally, fund_coin, penny, respect_bit FROM budunit_s_put_agg "
+INSERT_BUDUNIT_VOICE_RAW_DEL_SQLSTR = "INSERT INTO budunit_v_del_raw (event_int, face_name_otx, fisc_label_otx, owner_name_ERASE_otx) SELECT event_int, face_name, fisc_label, owner_name_ERASE FROM budunit_s_del_agg "
 
 
 def get_insert_into_voice_raw_sqlstrs() -> dict[str, str]:
@@ -761,26 +761,26 @@ def get_insert_into_voice_raw_sqlstrs() -> dict[str, str]:
         "fisc_timeline_weekday_v_raw": INSERT_FISWEEK_VOICE_RAW_SQLSTR,
         "fisc_timeoffi_v_raw": INSERT_FISOFFI_VOICE_RAW_SQLSTR,
         "fiscunit_v_raw": INSERT_FISUNIT_VOICE_RAW_SQLSTR,
-        "bud_acct_membership_v_put_raw": INSERT_BUDMEMB_VOICE_PUT_RAW_SQLSTR,
-        "bud_acct_membership_v_del_raw": INSERT_BUDMEMB_VOICE_DEL_RAW_SQLSTR,
-        "bud_acctunit_v_put_raw": INSERT_BUDACCT_VOICE_PUT_RAW_SQLSTR,
-        "bud_acctunit_v_del_raw": INSERT_BUDACCT_VOICE_DEL_RAW_SQLSTR,
-        "bud_concept_awardlink_v_put_raw": INSERT_BUDAWAR_VOICE_PUT_RAW_SQLSTR,
-        "bud_concept_awardlink_v_del_raw": INSERT_BUDAWAR_VOICE_DEL_RAW_SQLSTR,
-        "bud_concept_factunit_v_put_raw": INSERT_BUDFACT_VOICE_PUT_RAW_SQLSTR,
-        "bud_concept_factunit_v_del_raw": INSERT_BUDFACT_VOICE_DEL_RAW_SQLSTR,
-        "bud_concept_healerlink_v_put_raw": INSERT_BUDHEAL_VOICE_PUT_RAW_SQLSTR,
-        "bud_concept_healerlink_v_del_raw": INSERT_BUDHEAL_VOICE_DEL_RAW_SQLSTR,
-        "bud_concept_reason_premiseunit_v_put_raw": INSERT_BUDPREM_VOICE_PUT_RAW_SQLSTR,
-        "bud_concept_reason_premiseunit_v_del_raw": INSERT_BUDPREM_VOICE_DEL_RAW_SQLSTR,
-        "bud_concept_reasonunit_v_put_raw": INSERT_BUDREAS_VOICE_PUT_RAW_SQLSTR,
-        "bud_concept_reasonunit_v_del_raw": INSERT_BUDREAS_VOICE_DEL_RAW_SQLSTR,
-        "bud_concept_laborlink_v_put_raw": INSERT_BUDLABO_VOICE_PUT_RAW_SQLSTR,
-        "bud_concept_laborlink_v_del_raw": INSERT_BUDLABO_VOICE_DEL_RAW_SQLSTR,
-        "bud_conceptunit_v_put_raw": INSERT_BUDCONC_VOICE_PUT_RAW_SQLSTR,
-        "bud_conceptunit_v_del_raw": INSERT_BUDCONC_VOICE_DEL_RAW_SQLSTR,
-        "budunit_v_put_raw": INSERT_BUDUNIT_VOICE_PUT_RAW_SQLSTR,
-        "budunit_v_del_raw": INSERT_BUDUNIT_VOICE_DEL_RAW_SQLSTR,
+        "bud_acct_membership_v_put_raw": INSERT_BUDMEMB_VOICE_RAW_PUT_SQLSTR,
+        "bud_acct_membership_v_del_raw": INSERT_BUDMEMB_VOICE_RAW_DEL_SQLSTR,
+        "bud_acctunit_v_put_raw": INSERT_BUDACCT_VOICE_RAW_PUT_SQLSTR,
+        "bud_acctunit_v_del_raw": INSERT_BUDACCT_VOICE_RAW_DEL_SQLSTR,
+        "bud_concept_awardlink_v_put_raw": INSERT_BUDAWAR_VOICE_RAW_PUT_SQLSTR,
+        "bud_concept_awardlink_v_del_raw": INSERT_BUDAWAR_VOICE_RAW_DEL_SQLSTR,
+        "bud_concept_factunit_v_put_raw": INSERT_BUDFACT_VOICE_RAW_PUT_SQLSTR,
+        "bud_concept_factunit_v_del_raw": INSERT_BUDFACT_VOICE_RAW_DEL_SQLSTR,
+        "bud_concept_healerlink_v_put_raw": INSERT_BUDHEAL_VOICE_RAW_PUT_SQLSTR,
+        "bud_concept_healerlink_v_del_raw": INSERT_BUDHEAL_VOICE_RAW_DEL_SQLSTR,
+        "bud_concept_reason_premiseunit_v_put_raw": INSERT_BUDPREM_VOICE_RAW_PUT_SQLSTR,
+        "bud_concept_reason_premiseunit_v_del_raw": INSERT_BUDPREM_VOICE_RAW_DEL_SQLSTR,
+        "bud_concept_reasonunit_v_put_raw": INSERT_BUDREAS_VOICE_RAW_PUT_SQLSTR,
+        "bud_concept_reasonunit_v_del_raw": INSERT_BUDREAS_VOICE_RAW_DEL_SQLSTR,
+        "bud_concept_laborlink_v_put_raw": INSERT_BUDLABO_VOICE_RAW_PUT_SQLSTR,
+        "bud_concept_laborlink_v_del_raw": INSERT_BUDLABO_VOICE_RAW_DEL_SQLSTR,
+        "bud_conceptunit_v_put_raw": INSERT_BUDCONC_VOICE_RAW_PUT_SQLSTR,
+        "bud_conceptunit_v_del_raw": INSERT_BUDCONC_VOICE_RAW_DEL_SQLSTR,
+        "budunit_v_put_raw": INSERT_BUDUNIT_VOICE_RAW_PUT_SQLSTR,
+        "budunit_v_del_raw": INSERT_BUDUNIT_VOICE_RAW_DEL_SQLSTR,
     }
 
 
@@ -920,6 +920,147 @@ FROM fiscunit_v_raw
 GROUP BY fisc_label_inx, timeline_label_inx, c400_number, yr1_jan1_offset, monthday_distortion, fund_coin, penny, respect_bit, bridge, job_listen_rotations
 """
 
+INSERT_BUDMEMB_VOICE_AGG_PUT_SQLSTR = """
+INSERT INTO bud_acct_membership_v_put_agg (event_int, face_name, fisc_label, owner_name, acct_name, group_title, credit_vote, debtit_vote)
+SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, acct_name_inx, group_title_inx, credit_vote, debtit_vote
+WHERE error_message IS NULL
+FROM bud_acct_membership_v_put_raw
+GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, acct_name_inx, group_title_inx, credit_vote, debtit_vote
+"""
+INSERT_BUDMEMB_VOICE_AGG_DEL_SQLSTR = """
+INSERT INTO bud_acct_membership_v_del_agg (event_int, face_name, fisc_label, owner_name, acct_name, group_title_ERASE)
+SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, acct_name_inx, group_title_ERASE_inx
+WHERE error_message IS NULL
+FROM bud_acct_membership_v_del_raw
+GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, acct_name_inx, group_title_ERASE_inx
+"""
+INSERT_BUDACCT_VOICE_AGG_PUT_SQLSTR = """
+INSERT INTO bud_acctunit_v_put_agg (event_int, face_name, fisc_label, owner_name, acct_name, credit_belief, debtit_belief)
+SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, acct_name_inx, credit_belief, debtit_belief
+WHERE error_message IS NULL
+FROM bud_acctunit_v_put_raw
+GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, acct_name_inx, credit_belief, debtit_belief
+"""
+INSERT_BUDACCT_VOICE_AGG_DEL_SQLSTR = """
+INSERT INTO bud_acctunit_v_del_agg (event_int, face_name, fisc_label, owner_name, acct_name_ERASE)
+SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, acct_name_ERASE_inx
+WHERE error_message IS NULL
+FROM bud_acctunit_v_del_raw
+GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, acct_name_ERASE_inx
+"""
+INSERT_BUDAWAR_VOICE_AGG_PUT_SQLSTR = """
+INSERT INTO bud_concept_awardlink_v_put_agg (event_int, face_name, fisc_label, owner_name, concept_way, awardee_title, give_force, take_force)
+SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, awardee_title_inx, give_force, take_force
+WHERE error_message IS NULL
+FROM bud_concept_awardlink_v_put_raw
+GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, awardee_title_inx, give_force, take_force
+"""
+INSERT_BUDAWAR_VOICE_AGG_DEL_SQLSTR = """
+INSERT INTO bud_concept_awardlink_v_del_agg (event_int, face_name, fisc_label, owner_name, concept_way, awardee_title_ERASE)
+SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, awardee_title_ERASE_inx
+WHERE error_message IS NULL
+FROM bud_concept_awardlink_v_del_raw
+GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, awardee_title_ERASE_inx
+"""
+INSERT_BUDFACT_VOICE_AGG_PUT_SQLSTR = """
+INSERT INTO bud_concept_factunit_v_put_agg (event_int, face_name, fisc_label, owner_name, concept_way, fcontext, fbranch, fopen, fnigh)
+SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, fcontext_inx, fbranch_inx, fopen, fnigh
+WHERE error_message IS NULL
+FROM bud_concept_factunit_v_put_raw
+GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, fcontext_inx, fbranch_inx, fopen, fnigh
+"""
+INSERT_BUDFACT_VOICE_AGG_DEL_SQLSTR = """
+INSERT INTO bud_concept_factunit_v_del_agg (event_int, face_name, fisc_label, owner_name, concept_way, fcontext_ERASE)
+SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, fcontext_ERASE_inx
+WHERE error_message IS NULL
+FROM bud_concept_factunit_v_del_raw
+GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, fcontext_ERASE_inx
+"""
+INSERT_BUDHEAL_VOICE_AGG_PUT_SQLSTR = """
+INSERT INTO bud_concept_healerlink_v_put_agg (event_int, face_name, fisc_label, owner_name, concept_way, healer_name)
+SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, healer_name_inx
+WHERE error_message IS NULL
+FROM bud_concept_healerlink_v_put_raw
+GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, healer_name_inx
+"""
+INSERT_BUDHEAL_VOICE_AGG_DEL_SQLSTR = """
+INSERT INTO bud_concept_healerlink_v_del_agg (event_int, face_name, fisc_label, owner_name, concept_way, healer_name_ERASE)
+SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, healer_name_ERASE_inx
+WHERE error_message IS NULL
+FROM bud_concept_healerlink_v_del_raw
+GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, healer_name_ERASE_inx
+"""
+INSERT_BUDPREM_VOICE_AGG_PUT_SQLSTR = """
+INSERT INTO bud_concept_reason_premiseunit_v_put_agg (event_int, face_name, fisc_label, owner_name, concept_way, rcontext, pbranch, pnigh, popen, pdivisor)
+SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, rcontext_inx, pbranch_inx, pnigh, popen, pdivisor
+WHERE error_message IS NULL
+FROM bud_concept_reason_premiseunit_v_put_raw
+GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, rcontext_inx, pbranch_inx, pnigh, popen, pdivisor
+"""
+INSERT_BUDPREM_VOICE_AGG_DEL_SQLSTR = """
+INSERT INTO bud_concept_reason_premiseunit_v_del_agg (event_int, face_name, fisc_label, owner_name, concept_way, rcontext, pbranch_ERASE)
+SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, rcontext_inx, pbranch_ERASE_inx
+WHERE error_message IS NULL
+FROM bud_concept_reason_premiseunit_v_del_raw
+GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, rcontext_inx, pbranch_ERASE_inx
+"""
+INSERT_BUDREAS_VOICE_AGG_PUT_SQLSTR = """
+INSERT INTO bud_concept_reasonunit_v_put_agg (event_int, face_name, fisc_label, owner_name, concept_way, rcontext, rcontext_concept_active_requisite)
+SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, rcontext_inx, rcontext_concept_active_requisite
+WHERE error_message IS NULL
+FROM bud_concept_reasonunit_v_put_raw
+GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, rcontext_inx, rcontext_concept_active_requisite
+"""
+INSERT_BUDREAS_VOICE_AGG_DEL_SQLSTR = """
+INSERT INTO bud_concept_reasonunit_v_del_agg (event_int, face_name, fisc_label, owner_name, concept_way, rcontext_ERASE)
+SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, rcontext_ERASE_inx
+WHERE error_message IS NULL
+FROM bud_concept_reasonunit_v_del_raw
+GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, rcontext_ERASE_inx
+"""
+INSERT_BUDLABO_VOICE_AGG_PUT_SQLSTR = """
+INSERT INTO bud_concept_laborlink_v_put_agg (event_int, face_name, fisc_label, owner_name, concept_way, labor_title)
+SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, labor_title_inx
+WHERE error_message IS NULL
+FROM bud_concept_laborlink_v_put_raw
+GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, labor_title_inx
+"""
+INSERT_BUDLABO_VOICE_AGG_DEL_SQLSTR = """
+INSERT INTO bud_concept_laborlink_v_del_agg (event_int, face_name, fisc_label, owner_name, concept_way, labor_title_ERASE)
+SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, labor_title_ERASE_inx
+WHERE error_message IS NULL
+FROM bud_concept_laborlink_v_del_raw
+GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, labor_title_ERASE_inx
+"""
+INSERT_BUDCONC_VOICE_AGG_PUT_SQLSTR = """
+INSERT INTO bud_conceptunit_v_put_agg (event_int, face_name, fisc_label, owner_name, concept_way, begin, close, addin, numor, denom, morph, gogo_want, stop_want, mass, pledge, problem_bool)
+SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, begin, close, addin, numor, denom, morph, gogo_want, stop_want, mass, pledge, problem_bool
+WHERE error_message IS NULL
+FROM bud_conceptunit_v_put_raw
+GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, begin, close, addin, numor, denom, morph, gogo_want, stop_want, mass, pledge, problem_bool
+"""
+INSERT_BUDCONC_VOICE_AGG_DEL_SQLSTR = """
+INSERT INTO bud_conceptunit_v_del_agg (event_int, face_name, fisc_label, owner_name, concept_way_ERASE)
+SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_ERASE_inx
+WHERE error_message IS NULL
+FROM bud_conceptunit_v_del_raw
+GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_ERASE_inx
+"""
+INSERT_BUDUNIT_VOICE_AGG_PUT_SQLSTR = """
+INSERT INTO budunit_v_put_agg (event_int, face_name, fisc_label, owner_name, credor_respect, debtor_respect, fund_pool, max_tree_traverse, tally, fund_coin, penny, respect_bit)
+SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, credor_respect, debtor_respect, fund_pool, max_tree_traverse, tally, fund_coin, penny, respect_bit
+WHERE error_message IS NULL
+FROM budunit_v_put_raw
+GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, credor_respect, debtor_respect, fund_pool, max_tree_traverse, tally, fund_coin, penny, respect_bit
+"""
+INSERT_BUDUNIT_VOICE_AGG_DEL_SQLSTR = """
+INSERT INTO budunit_v_del_agg (event_int, face_name, fisc_label, owner_name_ERASE)
+SELECT pidgin_event_int, fisc_label_inx, owner_name_ERASE_inx
+WHERE error_message IS NULL
+FROM budunit_v_del_raw
+GROUP BY pidgin_event_int, fisc_label_inx, owner_name_ERASE_inx
+"""
+
 
 def get_insert_voice_agg_sqlstrs() -> dict[str, str]:
     return {
@@ -930,6 +1071,26 @@ def get_insert_voice_agg_sqlstrs() -> dict[str, str]:
         "fisc_timeline_weekday": FISWEEK_VOICE_AGG_INSERT_SQLSTR,
         "fisc_timeoffi": FISOFFI_VOICE_AGG_INSERT_SQLSTR,
         "fiscunit": FISUNIT_VOICE_AGG_INSERT_SQLSTR,
+        "bud_acct_membership_v_put_agg": INSERT_BUDMEMB_VOICE_AGG_PUT_SQLSTR,
+        "bud_acct_membership_v_del_agg": INSERT_BUDMEMB_VOICE_AGG_DEL_SQLSTR,
+        "bud_acctunit_v_put_agg": INSERT_BUDACCT_VOICE_AGG_PUT_SQLSTR,
+        "bud_acctunit_v_del_agg": INSERT_BUDACCT_VOICE_AGG_DEL_SQLSTR,
+        "bud_concept_awardlink_v_put_agg": INSERT_BUDAWAR_VOICE_AGG_PUT_SQLSTR,
+        "bud_concept_awardlink_v_del_agg": INSERT_BUDAWAR_VOICE_AGG_DEL_SQLSTR,
+        "bud_concept_factunit_v_put_agg": INSERT_BUDFACT_VOICE_AGG_PUT_SQLSTR,
+        "bud_concept_factunit_v_del_agg": INSERT_BUDFACT_VOICE_AGG_DEL_SQLSTR,
+        "bud_concept_healerlink_v_put_agg": INSERT_BUDHEAL_VOICE_AGG_PUT_SQLSTR,
+        "bud_concept_healerlink_v_del_agg": INSERT_BUDHEAL_VOICE_AGG_DEL_SQLSTR,
+        "bud_concept_reason_premiseunit_v_put_agg": INSERT_BUDPREM_VOICE_AGG_PUT_SQLSTR,
+        "bud_concept_reason_premiseunit_v_del_agg": INSERT_BUDPREM_VOICE_AGG_DEL_SQLSTR,
+        "bud_concept_reasonunit_v_put_agg": INSERT_BUDREAS_VOICE_AGG_PUT_SQLSTR,
+        "bud_concept_reasonunit_v_del_agg": INSERT_BUDREAS_VOICE_AGG_DEL_SQLSTR,
+        "bud_concept_laborlink_v_put_agg": INSERT_BUDLABO_VOICE_AGG_PUT_SQLSTR,
+        "bud_concept_laborlink_v_del_agg": INSERT_BUDLABO_VOICE_AGG_DEL_SQLSTR,
+        "bud_conceptunit_v_put_agg": INSERT_BUDCONC_VOICE_AGG_PUT_SQLSTR,
+        "bud_conceptunit_v_del_agg": INSERT_BUDCONC_VOICE_AGG_DEL_SQLSTR,
+        "budunit_v_put_agg": INSERT_BUDUNIT_VOICE_AGG_PUT_SQLSTR,
+        "budunit_v_del_agg": INSERT_BUDUNIT_VOICE_AGG_DEL_SQLSTR,
     }
 
 

--- a/src/a18_etl_toolbox/tran_sqlstrs.py
+++ b/src/a18_etl_toolbox/tran_sqlstrs.py
@@ -67,7 +67,7 @@ def get_dimen_abbv7(dimen: str) -> str:
 
 
 def create_prime_tablename(
-    idea_dimen_or_abbv7: str, sound: str, slabele: str, put_del: str = None
+    idea_dimen_or_abbv7: str, sound: str, stage: str, put_del: str = None
 ) -> str:
     abbv_references = {
         "FISCASH": "fisc_cashbook",
@@ -99,7 +99,7 @@ def create_prime_tablename(
     if sound in {"s", "v"}:
         tablename = f"{tablename}_{sound}"
 
-    return f"{tablename}_{put_del}_{slabele}" if put_del else f"{tablename}_{slabele}"
+    return f"{tablename}_{put_del}_{stage}" if put_del else f"{tablename}_{stage}"
 
 
 CREATE_PIDTITL_SOUND_RAW_SQLSTR = """CREATE TABLE IF NOT EXISTS pidgin_title_s_raw (idea_number TEXT, event_int INTEGER, face_name TEXT, otx_title TEXT, inx_title TEXT, otx_bridge TEXT, inx_bridge TEXT, unknown_term TEXT, error_message TEXT)"""
@@ -868,6 +868,69 @@ SET {column_prefix}_inx = {column_prefix}_otx
 WHERE {column_prefix}_inx IS NULL
 ;
 """
+
+
+FISCASH_VOICE_AGG_INSERT_SQLSTR = """
+INSERT INTO fisc_cashbook_v_agg (fisc_label, owner_name, acct_name, tran_time, amount)
+SELECT fisc_label_inx, owner_name_inx, acct_name_inx, tran_time, amount
+WHERE error_message IS NULL
+FROM fisc_cashbook_v_raw
+GROUP BY fisc_label_inx, owner_name_inx, acct_name_inx, tran_time, amount
+"""
+FISDEAL_VOICE_AGG_INSERT_SQLSTR = """
+INSERT INTO fisc_dealunit_v_agg (fisc_label, owner_name, deal_time, quota, celldepth)
+SELECT fisc_label_inx, owner_name_inx, deal_time, quota, celldepth
+WHERE error_message IS NULL
+FROM fisc_dealunit_v_raw
+GROUP BY fisc_label_inx, owner_name_inx, deal_time, quota, celldepth
+"""
+FISHOUR_VOICE_AGG_INSERT_SQLSTR = """
+INSERT INTO fisc_timeline_hour_v_agg (fisc_label, cumlative_minute, hour_label)
+SELECT fisc_label_inx, cumlative_minute, hour_label_inx
+WHERE error_message IS NULL
+FROM fisc_timeline_hour_v_raw
+GROUP BY fisc_label_inx, cumlative_minute, hour_label_inx
+"""
+FISMONT_VOICE_AGG_INSERT_SQLSTR = """
+INSERT INTO fisc_timeline_month_v_agg (fisc_label, cumlative_day, month_label)
+SELECT fisc_label_inx, cumlative_day, month_label_inx
+WHERE error_message IS NULL
+FROM fisc_timeline_month_v_raw
+GROUP BY fisc_label_inx, cumlative_day, month_label_inx
+"""
+FISWEEK_VOICE_AGG_INSERT_SQLSTR = """
+INSERT INTO fisc_timeline_weekday_v_agg (fisc_label, weekday_order, weekday_label)
+SELECT fisc_label_inx, weekday_order, weekday_label_inx
+WHERE error_message IS NULL
+FROM fisc_timeline_weekday_v_raw
+GROUP BY fisc_label_inx, weekday_order, weekday_label_inx
+"""
+FISOFFI_VOICE_AGG_INSERT_SQLSTR = """
+INSERT INTO fisc_timeoffi_v_agg (fisc_label, offi_time)
+SELECT fisc_label_inx, offi_time
+WHERE error_message IS NULL
+FROM fisc_timeoffi_v_raw
+GROUP BY fisc_label_inx, offi_time
+"""
+FISUNIT_VOICE_AGG_INSERT_SQLSTR = """
+INSERT INTO fiscunit_v_agg (fisc_label, timeline_label, c400_number, yr1_jan1_offset, monthday_distortion, fund_coin, penny, respect_bit, bridge, job_listen_rotations)
+SELECT fisc_label_inx, timeline_label_inx, c400_number, yr1_jan1_offset, monthday_distortion, fund_coin, penny, respect_bit, bridge, job_listen_rotations
+WHERE error_message IS NULL
+FROM fiscunit_v_raw
+GROUP BY fisc_label_inx, timeline_label_inx, c400_number, yr1_jan1_offset, monthday_distortion, fund_coin, penny, respect_bit, bridge, job_listen_rotations
+"""
+
+
+def get_insert_voice_agg_sqlstrs() -> dict[str, str]:
+    return {
+        "fisc_cashbook": FISCASH_VOICE_AGG_INSERT_SQLSTR,
+        "fisc_dealunit": FISDEAL_VOICE_AGG_INSERT_SQLSTR,
+        "fisc_timeline_hour": FISHOUR_VOICE_AGG_INSERT_SQLSTR,
+        "fisc_timeline_month": FISMONT_VOICE_AGG_INSERT_SQLSTR,
+        "fisc_timeline_weekday": FISWEEK_VOICE_AGG_INSERT_SQLSTR,
+        "fisc_timeoffi": FISOFFI_VOICE_AGG_INSERT_SQLSTR,
+        "fiscunit": FISUNIT_VOICE_AGG_INSERT_SQLSTR,
+    }
 
 
 PIDTITL_INCONSISTENCY_SQLSTR = """SELECT otx_title

--- a/src/a18_etl_toolbox/tran_sqlstrs.py
+++ b/src/a18_etl_toolbox/tran_sqlstrs.py
@@ -873,192 +873,165 @@ WHERE {column_prefix}_inx IS NULL
 FISCASH_VOICE_AGG_INSERT_SQLSTR = """
 INSERT INTO fisc_cashbook_v_agg (fisc_label, owner_name, acct_name, tran_time, amount)
 SELECT fisc_label_inx, owner_name_inx, acct_name_inx, tran_time, amount
-WHERE error_message IS NULL
 FROM fisc_cashbook_v_raw
 GROUP BY fisc_label_inx, owner_name_inx, acct_name_inx, tran_time, amount
 """
 FISDEAL_VOICE_AGG_INSERT_SQLSTR = """
 INSERT INTO fisc_dealunit_v_agg (fisc_label, owner_name, deal_time, quota, celldepth)
 SELECT fisc_label_inx, owner_name_inx, deal_time, quota, celldepth
-WHERE error_message IS NULL
 FROM fisc_dealunit_v_raw
 GROUP BY fisc_label_inx, owner_name_inx, deal_time, quota, celldepth
 """
 FISHOUR_VOICE_AGG_INSERT_SQLSTR = """
 INSERT INTO fisc_timeline_hour_v_agg (fisc_label, cumlative_minute, hour_label)
 SELECT fisc_label_inx, cumlative_minute, hour_label_inx
-WHERE error_message IS NULL
 FROM fisc_timeline_hour_v_raw
 GROUP BY fisc_label_inx, cumlative_minute, hour_label_inx
 """
 FISMONT_VOICE_AGG_INSERT_SQLSTR = """
 INSERT INTO fisc_timeline_month_v_agg (fisc_label, cumlative_day, month_label)
 SELECT fisc_label_inx, cumlative_day, month_label_inx
-WHERE error_message IS NULL
 FROM fisc_timeline_month_v_raw
 GROUP BY fisc_label_inx, cumlative_day, month_label_inx
 """
 FISWEEK_VOICE_AGG_INSERT_SQLSTR = """
 INSERT INTO fisc_timeline_weekday_v_agg (fisc_label, weekday_order, weekday_label)
 SELECT fisc_label_inx, weekday_order, weekday_label_inx
-WHERE error_message IS NULL
 FROM fisc_timeline_weekday_v_raw
 GROUP BY fisc_label_inx, weekday_order, weekday_label_inx
 """
 FISOFFI_VOICE_AGG_INSERT_SQLSTR = """
 INSERT INTO fisc_timeoffi_v_agg (fisc_label, offi_time)
 SELECT fisc_label_inx, offi_time
-WHERE error_message IS NULL
 FROM fisc_timeoffi_v_raw
 GROUP BY fisc_label_inx, offi_time
 """
 FISUNIT_VOICE_AGG_INSERT_SQLSTR = """
 INSERT INTO fiscunit_v_agg (fisc_label, timeline_label, c400_number, yr1_jan1_offset, monthday_distortion, fund_coin, penny, respect_bit, bridge, job_listen_rotations)
 SELECT fisc_label_inx, timeline_label_inx, c400_number, yr1_jan1_offset, monthday_distortion, fund_coin, penny, respect_bit, bridge, job_listen_rotations
-WHERE error_message IS NULL
 FROM fiscunit_v_raw
 GROUP BY fisc_label_inx, timeline_label_inx, c400_number, yr1_jan1_offset, monthday_distortion, fund_coin, penny, respect_bit, bridge, job_listen_rotations
 """
 
 INSERT_BUDMEMB_VOICE_AGG_PUT_SQLSTR = """
 INSERT INTO bud_acct_membership_v_put_agg (event_int, face_name, fisc_label, owner_name, acct_name, group_title, credit_vote, debtit_vote)
-SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, acct_name_inx, group_title_inx, credit_vote, debtit_vote
-WHERE error_message IS NULL
+SELECT event_int, face_name_inx, fisc_label_inx, owner_name_inx, acct_name_inx, group_title_inx, credit_vote, debtit_vote
 FROM bud_acct_membership_v_put_raw
-GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, acct_name_inx, group_title_inx, credit_vote, debtit_vote
+GROUP BY event_int, face_name_inx, fisc_label_inx, owner_name_inx, acct_name_inx, group_title_inx, credit_vote, debtit_vote
 """
 INSERT_BUDMEMB_VOICE_AGG_DEL_SQLSTR = """
 INSERT INTO bud_acct_membership_v_del_agg (event_int, face_name, fisc_label, owner_name, acct_name, group_title_ERASE)
-SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, acct_name_inx, group_title_ERASE_inx
-WHERE error_message IS NULL
+SELECT event_int, face_name_inx, fisc_label_inx, owner_name_inx, acct_name_inx, group_title_ERASE_inx
 FROM bud_acct_membership_v_del_raw
-GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, acct_name_inx, group_title_ERASE_inx
+GROUP BY event_int, face_name_inx, fisc_label_inx, owner_name_inx, acct_name_inx, group_title_ERASE_inx
 """
 INSERT_BUDACCT_VOICE_AGG_PUT_SQLSTR = """
 INSERT INTO bud_acctunit_v_put_agg (event_int, face_name, fisc_label, owner_name, acct_name, credit_belief, debtit_belief)
-SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, acct_name_inx, credit_belief, debtit_belief
-WHERE error_message IS NULL
+SELECT event_int, face_name_inx, fisc_label_inx, owner_name_inx, acct_name_inx, credit_belief, debtit_belief
 FROM bud_acctunit_v_put_raw
-GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, acct_name_inx, credit_belief, debtit_belief
+GROUP BY event_int, face_name_inx, fisc_label_inx, owner_name_inx, acct_name_inx, credit_belief, debtit_belief
 """
 INSERT_BUDACCT_VOICE_AGG_DEL_SQLSTR = """
 INSERT INTO bud_acctunit_v_del_agg (event_int, face_name, fisc_label, owner_name, acct_name_ERASE)
-SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, acct_name_ERASE_inx
-WHERE error_message IS NULL
+SELECT event_int, face_name_inx, fisc_label_inx, owner_name_inx, acct_name_ERASE_inx
 FROM bud_acctunit_v_del_raw
-GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, acct_name_ERASE_inx
+GROUP BY event_int, face_name_inx, fisc_label_inx, owner_name_inx, acct_name_ERASE_inx
 """
 INSERT_BUDAWAR_VOICE_AGG_PUT_SQLSTR = """
 INSERT INTO bud_concept_awardlink_v_put_agg (event_int, face_name, fisc_label, owner_name, concept_way, awardee_title, give_force, take_force)
-SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, awardee_title_inx, give_force, take_force
-WHERE error_message IS NULL
+SELECT event_int, face_name_inx, fisc_label_inx, owner_name_inx, concept_way_inx, awardee_title_inx, give_force, take_force
 FROM bud_concept_awardlink_v_put_raw
-GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, awardee_title_inx, give_force, take_force
+GROUP BY event_int, face_name_inx, fisc_label_inx, owner_name_inx, concept_way_inx, awardee_title_inx, give_force, take_force
 """
 INSERT_BUDAWAR_VOICE_AGG_DEL_SQLSTR = """
 INSERT INTO bud_concept_awardlink_v_del_agg (event_int, face_name, fisc_label, owner_name, concept_way, awardee_title_ERASE)
-SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, awardee_title_ERASE_inx
-WHERE error_message IS NULL
+SELECT event_int, face_name_inx, fisc_label_inx, owner_name_inx, concept_way_inx, awardee_title_ERASE_inx
 FROM bud_concept_awardlink_v_del_raw
-GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, awardee_title_ERASE_inx
+GROUP BY event_int, face_name_inx, fisc_label_inx, owner_name_inx, concept_way_inx, awardee_title_ERASE_inx
 """
 INSERT_BUDFACT_VOICE_AGG_PUT_SQLSTR = """
 INSERT INTO bud_concept_factunit_v_put_agg (event_int, face_name, fisc_label, owner_name, concept_way, fcontext, fbranch, fopen, fnigh)
-SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, fcontext_inx, fbranch_inx, fopen, fnigh
-WHERE error_message IS NULL
+SELECT event_int, face_name_inx, fisc_label_inx, owner_name_inx, concept_way_inx, fcontext_inx, fbranch_inx, fopen, fnigh
 FROM bud_concept_factunit_v_put_raw
-GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, fcontext_inx, fbranch_inx, fopen, fnigh
+GROUP BY event_int, face_name_inx, fisc_label_inx, owner_name_inx, concept_way_inx, fcontext_inx, fbranch_inx, fopen, fnigh
 """
 INSERT_BUDFACT_VOICE_AGG_DEL_SQLSTR = """
 INSERT INTO bud_concept_factunit_v_del_agg (event_int, face_name, fisc_label, owner_name, concept_way, fcontext_ERASE)
-SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, fcontext_ERASE_inx
-WHERE error_message IS NULL
+SELECT event_int, face_name_inx, fisc_label_inx, owner_name_inx, concept_way_inx, fcontext_ERASE_inx
 FROM bud_concept_factunit_v_del_raw
-GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, fcontext_ERASE_inx
+GROUP BY event_int, face_name_inx, fisc_label_inx, owner_name_inx, concept_way_inx, fcontext_ERASE_inx
 """
 INSERT_BUDHEAL_VOICE_AGG_PUT_SQLSTR = """
 INSERT INTO bud_concept_healerlink_v_put_agg (event_int, face_name, fisc_label, owner_name, concept_way, healer_name)
-SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, healer_name_inx
-WHERE error_message IS NULL
+SELECT event_int, face_name_inx, fisc_label_inx, owner_name_inx, concept_way_inx, healer_name_inx
 FROM bud_concept_healerlink_v_put_raw
-GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, healer_name_inx
+GROUP BY event_int, face_name_inx, fisc_label_inx, owner_name_inx, concept_way_inx, healer_name_inx
 """
 INSERT_BUDHEAL_VOICE_AGG_DEL_SQLSTR = """
 INSERT INTO bud_concept_healerlink_v_del_agg (event_int, face_name, fisc_label, owner_name, concept_way, healer_name_ERASE)
-SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, healer_name_ERASE_inx
-WHERE error_message IS NULL
+SELECT event_int, face_name_inx, fisc_label_inx, owner_name_inx, concept_way_inx, healer_name_ERASE_inx
 FROM bud_concept_healerlink_v_del_raw
-GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, healer_name_ERASE_inx
+GROUP BY event_int, face_name_inx, fisc_label_inx, owner_name_inx, concept_way_inx, healer_name_ERASE_inx
 """
 INSERT_BUDPREM_VOICE_AGG_PUT_SQLSTR = """
 INSERT INTO bud_concept_reason_premiseunit_v_put_agg (event_int, face_name, fisc_label, owner_name, concept_way, rcontext, pbranch, pnigh, popen, pdivisor)
-SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, rcontext_inx, pbranch_inx, pnigh, popen, pdivisor
-WHERE error_message IS NULL
+SELECT event_int, face_name_inx, fisc_label_inx, owner_name_inx, concept_way_inx, rcontext_inx, pbranch_inx, pnigh, popen, pdivisor
 FROM bud_concept_reason_premiseunit_v_put_raw
-GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, rcontext_inx, pbranch_inx, pnigh, popen, pdivisor
+GROUP BY event_int, face_name_inx, fisc_label_inx, owner_name_inx, concept_way_inx, rcontext_inx, pbranch_inx, pnigh, popen, pdivisor
 """
 INSERT_BUDPREM_VOICE_AGG_DEL_SQLSTR = """
 INSERT INTO bud_concept_reason_premiseunit_v_del_agg (event_int, face_name, fisc_label, owner_name, concept_way, rcontext, pbranch_ERASE)
-SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, rcontext_inx, pbranch_ERASE_inx
-WHERE error_message IS NULL
+SELECT event_int, face_name_inx, fisc_label_inx, owner_name_inx, concept_way_inx, rcontext_inx, pbranch_ERASE_inx
 FROM bud_concept_reason_premiseunit_v_del_raw
-GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, rcontext_inx, pbranch_ERASE_inx
+GROUP BY event_int, face_name_inx, fisc_label_inx, owner_name_inx, concept_way_inx, rcontext_inx, pbranch_ERASE_inx
 """
 INSERT_BUDREAS_VOICE_AGG_PUT_SQLSTR = """
 INSERT INTO bud_concept_reasonunit_v_put_agg (event_int, face_name, fisc_label, owner_name, concept_way, rcontext, rcontext_concept_active_requisite)
-SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, rcontext_inx, rcontext_concept_active_requisite
-WHERE error_message IS NULL
+SELECT event_int, face_name_inx, fisc_label_inx, owner_name_inx, concept_way_inx, rcontext_inx, rcontext_concept_active_requisite
 FROM bud_concept_reasonunit_v_put_raw
-GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, rcontext_inx, rcontext_concept_active_requisite
+GROUP BY event_int, face_name_inx, fisc_label_inx, owner_name_inx, concept_way_inx, rcontext_inx, rcontext_concept_active_requisite
 """
 INSERT_BUDREAS_VOICE_AGG_DEL_SQLSTR = """
 INSERT INTO bud_concept_reasonunit_v_del_agg (event_int, face_name, fisc_label, owner_name, concept_way, rcontext_ERASE)
-SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, rcontext_ERASE_inx
-WHERE error_message IS NULL
+SELECT event_int, face_name_inx, fisc_label_inx, owner_name_inx, concept_way_inx, rcontext_ERASE_inx
 FROM bud_concept_reasonunit_v_del_raw
-GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, rcontext_ERASE_inx
+GROUP BY event_int, face_name_inx, fisc_label_inx, owner_name_inx, concept_way_inx, rcontext_ERASE_inx
 """
 INSERT_BUDLABO_VOICE_AGG_PUT_SQLSTR = """
 INSERT INTO bud_concept_laborlink_v_put_agg (event_int, face_name, fisc_label, owner_name, concept_way, labor_title)
-SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, labor_title_inx
-WHERE error_message IS NULL
+SELECT event_int, face_name_inx, fisc_label_inx, owner_name_inx, concept_way_inx, labor_title_inx
 FROM bud_concept_laborlink_v_put_raw
-GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, labor_title_inx
+GROUP BY event_int, face_name_inx, fisc_label_inx, owner_name_inx, concept_way_inx, labor_title_inx
 """
 INSERT_BUDLABO_VOICE_AGG_DEL_SQLSTR = """
 INSERT INTO bud_concept_laborlink_v_del_agg (event_int, face_name, fisc_label, owner_name, concept_way, labor_title_ERASE)
-SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, labor_title_ERASE_inx
-WHERE error_message IS NULL
+SELECT event_int, face_name_inx, fisc_label_inx, owner_name_inx, concept_way_inx, labor_title_ERASE_inx
 FROM bud_concept_laborlink_v_del_raw
-GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, labor_title_ERASE_inx
+GROUP BY event_int, face_name_inx, fisc_label_inx, owner_name_inx, concept_way_inx, labor_title_ERASE_inx
 """
 INSERT_BUDCONC_VOICE_AGG_PUT_SQLSTR = """
 INSERT INTO bud_conceptunit_v_put_agg (event_int, face_name, fisc_label, owner_name, concept_way, begin, close, addin, numor, denom, morph, gogo_want, stop_want, mass, pledge, problem_bool)
-SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, begin, close, addin, numor, denom, morph, gogo_want, stop_want, mass, pledge, problem_bool
-WHERE error_message IS NULL
+SELECT event_int, face_name_inx, fisc_label_inx, owner_name_inx, concept_way_inx, begin, close, addin, numor, denom, morph, gogo_want, stop_want, mass, pledge, problem_bool
 FROM bud_conceptunit_v_put_raw
-GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_inx, begin, close, addin, numor, denom, morph, gogo_want, stop_want, mass, pledge, problem_bool
+GROUP BY event_int, face_name_inx, fisc_label_inx, owner_name_inx, concept_way_inx, begin, close, addin, numor, denom, morph, gogo_want, stop_want, mass, pledge, problem_bool
 """
 INSERT_BUDCONC_VOICE_AGG_DEL_SQLSTR = """
 INSERT INTO bud_conceptunit_v_del_agg (event_int, face_name, fisc_label, owner_name, concept_way_ERASE)
-SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_ERASE_inx
-WHERE error_message IS NULL
+SELECT event_int, face_name_inx, fisc_label_inx, owner_name_inx, concept_way_ERASE_inx
 FROM bud_conceptunit_v_del_raw
-GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, concept_way_ERASE_inx
+GROUP BY event_int, face_name_inx, fisc_label_inx, owner_name_inx, concept_way_ERASE_inx
 """
 INSERT_BUDUNIT_VOICE_AGG_PUT_SQLSTR = """
 INSERT INTO budunit_v_put_agg (event_int, face_name, fisc_label, owner_name, credor_respect, debtor_respect, fund_pool, max_tree_traverse, tally, fund_coin, penny, respect_bit)
-SELECT pidgin_event_int, fisc_label_inx, owner_name_inx, credor_respect, debtor_respect, fund_pool, max_tree_traverse, tally, fund_coin, penny, respect_bit
-WHERE error_message IS NULL
+SELECT event_int, face_name_inx, fisc_label_inx, owner_name_inx, credor_respect, debtor_respect, fund_pool, max_tree_traverse, tally, fund_coin, penny, respect_bit
 FROM budunit_v_put_raw
-GROUP BY pidgin_event_int, fisc_label_inx, owner_name_inx, credor_respect, debtor_respect, fund_pool, max_tree_traverse, tally, fund_coin, penny, respect_bit
+GROUP BY event_int, face_name_inx, fisc_label_inx, owner_name_inx, credor_respect, debtor_respect, fund_pool, max_tree_traverse, tally, fund_coin, penny, respect_bit
 """
 INSERT_BUDUNIT_VOICE_AGG_DEL_SQLSTR = """
 INSERT INTO budunit_v_del_agg (event_int, face_name, fisc_label, owner_name_ERASE)
-SELECT pidgin_event_int, fisc_label_inx, owner_name_ERASE_inx
-WHERE error_message IS NULL
+SELECT event_int, face_name_inx, fisc_label_inx, owner_name_ERASE_inx
 FROM budunit_v_del_raw
-GROUP BY pidgin_event_int, fisc_label_inx, owner_name_ERASE_inx
+GROUP BY event_int, face_name_inx, fisc_label_inx, owner_name_ERASE_inx
 """
 
 

--- a/src/a18_etl_toolbox/transformers.py
+++ b/src/a18_etl_toolbox/transformers.py
@@ -101,6 +101,7 @@ from src.a18_etl_toolbox.tran_sqlstrs import (
     get_insert_into_voice_raw_sqlstrs,
     create_update_voice_raw_existing_inx_col_sqlstr,
     create_update_voice_raw_empty_inx_col_sqlstr,
+    get_insert_voice_agg_sqlstrs,
     get_bud_prime_create_table_sqlstrs,
     create_pidgin_prime_tables,
     create_fisc_prime_tables,
@@ -622,7 +623,8 @@ def set_voice_raw_inx_column(
 
 
 def etl_voice_raw_tables_to_voice_agg_tables(cursor: sqlite3_Cursor):
-    pass
+    for insert_voice_agg_sqlstr in get_insert_voice_agg_sqlstrs().values():
+        cursor.execute(insert_voice_agg_sqlstr)
 
 
 def etl_brick_valid_table_into_prime_table(

--- a/src/a18_etl_toolbox/transformers.py
+++ b/src/a18_etl_toolbox/transformers.py
@@ -111,7 +111,7 @@ from src.a18_etl_toolbox.tran_sqlstrs import (
     get_bud_put_update_inconsist_error_message_sqlstrs,
     get_bud_insert_put_agg_from_raw_sqlstrs,
     get_bud_insert_del_agg_from_raw_sqlstrs,
-    get_idea_slabeleble_put_dimens,
+    get_idea_stageble_put_dimens,
     CREATE_FISC_EVENT_TIME_AGG_SQLSTR,
     INSERT_FISC_EVENT_TIME_AGG_SQLSTR,
     UPDATE_ERROR_MESSAGE_FISC_EVENT_TIME_AGG_SQLSTR,
@@ -1081,14 +1081,14 @@ def etl_idea_raw_to_bud_prime_tables(conn_or_cursor):
 
 
 def idea_raw_tables2fisc_raw_tables(conn_or_cursor: sqlite3_Connection):
-    ideas_slabeleble_dimens = get_idea_slabeleble_put_dimens()
+    ideas_stageble_dimens = get_idea_stageble_put_dimens()
     idea_config_dict = get_idea_config_dict()
     for idea_number in get_idea_numbers():
         idea_raw = f"{idea_number}_raw"
         if db_table_exists(conn_or_cursor, idea_raw):
             # only inserts from pre-identified idea categorys
-            slabeleble_dimens = ideas_slabeleble_dimens.get(idea_number)
-            for x_dimen in slabeleble_dimens:
+            stageble_dimens = ideas_stageble_dimens.get(idea_number)
+            for x_dimen in stageble_dimens:
                 dimen_config = idea_config_dict.get(x_dimen)
                 if dimen_config.get("idea_category") == "fisc":
                     dimen_jkeys = set(dimen_config.get("jkeys").keys())
@@ -1114,8 +1114,8 @@ def idea_raw_tables2bud_raw_tables(conn_or_cursor: sqlite3_Connection):
         idea_raw = f"{idea_number}_raw"
         if db_table_exists(conn_or_cursor, idea_raw):
             # only inserts from pre-identified idea categorys
-            slabeleble_dimens = get_idea_slabeleble_put_dimens().get(idea_number)
-            for x_dimen in slabeleble_dimens:
+            stageble_dimens = get_idea_stageble_put_dimens().get(idea_number)
+            for x_dimen in stageble_dimens:
                 dimen_config = idea_config_dict.get(x_dimen)
                 if dimen_config.get("idea_category") == "bud":
                     dimen_jkeys = set(dimen_config.get("jkeys").keys())

--- a/src/a18_etl_toolbox/transformers.py
+++ b/src/a18_etl_toolbox/transformers.py
@@ -621,6 +621,10 @@ def set_voice_raw_inx_column(
         cursor.execute(update_empty_inx_sqlstr)
 
 
+def etl_voice_raw_tables_to_voice_agg_tables(cursor: sqlite3_Cursor):
+    pass
+
+
 def etl_brick_valid_table_into_prime_table(
     cursor: sqlite3_Cursor,
     brick_valid_table: str,

--- a/src/a19_world_logic/test_etl_pipeline/test_world_mud_to_stances.py
+++ b/src/a19_world_logic/test_etl_pipeline/test_world_mud_to_stances.py
@@ -8,7 +8,13 @@ from src.a02_finance_logic._utils.strs_a02 import (
     celldepth_str,
 )
 from src.a06_bud_logic._utils.str_a06 import face_name_str, event_int_str, acct_name_str
-from src.a12_hub_tools.hub_path import create_fisc_ote1_csv_path
+from src.a12_hub_tools.hub_path import (
+    create_fisc_ote1_csv_path,
+    create_fisc_json_path,
+    create_gut_path,
+    create_job_path,
+    create_deal_acct_mandate_ledger_path as deal_mandate,
+)
 from src.a15_fisc_logic._utils.str_a15 import cumlative_minute_str, hour_label_str
 from src.a16_pidgin_logic._utils.str_a16 import otx_name_str, inx_name_str
 from src.a17_idea_logic._utils.str_a17 import brick_agg_str, brick_raw_str
@@ -156,99 +162,99 @@ def test_WorldUnit_mud_to_stances_v2_with_cursor_Scenario3_br000113PopulatesTabl
         assert get_row_count(cursor, fisunit_voice_raw) == 1
         assert get_row_count(cursor, budunit_voice_put_raw) == 1
         assert get_row_count(cursor, budacct_voice_put_raw) == 1
-        # assert get_row_count(cursor, fisunit_voice_agg) == 1
-        # assert get_row_count(cursor, budunit_voice_put_agg) == 1
-        # assert get_row_count(cursor, budacct_voice_put_agg) == 1
+        assert get_row_count(cursor, fisunit_voice_agg) == 1
+        assert get_row_count(cursor, budunit_voice_put_agg) == 1
+        assert get_row_count(cursor, budacct_voice_put_agg) == 1
 
 
-# def test_WorldUnit_mud_to_stances_Scenario3_CreatesFiles(env_dir_setup_cleanup):
-#     # ESTABLISH
-#     fizz_str = "fizz"
-#     fizz_world = worldunit_shop(fizz_str, worlds_dir())
-#     # delete_dir(fizz_world.worlds_dir)
-#     sue_str = "Sue"
-#     event1 = 1
-#     event2 = 2
-#     minute_360 = 360
-#     minute_420 = 420
-#     hour6am = "6am"
-#     hour7am = "7am"
-#     ex_filename = "fizzbuzz.xlsx"
-#     mud_file_path = create_path(fizz_world._mud_dir, ex_filename)
-#     br00003_columns = [
-#         event_int_str(),
-#         face_name_str(),
-#         cumlative_minute_str(),
-#         fisc_label_str(),
-#         hour_label_str(),
-#     ]
-#     br00001_columns = [
-#         event_int_str(),
-#         face_name_str(),
-#         fisc_label_str(),
-#         owner_name_str(),
-#         deal_time_str(),
-#         quota_str(),
-#         celldepth_str(),
-#     ]
-#     accord23_str = "accord23"
-#     tp37 = 37
-#     sue_quota = 235
-#     sue_celldepth = 3
-#     br1row0 = [event2, sue_str, accord23_str, sue_str, tp37, sue_quota, sue_celldepth]
-#     br00001_1df = DataFrame([br1row0], columns=br00001_columns)
-#     br00001_ex0_str = "example0_br00001"
-#     upsert_sheet(mud_file_path, br00001_ex0_str, br00001_1df)
+def test_WorldUnit_mud_to_stances_Scenario3_CreatesFiles(env_dir_setup_cleanup):
+    # ESTABLISH
+    fizz_str = "fizz"
+    fizz_world = worldunit_shop(fizz_str, worlds_dir())
+    # delete_dir(fizz_world.worlds_dir)
+    sue_str = "Sue"
+    event1 = 1
+    event2 = 2
+    minute_360 = 360
+    minute_420 = 420
+    hour6am = "6am"
+    hour7am = "7am"
+    ex_filename = "fizzbuzz.xlsx"
+    mud_file_path = create_path(fizz_world._mud_dir, ex_filename)
+    br00003_columns = [
+        event_int_str(),
+        face_name_str(),
+        cumlative_minute_str(),
+        fisc_label_str(),
+        hour_label_str(),
+    ]
+    br00001_columns = [
+        event_int_str(),
+        face_name_str(),
+        fisc_label_str(),
+        owner_name_str(),
+        deal_time_str(),
+        quota_str(),
+        celldepth_str(),
+    ]
+    accord23_str = "accord23"
+    tp37 = 37
+    sue_quota = 235
+    sue_celldepth = 3
+    br1row0 = [event2, sue_str, accord23_str, sue_str, tp37, sue_quota, sue_celldepth]
+    br00001_1df = DataFrame([br1row0], columns=br00001_columns)
+    br00001_ex0_str = "example0_br00001"
+    upsert_sheet(mud_file_path, br00001_ex0_str, br00001_1df)
 
-#     br3row0 = [event1, sue_str, minute_360, accord23_str, hour6am]
-#     br3row1 = [event1, sue_str, minute_420, accord23_str, hour7am]
-#     br3row2 = [event2, sue_str, minute_420, accord23_str, hour7am]
-#     br00003_1df = DataFrame([br3row0, br3row1], columns=br00003_columns)
-#     br00003_3df = DataFrame([br3row1, br3row0, br3row2], columns=br00003_columns)
-#     br00003_ex1_str = "example1_br00003"
-#     br00003_ex3_str = "example3_br00003"
-#     upsert_sheet(mud_file_path, br00003_ex1_str, br00003_1df)
-#     upsert_sheet(mud_file_path, br00003_ex3_str, br00003_3df)
-#     br00011_columns = [
-#         event_int_str(),
-#         face_name_str(),
-#         fisc_label_str(),
-#         owner_name_str(),
-#         acct_name_str(),
-#     ]
-#     br00011_rows = [[event2, sue_str, accord23_str, sue_str, sue_str]]
-#     br00011_df = DataFrame(br00011_rows, columns=br00011_columns)
-#     upsert_sheet(mud_file_path, "br00011_ex3", br00011_df)
-#     mstr_dir = fizz_world._fisc_mstr_dir
-#     wrong_a23_fisc_dir = create_path(mstr_dir, accord23_str)
-#     assert os_path_exists(wrong_a23_fisc_dir) is False
-#     brick_file_path = create_path(fizz_world._brick_dir, "br00003.xlsx")
-#     a23_json_path = create_fisc_json_path(mstr_dir, accord23_str)
-#     a23_sue_gut_path = create_gut_path(mstr_dir, accord23_str, sue_str)
-#     a23_sue_job_path = create_job_path(mstr_dir, accord23_str, sue_str)
-#     sue37_mandate_path = deal_mandate(mstr_dir, accord23_str, sue_str, tp37)
-#     assert os_path_exists(mud_file_path)
-#     assert not os_path_exists(brick_file_path)
-#     assert not os_path_exists(a23_json_path)
-#     assert not os_path_exists(a23_sue_gut_path)
-#     assert not os_path_exists(a23_sue_job_path)
-#     assert not os_path_exists(sue37_mandate_path)
-#     assert count_dirs_files(fizz_world.worlds_dir) == 7
+    br3row0 = [event1, sue_str, minute_360, accord23_str, hour6am]
+    br3row1 = [event1, sue_str, minute_420, accord23_str, hour7am]
+    br3row2 = [event2, sue_str, minute_420, accord23_str, hour7am]
+    br00003_1df = DataFrame([br3row0, br3row1], columns=br00003_columns)
+    br00003_3df = DataFrame([br3row1, br3row0, br3row2], columns=br00003_columns)
+    br00003_ex1_str = "example1_br00003"
+    br00003_ex3_str = "example3_br00003"
+    upsert_sheet(mud_file_path, br00003_ex1_str, br00003_1df)
+    upsert_sheet(mud_file_path, br00003_ex3_str, br00003_3df)
+    br00011_columns = [
+        event_int_str(),
+        face_name_str(),
+        fisc_label_str(),
+        owner_name_str(),
+        acct_name_str(),
+    ]
+    br00011_rows = [[event2, sue_str, accord23_str, sue_str, sue_str]]
+    br00011_df = DataFrame(br00011_rows, columns=br00011_columns)
+    upsert_sheet(mud_file_path, "br00011_ex3", br00011_df)
+    mstr_dir = fizz_world._fisc_mstr_dir
+    wrong_a23_fisc_dir = create_path(mstr_dir, accord23_str)
+    assert os_path_exists(wrong_a23_fisc_dir) is False
+    brick_file_path = create_path(fizz_world._brick_dir, "br00003.xlsx")
+    a23_json_path = create_fisc_json_path(mstr_dir, accord23_str)
+    a23_sue_gut_path = create_gut_path(mstr_dir, accord23_str, sue_str)
+    a23_sue_job_path = create_job_path(mstr_dir, accord23_str, sue_str)
+    sue37_mandate_path = deal_mandate(mstr_dir, accord23_str, sue_str, tp37)
+    assert os_path_exists(mud_file_path)
+    assert not os_path_exists(brick_file_path)
+    assert not os_path_exists(a23_json_path)
+    assert not os_path_exists(a23_sue_gut_path)
+    assert not os_path_exists(a23_sue_job_path)
+    assert not os_path_exists(sue37_mandate_path)
+    assert count_dirs_files(fizz_world.worlds_dir) == 7
 
-#     # WHEN
-#     fizz_world.mud_to_stances(store_tracing_files=True)
+    # WHEN
+    fizz_world.mud_to_stances(store_tracing_files=True)
 
-#     # THEN
-#     assert os_path_exists(wrong_a23_fisc_dir) is False
-#     assert os_path_exists(mud_file_path)
-#     assert os_path_exists(brick_file_path)
-#     assert sheet_exists(brick_file_path, brick_raw_str())
-#     assert os_path_exists(brick_file_path)
-#     assert os_path_exists(a23_json_path)
-#     assert os_path_exists(a23_sue_gut_path)
-#     assert os_path_exists(a23_sue_job_path)
-#     assert os_path_exists(sue37_mandate_path)
-#     assert count_dirs_files(fizz_world.worlds_dir) == 81
+    # THEN
+    assert os_path_exists(wrong_a23_fisc_dir) is False
+    assert os_path_exists(mud_file_path)
+    assert os_path_exists(brick_file_path)
+    assert sheet_exists(brick_file_path, brick_raw_str())
+    assert os_path_exists(brick_file_path)
+    assert os_path_exists(a23_json_path)
+    assert os_path_exists(a23_sue_gut_path)
+    assert os_path_exists(a23_sue_job_path)
+    assert os_path_exists(sue37_mandate_path)
+    assert count_dirs_files(fizz_world.worlds_dir) == 81
 
 
 def test_WorldUnit_mud_to_stances_Senario4_WhenNoFiscIdeas_ote1_IsStillCreated(

--- a/src/a19_world_logic/world.py
+++ b/src/a19_world_logic/world.py
@@ -22,6 +22,7 @@ from src.a18_etl_toolbox.transformers import (
     etl_sound_raw_tables_to_sound_agg_tables,
     etl_pidgin_sound_agg_tables_to_pidgin_sound_vld_tables,
     etl_sound_agg_tables_to_voice_raw_tables,
+    etl_voice_raw_tables_to_voice_agg_tables,
     etl_brick_raw_db_to_brick_raw_df,
     etl_brick_agg_tables_to_brick_agg_dfs,
     etl_brick_raw_tables_to_events_brick_agg_table,
@@ -332,6 +333,7 @@ class WorldUnit:
         etl_sound_raw_tables_to_sound_agg_tables(cursor)
         etl_pidgin_sound_agg_tables_to_pidgin_sound_vld_tables(cursor)
         etl_sound_agg_tables_to_voice_raw_tables(cursor)
+        etl_voice_raw_tables_to_voice_agg_tables(cursor)
 
         # identify all idea data that has conflicting face_name/event_int uniqueness
         # self._events = etl_events_brick_agg_db_to_event_dict(cursor)


### PR DESCRIPTION
## Summary by Sourcery

Enable a full voice-raw to voice-agg processing stage by defining aggregation SQL templates, wiring them into the ETL flow, renaming key parameters and constants for clarity, and bolstering test coverage to validate the new aggregation logic and updated naming conventions.

New Features:
- Generate and apply aggregation SQL strings for voice raw tables to aggregation tables across FISC and BUD dimensions
- Introduce etl_voice_raw_tables_to_voice_agg_tables and integrate it into the world.mud_to_stances ETL pipeline

Bug Fixes:
- Correct test function names in CSV table creation tests and minor variable rename in account net array to maintain consistent naming

Enhancements:
- Rename parameter "slabele" to "stage" in table creation functions and update related configuration getters from slabeleble to stageble nomenclature
- Refactor naming of voice raw SQL insert constants to include RAW and clearer PUT/DEL distinctions

Tests:
- Add comprehensive tests for get_insert_voice_agg_sqlstrs and etl_voice_raw_tables_to_voice_agg_tables
- Update existing tests to align with renamed functions/constants and re-enable previously commented world-to-stances assertions