### PR TITLE
175 enable documentation process

### DIFF
--- a/src/a01_way_logic/test/test_way_core.py
+++ b/src/a01_way_logic/test/test_way_core.py
@@ -39,6 +39,7 @@ def test_to_way_ReturnsObj_WithDefault_bridge():
     two_bridge_in_front_one_back = f"{x_bridge}{x_bridge}{x_label}{x_bridge}"
     assert to_way(f"{x_bridge}{x_bridge}{x_label}") == two_bridge_in_front_one_back
     assert to_way(x_bridge) == x_bridge
+    assert to_way("", x_bridge) == x_bridge
     assert to_way(None) == x_bridge
 
 

--- a/src/a01_way_logic/way.py
+++ b/src/a01_way_logic/way.py
@@ -174,6 +174,7 @@ def is_sub_way(ref_way: WayStr, sub_way: WayStr) -> bool:
 
 
 def is_heir_way(src: WayStr, heir: WayStr, bridge: str = None) -> bool:
+    # return src == heir or heir.startswith(src + default_bridge_if_None(bridge))
     return src == heir or heir.find(src) == 0
 
 

--- a/src/a17_idea_logic/idea.py
+++ b/src/a17_idea_logic/idea.py
@@ -162,7 +162,9 @@ def get_csv_idearef(header_row: list[str]) -> IdeaRef:
 
 
 def _remove_non_bud_dimens_from_idearef(x_idearef: IdeaRef) -> IdeaRef:
-    to_delete_dimen_set = {dimen for dimen in x_idearef.dimens if dimen[:3] != "bud"}
+    to_delete_dimen_set = {
+        dimen for dimen in x_idearef.dimens if not dimen.startswith("bud")
+    }
     dimens_set = set(x_idearef.dimens)
     for to_delete_dimen in to_delete_dimen_set:
         if to_delete_dimen in dimens_set:

--- a/src/a18_etl_toolbox/db_obj_tool.py
+++ b/src/a18_etl_toolbox/db_obj_tool.py
@@ -1,6 +1,9 @@
 from src.a00_data_toolbox.dict_toolbox import set_in_nested_dict
 from src.a02_finance_logic.deal import FiscLabel
-from src.a18_etl_toolbox.tran_sqlstrs import get_fisc_fu1_select_sqlstrs
+from src.a18_etl_toolbox.tran_sqlstrs import (
+    get_fisc_fu1_select_sqlstrs,
+    get_fisc_voice_select1_sqlstrs,
+)
 from sqlite3 import Cursor as sqlite3_Cursor
 
 
@@ -11,10 +14,11 @@ def get_fisc_dict_from_db(cursor: sqlite3_Cursor, fisc_label: FiscLabel) -> dict
     return get_fisc_dict_from_sqlstrs(cursor, fu1_sqlstrs, fisc_label)
 
 
-# def get_fisc_dict_from_voice_tables(
-#     cursor: sqlite3_Cursor, fisc_label: FiscLabel
-# ) -> dict:
-#     return {}
+def get_fisc_dict_from_voice_tables(
+    cursor: sqlite3_Cursor, fisc_label: FiscLabel
+) -> dict:
+    fu1_sqlstrs = get_fisc_voice_select1_sqlstrs(fisc_label)
+    return get_fisc_dict_from_sqlstrs(cursor, fu1_sqlstrs, fisc_label)
 
 
 def get_fisc_dict_from_sqlstrs(

--- a/src/a18_etl_toolbox/db_obj_tool.py
+++ b/src/a18_etl_toolbox/db_obj_tool.py
@@ -8,6 +8,18 @@ def get_fisc_dict_from_db(cursor: sqlite3_Cursor, fisc_label: FiscLabel) -> dict
     """Fetches a FiscUnit's data from multiple tables and returns it as a dictionary."""
 
     fu1_sqlstrs = get_fisc_fu1_select_sqlstrs(fisc_label)
+    return get_fisc_dict_from_sqlstrs(cursor, fu1_sqlstrs, fisc_label)
+
+
+# def get_fisc_dict_from_voice_tables(
+#     cursor: sqlite3_Cursor, fisc_label: FiscLabel
+# ) -> dict:
+#     return {}
+
+
+def get_fisc_dict_from_sqlstrs(
+    cursor: sqlite3_Cursor, fu1_sqlstrs: dict[str, str], fisc_label: FiscLabel
+) -> dict:
     cursor.execute(fu1_sqlstrs.get("fiscunit"))
     fiscunit_row = cursor.fetchone()
     if not fiscunit_row:

--- a/src/a18_etl_toolbox/test_etl_db2obj/test_db2obj_fisc.py
+++ b/src/a18_etl_toolbox/test_etl_db2obj/test_db2obj_fisc.py
@@ -5,15 +5,19 @@ from src.a15_fisc_logic._utils.str_a15 import (
     brokerunits_str,
     timeline_str,
 )
-from src.a18_etl_toolbox.tran_sqlstrs import create_fisc_prime_tables
+from src.a18_etl_toolbox.tran_sqlstrs import (
+    create_fisc_prime_tables,
+    create_prime_tablename,
+    create_sound_and_voice_tables,
+)
 from src.a18_etl_toolbox.db_obj_tool import (
     get_fisc_dict_from_db,
-    # get_fisc_dict_from_voice_tables,
+    get_fisc_dict_from_voice_tables,
 )
 from sqlite3 import connect as sqlite3_connect
 
 
-def test_get_fisc_dict_from_db_ReturnsObj_With_fiscunit_Attrs_Scenario0():
+def test_get_fisc_dict_from_db_ReturnsObj_With_fisunit_Attrs_Scenario0():
     # ESTABLISH
     a23_str = "accord23"
     a23_timeline_label = "timeline88"
@@ -40,7 +44,7 @@ def test_get_fisc_dict_from_db_ReturnsObj_With_fiscunit_Attrs_Scenario0():
 , bridge
 )
 VALUES (
-'{a23_str}'
+  '{a23_str}'
 , '{a23_timeline_label}'
 , {a23_c400_number}
 , {a23_yr1_jan1_offset}
@@ -377,7 +381,7 @@ def test_get_fisc_dict_from_db_ReturnsObj_IsCorrectlyFormatted_Scenario0_fiscuni
 , bridge
 )
 VALUES (
-'{a23_str}'
+  '{a23_str}'
 , '{a23_timeline_label}'
 , {a23_c400_number}
 , {a23_yr1_jan1_offset}
@@ -470,7 +474,7 @@ VALUES ('{a23_str}', '{bob_str}', {tp55}, {bob_tp55_quota}, {bob_tp55_celldepth}
     assert a23_bob_55_deal.celldepth == bob_tp55_celldepth
 
 
-def test_get_fisc_dict_from_db_ReturnsObj_With_fishour_Attrs_Scenario3_fishour():
+def test_get_fisc_dict_from_db_ReturnsObj_Scenario3_fishour():
     # ESTABLISH
     a23_str = "accord23"
     hour3_min = 300
@@ -503,7 +507,7 @@ VALUES
     ]
 
 
-def test_get_fisc_dict_from_db_ReturnsObj_With_fishour_Attrs_Scenario4_fismont():
+def test_get_fisc_dict_from_db_ReturnsObj_Scenario4_fismont():
     # ESTABLISH
     a23_str = "accord23"
     day111_min = 111
@@ -536,7 +540,7 @@ VALUES
     ]
 
 
-def test_get_fisc_dict_from_db_ReturnsObj_With_fishour_Attrs_Scenario5_fisweek():
+def test_get_fisc_dict_from_db_ReturnsObj_Scenario5_fisweek():
     # ESTABLISH
     a23_str = "accord23"
     ana_order = 1
@@ -566,7 +570,7 @@ VALUES
     assert a23_fiscunit.timeline.weekdays_config == [ana_label, bee_label]
 
 
-def test_get_fisc_dict_from_db_ReturnsObj_With_fishour_Attrs_Scenario5_fisweek():
+def test_get_fisc_dict_from_db_ReturnsObj_Scenario6_fisoffi():
     # sourcery skip: extract-method
     # ESTABLISH
     a23_str = "accord23"
@@ -592,4 +596,615 @@ VALUES
     a23_fiscunit = fiscunit_get_from_dict(a23_dict)
 
     # THEN
-    a23_fiscunit.offi_times == {offi_time5, offi_time7}
+    assert a23_fiscunit.offi_times == {offi_time5, offi_time7}
+
+
+def test_get_fisc_dict_from_voice_tables_ReturnsObj_With_fisunit_Attrs_Scenario0():
+    # ESTABLISH
+    a23_str = "accord23"
+    a23_timeline_label = "timeline88"
+    a23_c400_number = 3
+    a23_yr1_jan1_offset = 7
+    a23_monthday_distortion = 9
+    a23_fund_coin = 13
+    a23_penny = 17
+    a23_respect_bit = 23
+    a23_bridge = "."
+
+    with sqlite3_connect(":memory:") as conn:
+        cursor = conn.cursor()
+        create_sound_and_voice_tables(cursor)
+        fiscunit_v_agg_tablename = create_prime_tablename("fisunit", "v", "agg")
+        fiscunit_insert_sqlstr = f"""INSERT INTO {fiscunit_v_agg_tablename} (
+  fisc_label
+, timeline_label
+, c400_number
+, yr1_jan1_offset
+, monthday_distortion
+, fund_coin
+, penny
+, respect_bit
+, bridge
+)
+VALUES (
+  '{a23_str}'
+, '{a23_timeline_label}'
+, {a23_c400_number}
+, {a23_yr1_jan1_offset}
+, {a23_monthday_distortion}
+, {a23_fund_coin}
+, {a23_penny}
+, {a23_respect_bit}
+, '{a23_bridge}'
+)
+;"""
+        cursor.execute(fiscunit_insert_sqlstr)
+
+        # WHEN
+        a23_dict = get_fisc_dict_from_voice_tables(cursor, a23_str)
+
+    # THEN
+    assert a23_dict
+    assert a23_dict.get("fisc_label") == a23_str
+    print(f"{a23_dict=}")
+    a23_timeline_dict = a23_dict.get("timeline")
+    assert a23_timeline_dict.get("timeline_label") == a23_timeline_label
+    assert a23_timeline_dict.get("c400_number") == a23_c400_number
+    assert a23_timeline_dict.get("yr1_jan1_offset") == a23_yr1_jan1_offset
+    assert a23_timeline_dict.get("monthday_distortion") == a23_monthday_distortion
+    assert a23_dict.get("fund_coin") == a23_fund_coin
+    assert a23_dict.get("penny") == a23_penny
+    assert a23_dict.get("respect_bit") == a23_respect_bit
+    assert a23_dict.get("bridge") == a23_bridge
+
+
+def test_get_fisc_dict_from_voice_tables_ReturnsObj_With_fisunit_Attrs_Scenario1():
+    # ESTABLISH
+    a23_str = "accord23"
+    with sqlite3_connect(":memory:") as conn:
+        cursor = conn.cursor()
+        create_sound_and_voice_tables(cursor)
+        fiscunit_v_agg_tablename = create_prime_tablename("fisunit", "v", "agg")
+        fiscunit_insert_sqlstr = (
+            f"INSERT INTO {fiscunit_v_agg_tablename} (fisc_label) VALUES ('{a23_str}');"
+        )
+        cursor.execute(fiscunit_insert_sqlstr)
+
+        # WHEN
+        a23_dict = get_fisc_dict_from_voice_tables(cursor, a23_str)
+
+    # THEN
+    assert a23_dict
+    assert a23_dict.get("fisc_label") == a23_str
+    assert "timeline" in set(a23_dict.keys())
+    assert a23_dict.get("fund_coin") is None
+    assert a23_dict.get("penny") is None
+    assert a23_dict.get("respect_bit") is None
+    assert a23_dict.get("bridge") is None
+    assert set(a23_dict.keys()) == {
+        fisc_label_str(),
+        "offi_times",
+        timeline_str(),
+        cashbook_str(),
+        brokerunits_str(),
+    }
+
+
+def test_get_fisc_dict_from_voice_tables_ReturnsObj_With_fiscash_Attrs_Scenario0():
+    # ESTABLISH
+    a23_str = "accord23"
+    bob_str = "Bob"
+    sue_str = "Sue"
+    tp55 = 55
+    bob_sue_tp55_amount = 444
+    with sqlite3_connect(":memory:") as conn:
+        cursor = conn.cursor()
+        create_sound_and_voice_tables(cursor)
+        fiscunit_v_agg_tablename = create_prime_tablename("fisunit", "v", "agg")
+        fisccash_v_agg_tablename = create_prime_tablename("fiscash", "v", "agg")
+        fiscunit_insert_sqlstr = (
+            f"INSERT INTO {fiscunit_v_agg_tablename} (fisc_label) VALUES ('{a23_str}');"
+        )
+        cursor.execute(fiscunit_insert_sqlstr)
+        fiscash_insert_sqlstr = f"""INSERT INTO {fisccash_v_agg_tablename} (fisc_label, owner_name, acct_name, tran_time, amount)
+VALUES ('{a23_str}', '{bob_str}', '{sue_str}', {tp55}, {bob_sue_tp55_amount})
+;
+"""
+        cursor.execute(fiscash_insert_sqlstr)
+
+        # WHEN
+        a23_dict = get_fisc_dict_from_voice_tables(cursor, a23_str)
+
+    # THEN
+    a23_cashbook_dict = a23_dict.get("cashbook")
+    assert a23_cashbook_dict
+    assert a23_cashbook_dict.get("fisc_label") == a23_str
+    a23_tranunits_dict = a23_cashbook_dict.get("tranunits")
+    assert a23_tranunits_dict
+    a23_trans_bob_dict = a23_tranunits_dict.get(bob_str)
+    assert a23_trans_bob_dict
+    a23_trans_bob_sue_dict = a23_trans_bob_dict.get(sue_str)
+    assert a23_trans_bob_sue_dict
+    assert a23_trans_bob_sue_dict.get(tp55) == bob_sue_tp55_amount
+
+
+def test_get_fisc_dict_from_voice_tables_ReturnsObj_With_fiscash_Attrs_Scenario1():
+    # ESTABLISH
+    a23_str = "accord23"
+    a45_str = "accord45"
+    bob_str = "Bob"
+    sue_str = "Sue"
+    tp55 = 55
+    a23_bob_sue_tp55_amount = 444
+    a45_bob_sue_tp55_amount = 800
+    with sqlite3_connect(":memory:") as conn:
+        cursor = conn.cursor()
+        create_sound_and_voice_tables(cursor)
+        fiscunit_v_agg_tablename = create_prime_tablename("fisunit", "v", "agg")
+        fisccash_v_agg_tablename = create_prime_tablename("fiscash", "v", "agg")
+        fiscunit_insert_sqlstr = (
+            f"INSERT INTO {fiscunit_v_agg_tablename} (fisc_label) VALUES ('{a23_str}');"
+        )
+        cursor.execute(fiscunit_insert_sqlstr)
+        fiscash_insert_sqlstr = f"""INSERT INTO {fisccash_v_agg_tablename} (fisc_label, owner_name, acct_name, tran_time, amount)
+VALUES
+  ('{a23_str}', '{bob_str}', '{sue_str}', {tp55}, {a23_bob_sue_tp55_amount})
+, ('{a45_str}', '{bob_str}', '{sue_str}', {tp55}, {a45_bob_sue_tp55_amount})
+;
+"""
+        cursor.execute(fiscash_insert_sqlstr)
+
+        # WHEN
+        a23_dict = get_fisc_dict_from_voice_tables(cursor, a23_str)
+
+    # THEN
+    a23_cashbook_dict = a23_dict.get("cashbook")
+    assert a23_cashbook_dict
+    assert a23_cashbook_dict.get("fisc_label") == a23_str
+    a23_tranunits_dict = a23_cashbook_dict.get("tranunits")
+    assert a23_tranunits_dict
+    a23_trans_bob_dict = a23_tranunits_dict.get(bob_str)
+    assert a23_trans_bob_dict
+    a23_trans_bob_sue_dict = a23_trans_bob_dict.get(sue_str)
+    assert a23_trans_bob_sue_dict
+    assert a23_trans_bob_sue_dict == {tp55: a23_bob_sue_tp55_amount}
+
+
+def test_get_fisc_dict_from_voice_tables_ReturnsObj_With_fisdeal_Attrs_Scenario0():
+    # ESTABLISH
+    a23_str = "accord23"
+    bob_str = "Bob"
+    tp55 = 55
+    bob_tp55_quota = 444
+    bob_tp55_celldepth = 3
+    with sqlite3_connect(":memory:") as conn:
+        cursor = conn.cursor()
+        create_sound_and_voice_tables(cursor)
+        fiscunit_v_agg_tablename = create_prime_tablename("fisunit", "v", "agg")
+        fiscdeal_v_agg_tablename = create_prime_tablename("fisdeal", "v", "agg")
+        fiscunit_insert_sqlstr = (
+            f"INSERT INTO {fiscunit_v_agg_tablename} (fisc_label) VALUES ('{a23_str}');"
+        )
+        cursor.execute(fiscunit_insert_sqlstr)
+        fiscash_insert_sqlstr = f"""INSERT INTO {fiscdeal_v_agg_tablename} (fisc_label, owner_name, deal_time, quota, celldepth)
+VALUES ('{a23_str}', '{bob_str}', {tp55}, {bob_tp55_quota}, {bob_tp55_celldepth})
+;
+"""
+        cursor.execute(fiscash_insert_sqlstr)
+
+        # WHEN
+        a23_dict = get_fisc_dict_from_voice_tables(cursor, a23_str)
+
+    # THEN
+    a23_brokerunit_dict = a23_dict.get("brokerunits")
+    print(f"{a23_brokerunit_dict=}")
+    assert a23_brokerunit_dict
+    a23_brokerunit_bob_dict = a23_brokerunit_dict.get(bob_str)
+    assert a23_brokerunit_bob_dict
+    a23_bob_deals_dict = a23_brokerunit_bob_dict.get("deals")
+    assert a23_bob_deals_dict
+    a23_brokerunit_bob_tp55_dict = a23_bob_deals_dict.get(tp55)
+    assert a23_brokerunit_bob_tp55_dict
+    expected_a23_brokerunit_bob_tp55_dict = {
+        "deal_time": 55,
+        "quota": bob_tp55_quota,
+        "celldepth": bob_tp55_celldepth,
+    }
+    assert a23_brokerunit_bob_tp55_dict == expected_a23_brokerunit_bob_tp55_dict
+
+
+def test_get_fisc_dict_from_voice_tables_ReturnsObj_With_fishour_Attrs_Scenario0():
+    # ESTABLISH
+    a23_str = "accord23"
+    hour3_min = 300
+    hour4_min = 400
+    hour3_label = "3xm"
+    hour4_label = "4xm"
+    with sqlite3_connect(":memory:") as conn:
+        cursor = conn.cursor()
+        create_sound_and_voice_tables(cursor)
+        fiscunit_v_agg_tablename = create_prime_tablename("fisunit", "v", "agg")
+        fischour_v_agg_tablename = create_prime_tablename("fishour", "v", "agg")
+        fiscunit_insert_sqlstr = (
+            f"INSERT INTO {fiscunit_v_agg_tablename} (fisc_label) VALUES ('{a23_str}');"
+        )
+        cursor.execute(fiscunit_insert_sqlstr)
+        fiscash_insert_sqlstr = f"""INSERT INTO {fischour_v_agg_tablename} (fisc_label, cumlative_minute, hour_label)
+VALUES
+  ('{a23_str}', {hour3_min}, '{hour3_label}')
+, ('{a23_str}', {hour4_min}, '{hour4_label}')
+;
+"""
+        cursor.execute(fiscash_insert_sqlstr)
+
+        # WHEN
+        a23_dict = get_fisc_dict_from_voice_tables(cursor, a23_str)
+
+    # THEN
+    a23_timeline_dict = a23_dict.get("timeline")
+    print(f"{a23_timeline_dict=}")
+    assert a23_timeline_dict
+    a23_hours_config_dict = a23_timeline_dict.get("hours_config")
+    print(f"{a23_hours_config_dict=}")
+    assert a23_hours_config_dict == [[hour3_label, hour3_min], [hour4_label, hour4_min]]
+
+
+def test_get_fisc_dict_from_voice_tables_ReturnsObj_With_fismont_Attrs_Scenario0():
+    # ESTABLISH
+    a23_str = "accord23"
+    day111_min = 111
+    day222_min = 222
+    month111_label = "jan111"
+    month222_label = "feb222"
+    with sqlite3_connect(":memory:") as conn:
+        cursor = conn.cursor()
+        create_sound_and_voice_tables(cursor)
+        fiscunit_v_agg_tablename = create_prime_tablename("fisunit", "v", "agg")
+        fiscmont_v_agg_tablename = create_prime_tablename("fismont", "v", "agg")
+        fiscunit_insert_sqlstr = (
+            f"INSERT INTO {fiscunit_v_agg_tablename} (fisc_label) VALUES ('{a23_str}');"
+        )
+        cursor.execute(fiscunit_insert_sqlstr)
+        fiscash_insert_sqlstr = f"""INSERT INTO {fiscmont_v_agg_tablename} (fisc_label, cumlative_day, month_label)
+VALUES
+  ('{a23_str}', {day111_min}, '{month111_label}')
+, ('{a23_str}', {day222_min}, '{month222_label}')
+;
+"""
+        cursor.execute(fiscash_insert_sqlstr)
+
+        # WHEN
+        a23_dict = get_fisc_dict_from_voice_tables(cursor, a23_str)
+
+    # THEN
+    a23_timeline_dict = a23_dict.get("timeline")
+    assert a23_timeline_dict
+    a23_months_config_dict = a23_timeline_dict.get("months_config")
+    assert a23_months_config_dict == [
+        [month111_label, day111_min],
+        [month222_label, day222_min],
+    ]
+
+
+def test_get_fisc_dict_from_voice_tables_ReturnsObj_With_fisweek_Attrs_Scenario0():
+    # ESTABLISH
+    a23_str = "accord23"
+    ana_order = 1
+    bee_order = 2
+    ana_label = "ana_weekday"
+    bee_label = "bee_weekday"
+    with sqlite3_connect(":memory:") as conn:
+        cursor = conn.cursor()
+        create_sound_and_voice_tables(cursor)
+        fiscunit_v_agg_tablename = create_prime_tablename("fisunit", "v", "agg")
+        fiscweek_v_agg_tablename = create_prime_tablename("fisweek", "v", "agg")
+        fiscunit_insert_sqlstr = (
+            f"INSERT INTO {fiscunit_v_agg_tablename} (fisc_label) VALUES ('{a23_str}');"
+        )
+        cursor.execute(fiscunit_insert_sqlstr)
+        fiscash_insert_sqlstr = f"""INSERT INTO {fiscweek_v_agg_tablename} (fisc_label, weekday_order, weekday_label)
+VALUES
+  ('{a23_str}', {ana_order}, '{ana_label}')
+, ('{a23_str}', {bee_order}, '{bee_label}')
+;
+"""
+        cursor.execute(fiscash_insert_sqlstr)
+
+        # WHEN
+        a23_dict = get_fisc_dict_from_voice_tables(cursor, a23_str)
+
+    # THEN
+    a23_timeline_dict = a23_dict.get("timeline")
+    assert a23_timeline_dict
+    a23_weekdays_config_dict = a23_timeline_dict.get("weekdays_config")
+    assert a23_weekdays_config_dict == [ana_label, bee_label]
+
+
+def test_get_fisc_dict_from_voice_tables_ReturnsObj_With_fisoffi_Attrs_Scenario0():
+    # sourcery skip: extract-method
+    # ESTABLISH
+    a23_str = "accord23"
+    offi_time5 = 5
+    offi_time7 = 7
+    with sqlite3_connect(":memory:") as conn:
+        cursor = conn.cursor()
+        create_sound_and_voice_tables(cursor)
+        fiscunit_v_agg_tablename = create_prime_tablename("fisunit", "v", "agg")
+        fiscoffi_v_agg_tablename = create_prime_tablename("fisoffi", "v", "agg")
+        fiscunit_insert_sqlstr = (
+            f"INSERT INTO {fiscunit_v_agg_tablename} (fisc_label) VALUES ('{a23_str}');"
+        )
+        cursor.execute(fiscunit_insert_sqlstr)
+        fiscash_insert_sqlstr = f"""INSERT INTO {fiscoffi_v_agg_tablename} (fisc_label, offi_time)
+VALUES
+  ('{a23_str}', {offi_time5})
+, ('{a23_str}', {offi_time7})
+;
+"""
+        cursor.execute(fiscash_insert_sqlstr)
+
+        # WHEN
+        a23_dict = get_fisc_dict_from_voice_tables(cursor, a23_str)
+
+    # THEN
+    a23_offi_times_config_dict = a23_dict.get("offi_times")
+    print(f"{a23_offi_times_config_dict=}")
+    assert a23_offi_times_config_dict == [offi_time5, offi_time7]
+
+
+def test_get_fisc_dict_from_voice_tables_ReturnsObj_IsCorrectlyFormatted_Scenario0_fiscunit():
+    # ESTABLISH
+    a23_str = "accord23"
+    a23_timeline_label = "timeline88"
+    a23_c400_number = 3
+    a23_yr1_jan1_offset = 7
+    a23_monthday_distortion = 9
+    a23_fund_coin = 13
+    a23_penny = 17
+    a23_respect_bit = 23
+    a23_bridge = "."
+
+    with sqlite3_connect(":memory:") as conn:
+        cursor = conn.cursor()
+        create_sound_and_voice_tables(cursor)
+        fiscunit_v_agg_tablename = create_prime_tablename("fisunit", "v", "agg")
+        fiscunit_insert_sqlstr = f"""INSERT INTO {fiscunit_v_agg_tablename} (
+  fisc_label
+, timeline_label
+, c400_number
+, yr1_jan1_offset
+, monthday_distortion
+, fund_coin
+, penny
+, respect_bit
+, bridge
+)
+VALUES (
+  '{a23_str}'
+, '{a23_timeline_label}'
+, {a23_c400_number}
+, {a23_yr1_jan1_offset}
+, {a23_monthday_distortion}
+, {a23_fund_coin}
+, {a23_penny}
+, {a23_respect_bit}
+, '{a23_bridge}'
+)
+;"""
+        cursor.execute(fiscunit_insert_sqlstr)
+        a23_dict = get_fisc_dict_from_voice_tables(cursor, a23_str)
+
+    # WHEN
+    a23_fiscunit = fiscunit_get_from_dict(a23_dict)
+
+    assert a23_fiscunit.fisc_label == a23_str
+    assert a23_fiscunit.timeline.timeline_label == a23_timeline_label
+    assert a23_fiscunit.timeline.c400_number == a23_c400_number
+    assert a23_fiscunit.timeline.yr1_jan1_offset == a23_yr1_jan1_offset
+    assert a23_fiscunit.timeline.monthday_distortion == a23_monthday_distortion
+    assert a23_fiscunit.fund_coin == a23_fund_coin
+    assert a23_fiscunit.penny == a23_penny
+    assert a23_fiscunit.respect_bit == a23_respect_bit
+    assert a23_fiscunit.bridge == a23_bridge
+
+
+def test_get_fisc_dict_from_voice_tables_ReturnsObj_IsCorrectlyFormatted_Scenario1_fiscash():
+    # ESTABLISH
+    a23_str = "accord23"
+    bob_str = "Bob"
+    sue_str = "Sue"
+    tp55 = 55
+    bob_sue_tp55_amount = 444
+    with sqlite3_connect(":memory:") as conn:
+        cursor = conn.cursor()
+        create_sound_and_voice_tables(cursor)
+        fiscunit_v_agg_tablename = create_prime_tablename("fisunit", "v", "agg")
+        fisccash_v_agg_tablename = create_prime_tablename("fiscash", "v", "agg")
+        fiscunit_insert_sqlstr = (
+            f"INSERT INTO {fiscunit_v_agg_tablename} (fisc_label) VALUES ('{a23_str}');"
+        )
+        cursor.execute(fiscunit_insert_sqlstr)
+        fiscash_insert_sqlstr = f"""INSERT INTO {fisccash_v_agg_tablename} (fisc_label, owner_name, acct_name, tran_time, amount)
+VALUES ('{a23_str}', '{bob_str}', '{sue_str}', {tp55}, {bob_sue_tp55_amount})
+;
+"""
+        cursor.execute(fiscash_insert_sqlstr)
+        a23_dict = get_fisc_dict_from_voice_tables(cursor, a23_str)
+
+    # WHEN
+    a23_fiscunit = fiscunit_get_from_dict(a23_dict)
+
+    # THEN
+    assert a23_fiscunit.fisc_label == a23_str
+    assert a23_fiscunit.cashbook.tranunits.get(bob_str)
+    bob_tranunit = a23_fiscunit.cashbook.tranunits.get(bob_str)
+    assert bob_tranunit == {sue_str: {tp55: bob_sue_tp55_amount}}
+
+
+def test_get_fisc_dict_from_voice_tables_ReturnsObj_IsCorrectlyFormatted_Scenario2_fisdeal():
+    # ESTABLISH
+    a23_str = "accord23"
+    bob_str = "Bob"
+    tp55 = 55
+    bob_tp55_quota = 444
+    bob_tp55_celldepth = 3
+    with sqlite3_connect(":memory:") as conn:
+        cursor = conn.cursor()
+        create_sound_and_voice_tables(cursor)
+        fiscunit_v_agg_tablename = create_prime_tablename("fisunit", "v", "agg")
+        fiscdeal_v_agg_tablename = create_prime_tablename("fisdeal", "v", "agg")
+        fiscunit_insert_sqlstr = (
+            f"INSERT INTO {fiscunit_v_agg_tablename} (fisc_label) VALUES ('{a23_str}');"
+        )
+        cursor.execute(fiscunit_insert_sqlstr)
+        fiscash_insert_sqlstr = f"""INSERT INTO {fiscdeal_v_agg_tablename} (fisc_label, owner_name, deal_time, quota, celldepth)
+VALUES ('{a23_str}', '{bob_str}', {tp55}, {bob_tp55_quota}, {bob_tp55_celldepth})
+;
+"""
+        cursor.execute(fiscash_insert_sqlstr)
+        a23_dict = get_fisc_dict_from_voice_tables(cursor, a23_str)
+
+    # WHEN
+    a23_fiscunit = fiscunit_get_from_dict(a23_dict)
+
+    # THEN
+    a23_bob_brokerunit = a23_fiscunit.get_brokerunit(bob_str)
+    print(f"{a23_bob_brokerunit=}")
+    assert a23_bob_brokerunit
+    a23_bob_55_deal = a23_bob_brokerunit.get_deal(tp55)
+    assert a23_bob_55_deal.deal_time == tp55
+    assert a23_bob_55_deal.quota == bob_tp55_quota
+    assert a23_bob_55_deal.celldepth == bob_tp55_celldepth
+
+
+def test_get_fisc_dict_from_voice_tables_ReturnsObj_Scenario3_fishour():
+    # ESTABLISH
+    a23_str = "accord23"
+    hour3_min = 300
+    hour4_min = 400
+    hour3_label = "3xm"
+    hour4_label = "4xm"
+    with sqlite3_connect(":memory:") as conn:
+        cursor = conn.cursor()
+        create_sound_and_voice_tables(cursor)
+        fiscunit_v_agg_tablename = create_prime_tablename("fisunit", "v", "agg")
+        fischour_v_agg_tablename = create_prime_tablename("fishour", "v", "agg")
+        fiscunit_insert_sqlstr = (
+            f"INSERT INTO {fiscunit_v_agg_tablename} (fisc_label) VALUES ('{a23_str}');"
+        )
+        cursor.execute(fiscunit_insert_sqlstr)
+        fiscash_insert_sqlstr = f"""INSERT INTO {fischour_v_agg_tablename} (fisc_label, cumlative_minute, hour_label)
+VALUES
+  ('{a23_str}', {hour3_min}, '{hour3_label}')
+, ('{a23_str}', {hour4_min}, '{hour4_label}')
+;
+"""
+        cursor.execute(fiscash_insert_sqlstr)
+        a23_dict = get_fisc_dict_from_voice_tables(cursor, a23_str)
+
+    # WHEN
+    a23_fiscunit = fiscunit_get_from_dict(a23_dict)
+
+    # THEN
+    a23_fiscunit.timeline.hours_config == [
+        [hour3_label, hour3_min],
+        [hour4_label, hour4_min],
+    ]
+
+
+def test_get_fisc_dict_from_voice_tables_ReturnsObj_Scenario4_fismont():
+    # ESTABLISH
+    a23_str = "accord23"
+    day111_min = 111
+    day222_min = 222
+    month111_label = "jan111"
+    month222_label = "feb222"
+    with sqlite3_connect(":memory:") as conn:
+        cursor = conn.cursor()
+        create_sound_and_voice_tables(cursor)
+        fiscunit_v_agg_tablename = create_prime_tablename("fisunit", "v", "agg")
+        fiscmont_v_agg_tablename = create_prime_tablename("fismont", "v", "agg")
+        fiscunit_insert_sqlstr = (
+            f"INSERT INTO {fiscunit_v_agg_tablename} (fisc_label) VALUES ('{a23_str}');"
+        )
+        cursor.execute(fiscunit_insert_sqlstr)
+        fiscash_insert_sqlstr = f"""INSERT INTO {fiscmont_v_agg_tablename} (fisc_label, cumlative_day, month_label)
+VALUES
+  ('{a23_str}', {day111_min}, '{month111_label}')
+, ('{a23_str}', {day222_min}, '{month222_label}')
+;
+"""
+        cursor.execute(fiscash_insert_sqlstr)
+        a23_dict = get_fisc_dict_from_voice_tables(cursor, a23_str)
+
+    # WHEN
+    a23_fiscunit = fiscunit_get_from_dict(a23_dict)
+
+    # THEN
+    assert a23_fiscunit.timeline.months_config == [
+        [month111_label, day111_min],
+        [month222_label, day222_min],
+    ]
+
+
+def test_get_fisc_dict_from_voice_tables_ReturnsObj_Scenario5_fisweek():
+    # ESTABLISH
+    a23_str = "accord23"
+    ana_order = 1
+    bee_order = 2
+    ana_label = "ana_weekday"
+    bee_label = "bee_weekday"
+    with sqlite3_connect(":memory:") as conn:
+        cursor = conn.cursor()
+        create_sound_and_voice_tables(cursor)
+        fiscunit_v_agg_tablename = create_prime_tablename("fisunit", "v", "agg")
+        fiscweek_v_agg_tablename = create_prime_tablename("fisweek", "v", "agg")
+        fiscunit_insert_sqlstr = (
+            f"INSERT INTO {fiscunit_v_agg_tablename} (fisc_label) VALUES ('{a23_str}');"
+        )
+        cursor.execute(fiscunit_insert_sqlstr)
+        fiscash_insert_sqlstr = f"""INSERT INTO {fiscweek_v_agg_tablename} (fisc_label, weekday_order, weekday_label)
+VALUES
+  ('{a23_str}', {ana_order}, '{ana_label}')
+, ('{a23_str}', {bee_order}, '{bee_label}')
+;
+"""
+        cursor.execute(fiscash_insert_sqlstr)
+        a23_dict = get_fisc_dict_from_voice_tables(cursor, a23_str)
+
+    # WHEN
+    a23_fiscunit = fiscunit_get_from_dict(a23_dict)
+
+    # THEN
+    assert a23_fiscunit.timeline.weekdays_config == [ana_label, bee_label]
+
+
+def test_get_fisc_dict_from_voice_tables_ReturnsObj_Scenario5_fisoffi():
+    # sourcery skip: extract-method
+    # ESTABLISH
+    a23_str = "accord23"
+    offi_time5 = 5
+    offi_time7 = 7
+    with sqlite3_connect(":memory:") as conn:
+        cursor = conn.cursor()
+        create_sound_and_voice_tables(cursor)
+        fiscunit_v_agg_tablename = create_prime_tablename("fisunit", "v", "agg")
+        fiscoffi_v_agg_tablename = create_prime_tablename("fisoffi", "v", "agg")
+        fiscunit_insert_sqlstr = (
+            f"INSERT INTO {fiscunit_v_agg_tablename} (fisc_label) VALUES ('{a23_str}');"
+        )
+        cursor.execute(fiscunit_insert_sqlstr)
+        fiscash_insert_sqlstr = f"""INSERT INTO {fiscoffi_v_agg_tablename} (fisc_label, offi_time)
+VALUES
+  ('{a23_str}', {offi_time5})
+, ('{a23_str}', {offi_time7})
+;
+"""
+        cursor.execute(fiscash_insert_sqlstr)
+        a23_dict = get_fisc_dict_from_voice_tables(cursor, a23_str)
+
+    # WHEN
+    a23_fiscunit = fiscunit_get_from_dict(a23_dict)
+
+    # THEN
+    assert a23_fiscunit.offi_times == {offi_time5, offi_time7}

--- a/src/a18_etl_toolbox/test_etl_db2obj/test_db2obj_fisc.py
+++ b/src/a18_etl_toolbox/test_etl_db2obj/test_db2obj_fisc.py
@@ -6,7 +6,10 @@ from src.a15_fisc_logic._utils.str_a15 import (
     timeline_str,
 )
 from src.a18_etl_toolbox.tran_sqlstrs import create_fisc_prime_tables
-from src.a18_etl_toolbox.db_obj_tool import get_fisc_dict_from_db
+from src.a18_etl_toolbox.db_obj_tool import (
+    get_fisc_dict_from_db,
+    # get_fisc_dict_from_voice_tables,
+)
 from sqlite3 import connect as sqlite3_connect
 
 

--- a/src/a18_etl_toolbox/test_tran/test_voice_agg_tables2fisc_jsons.py
+++ b/src/a18_etl_toolbox/test_tran/test_voice_agg_tables2fisc_jsons.py
@@ -1,0 +1,224 @@
+from src.a00_data_toolbox.file_toolbox import open_file
+from src.a00_data_toolbox.db_toolbox import (
+    get_row_count,
+    db_table_exists,
+    create_select_query,
+)
+from src.a02_finance_logic._utils.strs_a02 import fisc_label_str
+from src.a12_hub_tools.hub_path import create_fisc_json_path
+from src.a15_fisc_logic.fisc import get_from_json as fiscunit_get_from_json
+from src.a15_fisc_logic.fisc_config import get_fisc_dimens
+from src.a15_fisc_logic._utils.str_a15 import (
+    fiscunit_str,
+    fisc_cashbook_str,
+    fisc_dealunit_str,
+    fisc_timeline_hour_str,
+    fisc_timeline_month_str,
+    fisc_timeline_weekday_str,
+    fisc_timeoffi_str,
+)
+from src.a18_etl_toolbox.tran_sqlstrs import (
+    get_dimen_abbv7,
+    create_prime_tablename,
+    get_fisc_voice_select_sqlstrs,
+)
+from src.a18_etl_toolbox.transformers import (
+    create_sound_and_voice_tables,
+    etl_voice_agg_tables_to_fisc_jsons,
+)
+from src.a18_etl_toolbox._utils.env_a18 import (
+    get_module_temp_dir,
+    env_dir_setup_cleanup,
+)
+from os.path import exists as os_path_exists
+from sqlite3 import connect as sqlite3_connect
+
+
+def test_get_fisc_voice_select_sqlstrs_ReturnsObj_HasAllNeededKeys():
+    # ESTABLISH
+    a23_str = "accord23"
+
+    # WHEN
+    fu2_select_sqlstrs = get_fisc_voice_select_sqlstrs(a23_str)
+
+    # THEN
+    assert fu2_select_sqlstrs
+    expected_fu2_select_dimens = set(get_fisc_dimens())
+    assert set(fu2_select_sqlstrs.keys()) == expected_fu2_select_dimens
+
+
+def test_get_fisc_voice_select_sqlstrs_ReturnsObj():
+    # sourcery skip: no-loop-in-tests
+    # ESTABLISH
+    a23_str = "accord23"
+
+    # WHEN
+    fu2_select_sqlstrs = get_fisc_voice_select_sqlstrs(fisc_label=a23_str)
+
+    # THEN
+    gen_fiscash_sqlstr = fu2_select_sqlstrs.get(fisc_cashbook_str())
+    gen_fisdeal_sqlstr = fu2_select_sqlstrs.get(fisc_dealunit_str())
+    gen_fishour_sqlstr = fu2_select_sqlstrs.get(fisc_timeline_hour_str())
+    gen_fismont_sqlstr = fu2_select_sqlstrs.get(fisc_timeline_month_str())
+    gen_fisweek_sqlstr = fu2_select_sqlstrs.get(fisc_timeline_weekday_str())
+    gen_fisoffi_sqlstr = fu2_select_sqlstrs.get(fisc_timeoffi_str())
+    gen_fisunit_sqlstr = fu2_select_sqlstrs.get(fiscunit_str())
+    with sqlite3_connect(":memory:") as fisc_db_conn:
+        cursor = fisc_db_conn.cursor()
+        create_sound_and_voice_tables(cursor)
+        fiscash_abbv7 = get_dimen_abbv7(fisc_cashbook_str())
+        fisdeal_abbv7 = get_dimen_abbv7(fisc_dealunit_str())
+        fishour_abbv7 = get_dimen_abbv7(fisc_timeline_hour_str())
+        fismont_abbv7 = get_dimen_abbv7(fisc_timeline_month_str())
+        fisweek_abbv7 = get_dimen_abbv7(fisc_timeline_weekday_str())
+        fisoffi_abbv7 = get_dimen_abbv7(fisc_timeoffi_str())
+        fisunit_abbv7 = get_dimen_abbv7(fiscunit_str())
+        fiscash_v_agg = create_prime_tablename(fiscash_abbv7, "v", "agg")
+        fisdeal_v_agg = create_prime_tablename(fisdeal_abbv7, "v", "agg")
+        fishour_v_agg = create_prime_tablename(fishour_abbv7, "v", "agg")
+        fismont_v_agg = create_prime_tablename(fismont_abbv7, "v", "agg")
+        fisweek_v_agg = create_prime_tablename(fisweek_abbv7, "v", "agg")
+        fisoffi_v_agg = create_prime_tablename(fisoffi_abbv7, "v", "agg")
+        fisunit_v_agg = create_prime_tablename(fisunit_abbv7, "v", "agg")
+        where_dict = {fisc_label_str(): a23_str}
+        fiscash_sql = create_select_query(cursor, fiscash_v_agg, [], where_dict, True)
+        fisdeal_sql = create_select_query(cursor, fisdeal_v_agg, [], where_dict, True)
+        fishour_sql = create_select_query(cursor, fishour_v_agg, [], where_dict, True)
+        fismont_sql = create_select_query(cursor, fismont_v_agg, [], where_dict, True)
+        fisweek_sql = create_select_query(cursor, fisweek_v_agg, [], where_dict, True)
+        fisoffi_sql = create_select_query(cursor, fisoffi_v_agg, [], where_dict, True)
+        fisunit_sql = create_select_query(cursor, fisunit_v_agg, [], where_dict, True)
+        fiscash_sqlstr_ref = f"{fiscash_abbv7.upper()}_FU2_SELECT_SQLSTR"
+        fisdeal_sqlstr_ref = f"{fisdeal_abbv7.upper()}_FU2_SELECT_SQLSTR"
+        fishour_sqlstr_ref = f"{fishour_abbv7.upper()}_FU2_SELECT_SQLSTR"
+        fismont_sqlstr_ref = f"{fismont_abbv7.upper()}_FU2_SELECT_SQLSTR"
+        fisweek_sqlstr_ref = f"{fisweek_abbv7.upper()}_FU2_SELECT_SQLSTR"
+        fisoffi_sqlstr_ref = f"{fisoffi_abbv7.upper()}_FU2_SELECT_SQLSTR"
+        fisunit_sqlstr_ref = f"{fisunit_abbv7.upper()}_FU2_SELECT_SQLSTR"
+        qa23_str = "'accord23'"
+        blank = ""
+        print(f"""{fiscash_sqlstr_ref} = "{fiscash_sql.replace(qa23_str, blank)}" """)
+        print(f"""{fisdeal_sqlstr_ref} = "{fisdeal_sql.replace(qa23_str, blank)}" """)
+        print(f"""{fishour_sqlstr_ref} = "{fishour_sql.replace(qa23_str, blank)}" """)
+        print(f"""{fismont_sqlstr_ref} = "{fismont_sql.replace(qa23_str, blank)}" """)
+        print(f"""{fisweek_sqlstr_ref} = "{fisweek_sql.replace(qa23_str, blank)}" """)
+        print(f"""{fisoffi_sqlstr_ref} = "{fisoffi_sql.replace(qa23_str, blank)}" """)
+        print(f"""{fisunit_sqlstr_ref} = "{fisunit_sql.replace(qa23_str, blank)}" """)
+        assert gen_fiscash_sqlstr == fiscash_sql
+        assert gen_fisdeal_sqlstr == fisdeal_sql
+        assert gen_fishour_sqlstr == fishour_sql
+        assert gen_fismont_sqlstr == fismont_sql
+        assert gen_fisweek_sqlstr == fisweek_sql
+        assert gen_fisoffi_sqlstr == fisoffi_sql
+        assert gen_fisunit_sqlstr == fisunit_sql
+        static_example_sqlstr = f"SELECT fisc_label, timeline_label, c400_number, yr1_jan1_offset, monthday_distortion, fund_coin, penny, respect_bit, bridge, job_listen_rotations FROM fiscunit_v_agg WHERE fisc_label = '{a23_str}'"
+        assert gen_fisunit_sqlstr == static_example_sqlstr
+
+
+# def test_etl_voice_agg_tables_to_fisc_jsons_Scenario0_CreateFilesWithOnlyFiscLabel(
+#     env_dir_setup_cleanup,
+# ):
+#     # ESTABLISH
+#     accord23_str = "accord23"
+#     accord45_str = "accord45"
+#     fisc_mstr_dir = get_module_temp_dir()
+#     fisunit_v_agg_tablename = create_prime_tablename(fiscunit_str(), "v", "agg")
+#     print(f"{fisunit_v_agg_tablename=}")
+
+#     with sqlite3_connect(":memory:") as fisc_db_conn:
+#         cursor = fisc_db_conn.cursor()
+#         create_sound_and_voice_tables(cursor)
+
+#         insert_raw_sqlstr = f"""
+# INSERT INTO {fisunit_v_agg_tablename} ({fisc_label_str()})
+# VALUES ('{accord23_str}'), ('{accord45_str}')
+# ;
+# """
+#         cursor.execute(insert_raw_sqlstr)
+#         assert get_row_count(cursor, fisunit_v_agg_tablename) == 2
+#         fisc_event_time_agg_str = "fisc_event_time_agg"
+#         assert db_table_exists(cursor, fisc_event_time_agg_str) is False
+
+#         accord23_json_path = create_fisc_json_path(fisc_mstr_dir, accord23_str)
+#         accord45_json_path = create_fisc_json_path(fisc_mstr_dir, accord45_str)
+#         assert os_path_exists(accord23_json_path) is False
+#         assert os_path_exists(accord45_json_path) is False
+
+#         # WHEN
+#         etl_voice_agg_tables_to_fisc_jsons(cursor, fisc_mstr_dir)
+
+#     # THEN
+#     assert os_path_exists(accord23_json_path)
+#     assert os_path_exists(accord45_json_path)
+#     accord23_fisc = fiscunit_get_from_json(open_file(accord23_json_path))
+#     accord45_fisc = fiscunit_get_from_json(open_file(accord45_json_path))
+#     assert accord23_fisc.fisc_label == accord23_str
+#     assert accord45_fisc.fisc_label == accord45_str
+
+
+# def test_etl_fisc_agg_tables_to_fisc_jsons_Scenario1_CreateFilesWithFiscUnitAttrs(
+#     env_dir_setup_cleanup,
+# ):
+#     # ESTABLISH
+#     accord23_str = "accord23"
+#     accord45_str = "accord45"
+#     fisc_mstr_dir = get_module_temp_dir()
+#     x_fisc = FiscPrimeObjsRef(fisc_mstr_dir)
+#     x_cols = FiscPrimeColumnsRef()
+#     a45_fund_coin = 3
+#     a45_penny = 5
+#     a45_respect_bit = 7
+#     a45_bridge = "/"
+#     a45_c400_number = 88
+#     a45_yr1_jan1_offset = 501
+#     a45_monthday_distortion = 17
+#     a45_timeline_label = "a45_timeline"
+#     print(f"{x_cols.unit_agg_csv_header=}")
+#     fiscunit_agg_csv_str = f"""{x_cols.unit_agg_csv_header}
+# {accord23_str},,,,,,,,
+# {accord45_str},{a45_timeline_label},{a45_c400_number},{a45_yr1_jan1_offset},{a45_monthday_distortion},{a45_fund_coin},{a45_penny},{a45_respect_bit},{a45_bridge}
+# """
+#     save_file(fisc_mstr_dir, x_fisc.unit_agg_csv_filename, fiscunit_agg_csv_str)
+#     save_file(fisc_mstr_dir, x_fisc.deal_agg_csv_filename, x_cols.deal_agg_empty_csv)
+#     save_file(fisc_mstr_dir, x_fisc.cash_agg_csv_filename, x_cols.cash_agg_empty_csv)
+#     save_file(fisc_mstr_dir, x_fisc.hour_agg_csv_filename, x_cols.hour_agg_empty_csv)
+#     save_file(fisc_mstr_dir, x_fisc.mont_agg_csv_filename, x_cols.mont_agg_empty_csv)
+#     save_file(fisc_mstr_dir, x_fisc.week_agg_csv_filename, x_cols.week_agg_empty_csv)
+#     save_file(fisc_mstr_dir, x_fisc.offi_agg_csv_filename, x_cols.offi_agg_empty_csv)
+
+#     accord23_json_path = create_fisc_json_path(fisc_mstr_dir, accord23_str)
+#     accord45_json_path = create_fisc_json_path(fisc_mstr_dir, accord45_str)
+#     assert os_path_exists(accord23_json_path) is False
+#     assert os_path_exists(accord45_json_path) is False
+
+#     # WHEN
+#     etl_fisc_agg_tables_to_fisc_jsons(fisc_mstr_dir)
+
+#     # THEN
+#     assert os_path_exists(accord23_json_path)
+#     assert os_path_exists(accord45_json_path)
+#     accord23_fisc = fiscunit_get_from_json(open_file(accord23_json_path))
+#     accord45_fisc = fiscunit_get_from_json(open_file(accord45_json_path))
+#     assert accord23_fisc == fiscunit_shop(accord23_str)
+#     expected_45_tl = timelineunit_shop(
+#         timeline_config_shop(
+#             timeline_label=a45_timeline_label,
+#             c400_number=a45_c400_number,
+#             yr1_jan1_offset=a45_yr1_jan1_offset,
+#             monthday_distortion=a45_monthday_distortion,
+#         )
+#     )
+#     accord_45_timeline = accord45_fisc.timeline
+#     assert accord_45_timeline.c400_number == expected_45_tl.c400_number
+#     assert accord_45_timeline.monthday_distortion == expected_45_tl.monthday_distortion
+#     assert accord_45_timeline.timeline_label == expected_45_tl.timeline_label
+#     assert accord_45_timeline.yr1_jan1_offset == expected_45_tl.yr1_jan1_offset
+#     assert accord_45_timeline == expected_45_tl
+#     assert accord45_fisc == fiscunit_shop(
+#         fisc_label=accord45_str,
+#         fund_coin=a45_fund_coin,
+#         penny=a45_penny,
+#         respect_bit=a45_respect_bit,
+#         bridge=a45_bridge,
+#         timeline=expected_45_tl,
+#     )

--- a/src/a18_etl_toolbox/test_tran/test_voice_agg_tables2fisc_jsons.py
+++ b/src/a18_etl_toolbox/test_tran/test_voice_agg_tables2fisc_jsons.py
@@ -20,7 +20,7 @@ from src.a15_fisc_logic._utils.str_a15 import (
 from src.a18_etl_toolbox.tran_sqlstrs import (
     get_dimen_abbv7,
     create_prime_tablename,
-    get_fisc_voice_select_sqlstrs,
+    get_fisc_voice_select1_sqlstrs,
 )
 from src.a18_etl_toolbox.transformers import (
     create_sound_and_voice_tables,
@@ -34,12 +34,12 @@ from os.path import exists as os_path_exists
 from sqlite3 import connect as sqlite3_connect
 
 
-def test_get_fisc_voice_select_sqlstrs_ReturnsObj_HasAllNeededKeys():
+def test_get_fisc_voice_select1_sqlstrs_ReturnsObj_HasAllNeededKeys():
     # ESTABLISH
     a23_str = "accord23"
 
     # WHEN
-    fu2_select_sqlstrs = get_fisc_voice_select_sqlstrs(a23_str)
+    fu2_select_sqlstrs = get_fisc_voice_select1_sqlstrs(a23_str)
 
     # THEN
     assert fu2_select_sqlstrs
@@ -47,13 +47,13 @@ def test_get_fisc_voice_select_sqlstrs_ReturnsObj_HasAllNeededKeys():
     assert set(fu2_select_sqlstrs.keys()) == expected_fu2_select_dimens
 
 
-def test_get_fisc_voice_select_sqlstrs_ReturnsObj():
+def test_get_fisc_voice_select1_sqlstrs_ReturnsObj():
     # sourcery skip: no-loop-in-tests
     # ESTABLISH
     a23_str = "accord23"
 
     # WHEN
-    fu2_select_sqlstrs = get_fisc_voice_select_sqlstrs(fisc_label=a23_str)
+    fu2_select_sqlstrs = get_fisc_voice_select1_sqlstrs(fisc_label=a23_str)
 
     # THEN
     gen_fiscash_sqlstr = fu2_select_sqlstrs.get(fisc_cashbook_str())
@@ -115,45 +115,45 @@ def test_get_fisc_voice_select_sqlstrs_ReturnsObj():
         assert gen_fisunit_sqlstr == static_example_sqlstr
 
 
-# def test_etl_voice_agg_tables_to_fisc_jsons_Scenario0_CreateFilesWithOnlyFiscLabel(
-#     env_dir_setup_cleanup,
-# ):
-#     # ESTABLISH
-#     accord23_str = "accord23"
-#     accord45_str = "accord45"
-#     fisc_mstr_dir = get_module_temp_dir()
-#     fisunit_v_agg_tablename = create_prime_tablename(fiscunit_str(), "v", "agg")
-#     print(f"{fisunit_v_agg_tablename=}")
+def test_etl_voice_agg_tables_to_fisc_jsons_Scenario0_CreateFilesWithOnlyFiscLabel(
+    env_dir_setup_cleanup,
+):
+    # ESTABLISH
+    accord23_str = "accord23"
+    accord45_str = "accord45"
+    fisc_mstr_dir = get_module_temp_dir()
+    fisunit_v_agg_tablename = create_prime_tablename(fiscunit_str(), "v", "agg")
+    print(f"{fisunit_v_agg_tablename=}")
 
-#     with sqlite3_connect(":memory:") as fisc_db_conn:
-#         cursor = fisc_db_conn.cursor()
-#         create_sound_and_voice_tables(cursor)
+    with sqlite3_connect(":memory:") as fisc_db_conn:
+        cursor = fisc_db_conn.cursor()
+        create_sound_and_voice_tables(cursor)
 
-#         insert_raw_sqlstr = f"""
-# INSERT INTO {fisunit_v_agg_tablename} ({fisc_label_str()})
-# VALUES ('{accord23_str}'), ('{accord45_str}')
-# ;
-# """
-#         cursor.execute(insert_raw_sqlstr)
-#         assert get_row_count(cursor, fisunit_v_agg_tablename) == 2
-#         fisc_event_time_agg_str = "fisc_event_time_agg"
-#         assert db_table_exists(cursor, fisc_event_time_agg_str) is False
+        insert_raw_sqlstr = f"""
+INSERT INTO {fisunit_v_agg_tablename} ({fisc_label_str()})
+VALUES ('{accord23_str}'), ('{accord45_str}')
+;
+"""
+        cursor.execute(insert_raw_sqlstr)
+        assert get_row_count(cursor, fisunit_v_agg_tablename) == 2
+        fisc_event_time_agg_str = "fisc_event_time_agg"
+        assert db_table_exists(cursor, fisc_event_time_agg_str) is False
 
-#         accord23_json_path = create_fisc_json_path(fisc_mstr_dir, accord23_str)
-#         accord45_json_path = create_fisc_json_path(fisc_mstr_dir, accord45_str)
-#         assert os_path_exists(accord23_json_path) is False
-#         assert os_path_exists(accord45_json_path) is False
+        accord23_json_path = create_fisc_json_path(fisc_mstr_dir, accord23_str)
+        accord45_json_path = create_fisc_json_path(fisc_mstr_dir, accord45_str)
+        assert os_path_exists(accord23_json_path) is False
+        assert os_path_exists(accord45_json_path) is False
 
-#         # WHEN
-#         etl_voice_agg_tables_to_fisc_jsons(cursor, fisc_mstr_dir)
+        # WHEN
+        etl_voice_agg_tables_to_fisc_jsons(cursor, fisc_mstr_dir)
 
-#     # THEN
-#     assert os_path_exists(accord23_json_path)
-#     assert os_path_exists(accord45_json_path)
-#     accord23_fisc = fiscunit_get_from_json(open_file(accord23_json_path))
-#     accord45_fisc = fiscunit_get_from_json(open_file(accord45_json_path))
-#     assert accord23_fisc.fisc_label == accord23_str
-#     assert accord45_fisc.fisc_label == accord45_str
+    # THEN
+    assert os_path_exists(accord23_json_path)
+    assert os_path_exists(accord45_json_path)
+    accord23_fisc = fiscunit_get_from_json(open_file(accord23_json_path))
+    accord45_fisc = fiscunit_get_from_json(open_file(accord45_json_path))
+    assert accord23_fisc.fisc_label == accord23_str
+    assert accord45_fisc.fisc_label == accord45_str
 
 
 # def test_etl_fisc_agg_tables_to_fisc_jsons_Scenario1_CreateFilesWithFiscUnitAttrs(

--- a/src/a18_etl_toolbox/test_tran/test_voice_raw_tables2voice_agg_tables.py
+++ b/src/a18_etl_toolbox/test_tran/test_voice_raw_tables2voice_agg_tables.py
@@ -27,7 +27,7 @@ from sqlite3 import connect as sqlite3_connect
 
 
 def test_get_insert_voice_agg_sqlstrs_ReturnsObj_CheckFiscDimen():
-    # sourcery skip: extract-method, no-loop-in-tests
+    # sourcery skip: no-loop-in-tests
     # ESTABLISH / WHEN
     insert_voice_agg_sqlstrs = get_insert_voice_agg_sqlstrs()
 

--- a/src/a18_etl_toolbox/tran_sqlstrs.py
+++ b/src/a18_etl_toolbox/tran_sqlstrs.py
@@ -1078,7 +1078,7 @@ FISOFFI_FU2_SELECT_SQLSTR = (
 FISUNIT_FU2_SELECT_SQLSTR = "SELECT fisc_label, timeline_label, c400_number, yr1_jan1_offset, monthday_distortion, fund_coin, penny, respect_bit, bridge, job_listen_rotations FROM fiscunit_v_agg WHERE fisc_label = "
 
 
-def get_fisc_voice_select_sqlstrs(fisc_label: str) -> dict[str, str]:
+def get_fisc_voice_select1_sqlstrs(fisc_label: str) -> dict[str, str]:
     return {
         "fiscunit": f"{FISUNIT_FU2_SELECT_SQLSTR}'{fisc_label}'",
         "fisc_dealunit": f"{FISDEAL_FU2_SELECT_SQLSTR}'{fisc_label}'",

--- a/src/a18_etl_toolbox/tran_sqlstrs.py
+++ b/src/a18_etl_toolbox/tran_sqlstrs.py
@@ -531,11 +531,11 @@ def create_all_idea_tables(conn_or_cursor: sqlite3_Connection):
 def create_sound_raw_update_inconsist_error_message_sqlstr(
     conn_or_cursor: sqlite3_Connection, dimen: str
 ) -> str:
-    if dimen[:4].lower() == "fisc":
+    if dimen.lower().startswith("fisc"):
         exclude_cols = {"idea_number", "event_int", "face_name", "error_message"}
     else:
         exclude_cols = {"idea_number", "error_message"}
-    if dimen[:3].lower() == "bud":
+    if dimen.lower().startswith("bud"):
         x_tablename = create_prime_tablename(dimen, "s", "raw", "put")
     else:
         x_tablename = create_prime_tablename(dimen, "s", "raw")
@@ -552,7 +552,7 @@ def create_sound_agg_insert_sqlstrs(
     dimen_config = get_idea_config_dict().get(dimen)
     dimen_focus_columns = set(dimen_config.get("jkeys").keys())
 
-    if dimen[:4].lower() == "fisc":
+    if dimen.lower().startswith("fisc"):
         exclude_cols = {"idea_number", "event_int", "face_name", "error_message"}
         dimen_focus_columns = set(dimen_config.get("jkeys").keys())
         dimen_focus_columns.remove("event_int")
@@ -561,7 +561,7 @@ def create_sound_agg_insert_sqlstrs(
     else:
         exclude_cols = {"idea_number", "error_message"}
 
-    if dimen[:3].lower() == "bud":
+    if dimen.lower().startswith("bud"):
         agg_tablename = create_prime_tablename(dimen, "s", "agg", "put")
         raw_tablename = create_prime_tablename(dimen, "s", "raw", "put")
     else:
@@ -576,7 +576,7 @@ def create_sound_agg_insert_sqlstrs(
         exclude_cols=exclude_cols,
     )
     sqlstrs = [pidgin_fisc_bud_put_sqlstr]
-    if dimen[:3].lower() == "bud":
+    if dimen.lower().startswith("bud"):
         del_raw_tablename = create_prime_tablename(dimen, "s", "raw", "del")
         del_agg_tablename = create_prime_tablename(dimen, "s", "agg", "del")
         bud_del_sqlstr = create_table2table_agg_insert_query(
@@ -710,8 +710,8 @@ def create_insert_pidgin_sound_vld_table_sqlstr(dimen: str) -> str:
         "pidgin_label": "label",
         "pidgin_way": "way",
     }
-    otx_str = f"otx_{dimen_otx_inx_obj_names[dimen]}"
-    inx_str = f"inx_{dimen_otx_inx_obj_names[dimen]}"
+    otx_str = f"otx_{dimen_otx_inx_obj_names.get(dimen, dimen)}"
+    inx_str = f"inx_{dimen_otx_inx_obj_names.get(dimen, dimen)}"
     return f"""
 INSERT INTO {pidgin_s_vld_tablename} (event_int, face_name, {otx_str}, {inx_str})
 SELECT event_int, face_name, MAX({otx_str}), MAX({inx_str})
@@ -1064,6 +1064,29 @@ def get_insert_voice_agg_sqlstrs() -> dict[str, str]:
         "bud_conceptunit_v_del_agg": INSERT_BUDCONC_VOICE_AGG_DEL_SQLSTR,
         "budunit_v_put_agg": INSERT_BUDUNIT_VOICE_AGG_PUT_SQLSTR,
         "budunit_v_del_agg": INSERT_BUDUNIT_VOICE_AGG_DEL_SQLSTR,
+    }
+
+
+FISCASH_FU2_SELECT_SQLSTR = "SELECT fisc_label, owner_name, acct_name, tran_time, amount FROM fisc_cashbook_v_agg WHERE fisc_label = "
+FISDEAL_FU2_SELECT_SQLSTR = "SELECT fisc_label, owner_name, deal_time, quota, celldepth FROM fisc_dealunit_v_agg WHERE fisc_label = "
+FISHOUR_FU2_SELECT_SQLSTR = "SELECT fisc_label, cumlative_minute, hour_label FROM fisc_timeline_hour_v_agg WHERE fisc_label = "
+FISMONT_FU2_SELECT_SQLSTR = "SELECT fisc_label, cumlative_day, month_label FROM fisc_timeline_month_v_agg WHERE fisc_label = "
+FISWEEK_FU2_SELECT_SQLSTR = "SELECT fisc_label, weekday_order, weekday_label FROM fisc_timeline_weekday_v_agg WHERE fisc_label = "
+FISOFFI_FU2_SELECT_SQLSTR = (
+    "SELECT fisc_label, offi_time FROM fisc_timeoffi_v_agg WHERE fisc_label = "
+)
+FISUNIT_FU2_SELECT_SQLSTR = "SELECT fisc_label, timeline_label, c400_number, yr1_jan1_offset, monthday_distortion, fund_coin, penny, respect_bit, bridge, job_listen_rotations FROM fiscunit_v_agg WHERE fisc_label = "
+
+
+def get_fisc_voice_select_sqlstrs(fisc_label: str) -> dict[str, str]:
+    return {
+        "fiscunit": f"{FISUNIT_FU2_SELECT_SQLSTR}'{fisc_label}'",
+        "fisc_dealunit": f"{FISDEAL_FU2_SELECT_SQLSTR}'{fisc_label}'",
+        "fisc_cashbook": f"{FISCASH_FU2_SELECT_SQLSTR}'{fisc_label}'",
+        "fisc_timeline_hour": f"{FISHOUR_FU2_SELECT_SQLSTR}'{fisc_label}'",
+        "fisc_timeline_month": f"{FISMONT_FU2_SELECT_SQLSTR}'{fisc_label}'",
+        "fisc_timeline_weekday": f"{FISWEEK_FU2_SELECT_SQLSTR}'{fisc_label}'",
+        "fisc_timeoffi": f"{FISOFFI_FU2_SELECT_SQLSTR}'{fisc_label}'",
     }
 
 

--- a/src/a18_etl_toolbox/transformers.py
+++ b/src/a18_etl_toolbox/transformers.py
@@ -119,7 +119,10 @@ from src.a18_etl_toolbox.tran_sqlstrs import (
     CREATE_FISC_OTE1_AGG_SQLSTR,
     INSERT_FISC_OTE1_AGG_SQLSTR,
 )
-from src.a18_etl_toolbox.db_obj_tool import get_fisc_dict_from_db
+from src.a18_etl_toolbox.db_obj_tool import (
+    get_fisc_dict_from_db,
+    get_fisc_dict_from_voice_tables,
+)
 from src.a18_etl_toolbox.idea_collector import get_all_idea_dataframes, IdeaFileRef
 from src.a18_etl_toolbox.pidgin_agg import (
     pidginheartbook_shop,
@@ -634,7 +637,7 @@ def etl_voice_agg_tables_to_fisc_jsons(cursor: sqlite3_Cursor, fisc_mstr_dir: st
     cursor.execute(select_fisc_label_sqlstr)
     for fisc_label_set in cursor.fetchall():
         fisc_label = fisc_label_set[0]
-        fisc_dict = get_fisc_dict_from_db(cursor, fisc_label)
+        fisc_dict = get_fisc_dict_from_voice_tables(cursor, fisc_label)
         fiscunit_dir = create_path(fiscs_dir, fisc_label)
         save_json(fiscunit_dir, fisc_filename, fisc_dict)
 

--- a/src/a18_etl_toolbox/transformers.py
+++ b/src/a18_etl_toolbox/transformers.py
@@ -600,7 +600,7 @@ def set_voice_raw_inx_column(
     cursor: sqlite3_Cursor,
     voice_raw_tablename: str,
     column_without_otx: str,
-    arg_class_type: dict[str, str],
+    arg_class_type: str,
 ):
     if arg_class_type in {"NameStr", "TitleStr", "LabelStr", "WayStr"}:
         pidgin_type_abbv = ""

--- a/src/a18_etl_toolbox/transformers.py
+++ b/src/a18_etl_toolbox/transformers.py
@@ -468,7 +468,7 @@ def get_sound_raw_tablenames(
     valid_columns = set(get_table_columns(cursor, brick_valid_tablename))
     s_raw_tables = set()
     for dimen in dimens:
-        if dimen[:3].lower() == "bud":
+        if dimen.lower().startswith("bud"):
             bud_del_tablename = create_prime_tablename(dimen, "s", "raw", "del")
             bud_del_columns = get_table_columns(cursor, bud_del_tablename)
             delete_key = bud_del_columns[-1]
@@ -625,6 +625,18 @@ def set_voice_raw_inx_column(
 def etl_voice_raw_tables_to_voice_agg_tables(cursor: sqlite3_Cursor):
     for insert_voice_agg_sqlstr in get_insert_voice_agg_sqlstrs().values():
         cursor.execute(insert_voice_agg_sqlstr)
+
+
+def etl_voice_agg_tables_to_fisc_jsons(cursor: sqlite3_Cursor, fisc_mstr_dir: str):
+    fisc_filename = "fisc.json"
+    fiscs_dir = create_path(fisc_mstr_dir, "fiscs")
+    select_fisc_label_sqlstr = """SELECT fisc_label FROM fiscunit_v_agg;"""
+    cursor.execute(select_fisc_label_sqlstr)
+    for fisc_label_set in cursor.fetchall():
+        fisc_label = fisc_label_set[0]
+        fisc_dict = get_fisc_dict_from_db(cursor, fisc_label)
+        fiscunit_dir = create_path(fiscs_dir, fisc_label)
+        save_json(fiscunit_dir, fisc_filename, fisc_dict)
 
 
 def etl_brick_valid_table_into_prime_table(

--- a/src/a19_world_logic/test_etl_pipeline/test_world_mud_to_stances.py
+++ b/src/a19_world_logic/test_etl_pipeline/test_world_mud_to_stances.py
@@ -81,6 +81,7 @@ def test_WorldUnit_mud_to_stances_v2_with_cursor_Scenario3_br000113PopulatesTabl
         inx_name_str(),
     ]
     a23_str = "accord23"
+    tp37 = 37
     br00113_str = "br00113"
     br00113row0 = [sue_str, e3, a23_str, sue_str, sue_str, sue_str, sue_inx]
     br00113_df = DataFrame([br00113row0], columns=br00113_columns)
@@ -109,10 +110,11 @@ def test_WorldUnit_mud_to_stances_v2_with_cursor_Scenario3_br000113PopulatesTabl
     budunit_voice_put_agg = create_prime_tablename("budunit", "v", "agg", "put")
     budacct_voice_put_raw = create_prime_tablename("budacct", "v", "raw", "put")
     budacct_voice_put_agg = create_prime_tablename("budacct", "v", "agg", "put")
-    event1_pidgin_json_path = "events/1/pidgin.json"
-    event1_inherited_pidgin_json_path = "events/1/inherited_pidgin.json"
-    event1_voice_budunit_path = "events/1/voice_budunit.csv"
-    event1_voice_budacct_path = "events/1/voice_budacct.csv"
+    mstr_dir = fizz_world._fisc_mstr_dir
+    a23_json_path = create_fisc_json_path(mstr_dir, a23_str)
+    a23_sue_gut_path = create_gut_path(mstr_dir, a23_str, sue_str)
+    a23_sue_job_path = create_job_path(mstr_dir, a23_str, sue_str)
+    # sue37_mandate_path = deal_mandate(mstr_dir, a23_str, sue_str, tp37)
 
     with sqlite3_connect(":memory:") as db_conn:
         cursor = db_conn.cursor()
@@ -137,6 +139,23 @@ def test_WorldUnit_mud_to_stances_v2_with_cursor_Scenario3_br000113PopulatesTabl
         assert not db_table_exists(cursor, budunit_voice_put_agg)
         assert not db_table_exists(cursor, budacct_voice_put_raw)
         assert not db_table_exists(cursor, budacct_voice_put_agg)
+        assert not os_path_exists(a23_json_path)
+        # assert not os_path_exists(a23_sue_gut_path)
+        # assert not os_path_exists(a23_sue_job_path)
+
+        # self.fisc_agg_tables_to_fisc_jsons(cursor)
+        # self.fisc_agg_tables_to_fisc_ote1_agg(cursor)
+        # self.fisc_table2fisc_ote1_agg_csvs(cursor)
+        # self.fisc_ote1_agg_csvs2jsons()
+
+        # # create budunits
+        # self.bud_tables_to_event_bud_csvs(cursor)
+        # self.event_bud_csvs_to_pack_json()
+        # self.event_inherited_budunits_to_fisc_gut()
+
+        # # create all fisc_job and mandate reports
+        # self.fisc_gut_to_fisc_job()
+        # self.calc_fisc_deal_acct_mandate_net_ledgers()
 
         # WHEN
         fizz_world.mud_to_stances_v2_with_cursor(db_conn, cursor)
@@ -165,6 +184,9 @@ def test_WorldUnit_mud_to_stances_v2_with_cursor_Scenario3_br000113PopulatesTabl
         assert get_row_count(cursor, fisunit_voice_agg) == 1
         assert get_row_count(cursor, budunit_voice_put_agg) == 1
         assert get_row_count(cursor, budacct_voice_put_agg) == 1
+        assert os_path_exists(a23_json_path)
+        # assert os_path_exists(a23_sue_gut_path)
+        # assert os_path_exists(a23_sue_job_path)
 
 
 def test_WorldUnit_mud_to_stances_Scenario3_CreatesFiles(env_dir_setup_cleanup):

--- a/src/a19_world_logic/world.py
+++ b/src/a19_world_logic/world.py
@@ -23,6 +23,7 @@ from src.a18_etl_toolbox.transformers import (
     etl_pidgin_sound_agg_tables_to_pidgin_sound_vld_tables,
     etl_sound_agg_tables_to_voice_raw_tables,
     etl_voice_raw_tables_to_voice_agg_tables,
+    etl_voice_agg_tables_to_fisc_jsons,
     etl_brick_raw_db_to_brick_raw_df,
     etl_brick_agg_tables_to_brick_agg_dfs,
     etl_brick_raw_tables_to_events_brick_agg_table,
@@ -334,6 +335,7 @@ class WorldUnit:
         etl_pidgin_sound_agg_tables_to_pidgin_sound_vld_tables(cursor)
         etl_sound_agg_tables_to_voice_raw_tables(cursor)
         etl_voice_raw_tables_to_voice_agg_tables(cursor)
+        etl_voice_agg_tables_to_fisc_jsons(cursor, self._fisc_mstr_dir)
 
         # identify all idea data that has conflicting face_name/event_int uniqueness
         # self._events = etl_events_brick_agg_db_to_event_dict(cursor)


### PR DESCRIPTION
## Summary by Sourcery

Enable generating and exporting fiscal data from voice aggregation tables to JSON, integrate the new step into the ETL pipeline, refactor SQL generators for consistency and safety, and substantially expand test coverage for the new functionality.

New Features:
- Add get_fisc_dict_from_voice_tables and SQL constants to fetch fiscal data from voice aggregation tables
- Implement etl_voice_agg_tables_to_fisc_jsons to export fiscal voice data to JSON and integrate it into the world ETL pipeline

Bug Fixes:
- Fix test imports and function names for consistency
- Add missing assertion for to_way("", bridge) in way logic tests

Enhancements:
- Standardize dimension prefix checks in SQL string generators to use lower().startswith for ‚fisc‘ and ‚bud‘
- Refactor SQL OTX/INX string assembly to use a safe lookup with default fallback
- Unify DB and voice fiscal data fetching via a shared get_fisc_dict_from_sqlstrs helper

Tests:
- Expand test coverage for get_fisc_dict_from_voice_tables across all fiscal dimensions
- Add tests for get_fisc_voice_select1_sqlstrs and etl_voice_agg_tables_to_fisc_jsons
- Update world mud-to-stances tests to verify fiscal JSON file creation