### PR TITLE
create tool for generating year month displays in text. Given a timel…

### DIFF
--- a/docs/str_funcs.md
+++ b/docs/str_funcs.md
@@ -8,7 +8,7 @@
 - a04_reason_logic: _active, _chore, _status, fcontext, fnigh, fopen, fstate, labor_title, pdivisor, pnigh, popen, pstate, rconcept_active_requisite, rcontext
 - a05_concept_logic: _active_hx, _all_acct_cred, _all_acct_debt, _awardheirs, _awardlines, _descendant_task_count, _factheirs, _fund_cease, _fund_onset, _fund_ratio, _gogo_calc, _healerlink_ratio, _is_expanded, _kids, _range_evaluated, _reasonheirs, _stop_calc, _uid, addin, begin, close, concept_label, concept_rope, denom, gogo_want, healer_name, healerlink, mass, morph, numor, problem_bool, stop_want, task
 - a06_plan_logic: _keeps_buildable, _keeps_justified, _offtrack_fund, _offtrack_kids_mass_set, _rational, _reason_rcontexts, _sum_healerlink_share, _tree_traverse_count, acct_pool, ancestors, attributes, credor_respect, debtor_respect, dimen, dimens, jkeys, last_pack_id, mandate, max_tree_traverse, plan_acct_membership, plan_acctunit, plan_concept_awardlink, plan_concept_factunit, plan_concept_healerlink, plan_concept_laborlink, plan_concept_reason_premiseunit, plan_concept_reasonunit, plan_conceptunit, planunit, tally, timeline
-- a07_calendar_logic: c100, c400_clean, c400_leap, c400_number, creg, day, days, five, hour, hours_config, monthday_distortion, months_config, time, timeline_label, week, weekdays_config, weeks, year, yr1_jan1_offset, yr4_clean, yr4_leap
+- a07_calendar_logic: c100, c400_clean, c400_leap, c400_number, creg, cumlative_day, day, days, five, hour, hours_config, monthday_distortion, months_config, time, timeline_label, week, weekdays_config, weeks, year, yr1_jan1_offset, yr4_clean, yr4_leap
 - a08_plan_atom_logic: DELETE, atom_hx, class_type, column_order, crud, jvalues, nesting_order, normal_specs, normal_table_name
 - a09_pack_logic: event_int, face_name
 - a10_plan_calc: jmetrics, plan_groupunit
@@ -16,7 +16,7 @@
 - a12_hub_toolbox: gut, job, vow_ote1_agg
 - a13_plan_listen_logic: 
 - a14_keep_logic: 
-- a15_vow_logic: brokerunits, cumlative_day, cumlative_minute, hour_label, job_listen_rotations, month_label, paybook, vow_budunit, vow_paybook, vow_timeline_hour, vow_timeline_month, vow_timeline_weekday, vow_timeoffi, vowunit, weekday_label, weekday_order
+- a15_vow_logic: brokerunits, cumlative_minute, hour_label, job_listen_rotations, month_label, paybook, vow_budunit, vow_paybook, vow_timeline_hour, vow_timeline_month, vow_timeline_weekday, vow_timeoffi, vowunit, weekday_label, weekday_order
 - a16_pidgin_logic: inx_knot, inx_label, inx_name, inx_rope, inx_title, map_otx2inx, otx2inx, otx_key, otx_knot, otx_label, otx_name, otx_rope, otx_title, pidgin_core, pidgin_label, pidgin_name, pidgin_rope, pidgin_title, pidginunit, unknown_str
 - a17_idea_logic: allowed_crud, brick_raw, build_order, delete_insert, delete_insert_update, delete_update, idea_category, idea_number, insert_multiple, insert_one_time, insert_update, world_id
 - a18_etl_toolbox: brick_agg, brick_valid, events_brick_agg, events_brick_valid, owner_net_amount, sound_agg, sound_raw, voice_agg, voice_raw, vow_acct_nets, vow_event_time_agg

--- a/src/a07_calendar_logic/_util/a07_str.py
+++ b/src/a07_calendar_logic/_util/a07_str.py
@@ -18,6 +18,10 @@ def creg_str() -> str:
     return "creg"
 
 
+def cumlative_day_str() -> str:
+    return "cumlative_day"
+
+
 def day_str() -> str:
     return "day"
 

--- a/src/a07_calendar_logic/_util/test_a07_str.py
+++ b/src/a07_calendar_logic/_util/test_a07_str.py
@@ -4,6 +4,7 @@ from src.a07_calendar_logic._util.a07_str import (
     c400_leap_str,
     c400_number_str,
     creg_str,
+    cumlative_day_str,
     day_str,
     days_str,
     five_str,
@@ -30,6 +31,7 @@ def test_str_functions_ReturnsObj():
     assert c400_clean_str() == "c400_clean"
     assert c400_number_str() == "c400_number"
     assert creg_str() == "creg"
+    assert cumlative_day_str() == "cumlative_day"
     assert day_str() == "day"
     assert days_str() == "days"
     assert five_str() == "five"

--- a/src/a07_calendar_logic/calendar_markdown.py
+++ b/src/a07_calendar_logic/calendar_markdown.py
@@ -1,0 +1,154 @@
+from copy import copy as copy_copy
+from dataclasses import dataclass
+from math import ceil as roundup_math
+from src.a07_calendar_logic.chrono import TimeLineUnit, timelineunit_shop
+
+
+@dataclass
+class MonthGridUnit:
+    name: str = None
+    cumlative_days: str = None
+    first_weekday: int = None
+    week_length: int = None
+    month_days_int: int = None
+    monthday_distortion: int = None
+    weekday_2char_abvs: list[str] = None
+    max_monthday_rows: int = None
+
+    def markdown_name(self) -> str:
+        char_width = (self.week_length * 3) - 1
+        return center_word(char_width, self.name)
+
+    def markdown_weekdays(self) -> str:
+        x_str = "".join(f"{abv} " for abv in self.weekday_2char_abvs)
+        return x_str.rstrip()
+
+    def markdown_day_numbers(self, row_int: int) -> str:
+        starting_monthday = row_int * self.week_length
+        starting_monthday = starting_monthday - self.first_weekday
+        ending_monthday = starting_monthday + self.week_length
+        x_str = ""
+        for monthday in range(starting_monthday, ending_monthday):
+            if monthday < 0 or monthday >= self.month_days_int:
+                x_str += "   "
+            else:
+                display_monthday = monthday + self.monthday_distortion
+                x_str += f"{display_monthday:2} "
+        return x_str[:-1]
+
+    def set_max_monthday_rows(self):
+        row_int = 0
+        while self.markdown_day_numbers(row_int).rstrip() != "":
+            row_int += 1
+        self.max_monthday_rows = row_int
+
+    def get_next_month_first_weekday(self) -> int:
+        right_days = self.month_days_int + self.first_weekday
+        return right_days % self.week_length
+
+
+@dataclass
+class MonthGridRow:
+    months: list[MonthGridUnit] = None
+    max_monthday_numbers_row: int = None
+
+    def set_max_monthday_numbers_row(self):
+        x_max = 0
+        for monthgridunit in self.months:
+            monthgridunit.set_max_monthday_rows()
+            if monthgridunit.max_monthday_rows > x_max:
+                x_max = monthgridunit.max_monthday_rows
+        self.max_monthday_numbers_row = x_max
+
+    def markdown_str(self) -> str:
+        x_str = "\n"
+        for monthgridunit in self.months:
+            x_str += f"{monthgridunit.markdown_name()}      "
+        x_str = f"{x_str[:-6]}\n"
+        for monthgridunit in self.months:
+            x_str += f"{monthgridunit.markdown_weekdays()}      "
+        x_str = f"{x_str[:-6]}\n"
+        self.set_max_monthday_numbers_row()
+        for row_int in range(self.max_monthday_numbers_row):
+            for monthgridunit in self.months:
+                x_str += f"{monthgridunit.markdown_day_numbers(row_int)}      "
+            x_str = f"{x_str[:-6]}\n"
+        return x_str[:-1]
+
+
+@dataclass
+class CalendarGrid:
+    timeline_config: dict = None
+    monthgridrows: list[MonthGridRow] = None
+    timelineunit: TimeLineUnit = None
+    week_length: int = None
+    monthgridrow_length: int = None
+    month_char_width: int = None
+    max_md_width: int = 84
+    display_md_width: int = None
+
+    def create_2char_weekday_list(self, display_init_day: str) -> list[str]:
+        orig_weekdays = copy_copy(self.timelineunit.weekdays_config)
+        display_index = 0
+        for x_count, weekday in enumerate(orig_weekdays):
+            if weekday == display_init_day:
+                display_index = x_count
+
+        weekday_list = [
+            orig_weekdays[weekday_index]
+            for weekday_index in range(display_index, len(orig_weekdays))
+        ]
+        weekday_list.extend(
+            orig_weekdays[weekday_index] for weekday_index in range(display_index)
+        )
+
+        return [weekday[:2] for weekday in weekday_list]
+
+    def set_timelineunit(self, display_init_day: str, year_init_weekday: str):
+        self.timelineunit = timelineunit_shop(self.timeline_config)
+        self.week_length = len(self.timelineunit.weekdays_config)
+        self.month_char_width = (self.week_length * 3) + 5
+        self.monthgridrow_length = int(self.max_md_width / self.month_char_width)
+        self.display_md_width = self.monthgridrow_length * self.month_char_width - 6
+        self.monthgridrows = []
+        x_monthgridrow = MonthGridRow([])
+        previous_cumlative_days = 0
+        x_monthday_distortion = self.timelineunit.monthday_distortion
+        x_weekday_2char_list = self.create_2char_weekday_list(display_init_day)
+        year_init_2char = year_init_weekday[:2]
+        month_first_weekday_index = x_weekday_2char_list.index(year_init_2char)
+
+        for month_cumlative_list in self.timelineunit.months_config:
+            month_str = month_cumlative_list[0]
+            cumlative_days = month_cumlative_list[1]
+            new_monthgridunit = MonthGridUnit(month_str, cumlative_days)
+            new_monthgridunit.week_length = self.week_length
+            new_monthgridunit.month_days_int = cumlative_days - previous_cumlative_days
+            new_monthgridunit.monthday_distortion = x_monthday_distortion
+            new_monthgridunit.weekday_2char_abvs = x_weekday_2char_list
+            new_monthgridunit.first_weekday = month_first_weekday_index
+            month_first_weekday_index = new_monthgridunit.get_next_month_first_weekday()
+            previous_cumlative_days = cumlative_days
+            # new_monthgridunit.week_length = self.week_length
+            x_monthgridrow.months.append(new_monthgridunit)
+            if len(x_monthgridrow.months) == self.monthgridrow_length:
+                self.monthgridrows.append(x_monthgridrow)
+                x_monthgridrow = MonthGridRow([])
+        if len(x_monthgridrow.months) > 0:
+            self.monthgridrows.append(x_monthgridrow)
+            x_monthgridrow = MonthGridRow([])
+
+    def create_markdown(self, year: int) -> str:
+        markdown_str = f"""
+{center_word(self.display_md_width, f"Year {year}")}
+"""
+        for monthgridrow in self.monthgridrows:
+            markdown_str += monthgridrow.markdown_str()
+            markdown_str += "\n"
+        return markdown_str[:-1]
+
+
+def center_word(length, word):
+    if len(word) > length:
+        raise ValueError("Word is longer than the specified length.")
+    return word.center(length)

--- a/src/a07_calendar_logic/test/test_md_generator.py
+++ b/src/a07_calendar_logic/test/test_md_generator.py
@@ -1,0 +1,428 @@
+from src.a07_calendar_logic._util.calendar_examples import get_five_config
+from src.a07_calendar_logic.calendar_markdown import (
+    CalendarGrid,
+    MonthGridRow,
+    MonthGridUnit,
+)
+from src.a07_calendar_logic.chrono import (
+    get_default_timeline_config_dict,
+    timelineunit_shop,
+)
+
+
+def test_MonthGridUnit_Exists():
+    # ESTABLISH / WHEN
+    x_monthgridunit = MonthGridUnit()
+
+    # THEN
+    assert not x_monthgridunit.name
+    assert not x_monthgridunit.cumlative_days
+    assert not x_monthgridunit.first_weekday
+    assert not x_monthgridunit.week_length
+    assert not x_monthgridunit.month_days_int
+    assert not x_monthgridunit.monthday_distortion
+    assert not x_monthgridunit.weekday_2char_abvs
+    assert not x_monthgridunit.max_monthday_rows
+
+
+def test_MonthGridUnit_markdown_name_ReturnsObj():
+    # ESTABLISH
+    jan_monthgridunit = MonthGridUnit("January", None, 5, 7, 31, 1)
+
+    # WHEN
+    markdown_name = jan_monthgridunit.markdown_name()
+
+    # THEN
+    assert markdown_name == "      January       "
+    assert len(markdown_name) == 3 * 7 - 1
+
+
+def test_MonthGridUnit_markdown_weekdays_ReturnsObj():
+    # ESTABLISH
+    jan_monthgridunit = MonthGridUnit("January", None, 5, 7, 31, 1)
+    jan_monthgridunit.weekday_2char_abvs = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]
+
+    # WHEN
+    markdown_weekdays = jan_monthgridunit.markdown_weekdays()
+
+    # THEN
+    assert markdown_weekdays == "Mo Tu We Th Fr Sa Su"
+
+
+def test_MonthGridUnit_markdown_day_numbers_ReturnsObj_Scenario0_Row0():
+    # ESTABLISH
+    jan_monthgridunit = MonthGridUnit(
+        "January",
+        None,
+        first_weekday=0,
+        week_length=7,
+        month_days_int=31,
+        monthday_distortion=0,
+    )
+
+    # WHEN
+    markdown_day_numbers = jan_monthgridunit.markdown_day_numbers(row_int=0)
+
+    # THEN
+    assert markdown_day_numbers == " 0  1  2  3  4  5  6"
+
+
+def test_MonthGridUnit_markdown_day_numbers_ReturnsObj_Scenario1_Row1():
+    # ESTABLISH
+    jan_monthgridunit = MonthGridUnit(
+        "January",
+        None,
+        first_weekday=0,
+        week_length=7,
+        month_days_int=31,
+        monthday_distortion=0,
+    )
+
+    # WHEN
+    markdown_day_numbers = jan_monthgridunit.markdown_day_numbers(row_int=1)
+
+    # THEN
+    assert markdown_day_numbers == " 7  8  9 10 11 12 13"
+
+
+def test_MonthGridUnit_markdown_day_numbers_ReturnsObj_Scenario2_monthday_distortion():
+    # ESTABLISH
+    jan_monthgridunit = MonthGridUnit(
+        "January",
+        None,
+        first_weekday=0,
+        week_length=7,
+        month_days_int=31,
+        monthday_distortion=1,
+    )
+
+    # WHEN
+    markdown_day_numbers = jan_monthgridunit.markdown_day_numbers(row_int=0)
+
+    # THEN
+    assert markdown_day_numbers == " 1  2  3  4  5  6  7"
+
+
+def test_MonthGridUnit_markdown_day_numbers_ReturnsObj_Scenario3_first_weekday():
+    # ESTABLISH
+    jan_monthgridunit = MonthGridUnit(
+        "January",
+        None,
+        first_weekday=3,
+        week_length=7,
+        month_days_int=31,
+        monthday_distortion=1,
+    )
+
+    # WHEN
+    markdown_day_numbers = jan_monthgridunit.markdown_day_numbers(row_int=0)
+
+    # THEN
+    assert markdown_day_numbers == "          1  2  3  4"
+
+
+def test_MonthGridUnit_markdown_day_numbers_ReturnsObj_Scenario4_first_weekday():
+    # ESTABLISH
+    jan_monthgridunit = MonthGridUnit(
+        "January",
+        None,
+        first_weekday=3,
+        week_length=7,
+        month_days_int=31,
+        monthday_distortion=1,
+    )
+
+    # WHEN / THEN
+    assert jan_monthgridunit.markdown_day_numbers(row_int=1) == " 5  6  7  8  9 10 11"
+    assert jan_monthgridunit.markdown_day_numbers(row_int=4) == "26 27 28 29 30 31   "
+
+
+def test_MonthGridUnit_set_max_monthday_rows_ReturnsObj_Scenario0():
+    # ESTABLISH
+    jan_monthgridunit = MonthGridUnit(
+        "January",
+        None,
+        first_weekday=3,
+        week_length=7,
+        month_days_int=31,
+        monthday_distortion=1,
+    )
+    assert not jan_monthgridunit.max_monthday_rows
+
+    # WHEN
+    jan_monthgridunit.set_max_monthday_rows()
+
+    # THEN
+    assert jan_monthgridunit.max_monthday_rows == 5
+
+
+def test_MonthGridUnit_get_next_month_first_weekday_ReturnsObj_Scenario0():
+    # ESTABLISH
+    jan_monthgridunit = MonthGridUnit(
+        "February",
+        None,
+        first_weekday=3,
+        week_length=7,
+        month_days_int=28,
+    )
+
+    # WHEN / THEN
+    assert jan_monthgridunit.get_next_month_first_weekday() == 3
+
+
+def test_MonthGridUnit_get_next_month_first_weekday_ReturnsObj_Scenario1():
+    # ESTABLISH
+    jan_monthgridunit = MonthGridUnit(
+        "February",
+        None,
+        first_weekday=6,
+        week_length=7,
+        month_days_int=28,
+    )
+
+    # WHEN / THEN
+    assert jan_monthgridunit.get_next_month_first_weekday() == 6
+
+
+def test_MonthGridUnit_get_next_month_first_weekday_ReturnsObj_Scenario2():
+    # ESTABLISH
+    jan_monthgridunit = MonthGridUnit(
+        "February",
+        None,
+        first_weekday=6,
+        week_length=7,
+        month_days_int=31,
+    )
+
+    # WHEN / THEN
+    assert jan_monthgridunit.get_next_month_first_weekday() == 2
+
+
+def test_MonthGridRow_Exists():
+    # ESTABLISH / WHEN
+    x_monthgridrow = MonthGridRow()
+
+    # THEN
+    assert not x_monthgridrow.months
+    assert not x_monthgridrow.max_monthday_numbers_row
+
+
+def test_MonthGridRow_set_max_monthday_numbers_row_SetsAttr():
+    # ESTABLISH
+    x_monthgridrow = MonthGridRow([])
+    jan_monthgridunit = MonthGridUnit("January", None, 5, 7, 31, 1)
+    feb_monthgridunit = MonthGridUnit("February", None, 1, 7, 29, 1)
+    mar_monthgridunit = MonthGridUnit("March", None, 2, 7, 31, 1)
+    x_monthgridrow.months.append(jan_monthgridunit)
+    x_monthgridrow.months.append(feb_monthgridunit)
+    x_monthgridrow.months.append(mar_monthgridunit)
+    assert not x_monthgridrow.max_monthday_numbers_row
+
+    # WHEN
+    x_monthgridrow.set_max_monthday_numbers_row()
+
+    # THEN
+    assert x_monthgridrow.max_monthday_numbers_row == 6
+
+
+def test_MonthGridRow_markdown_str_ReturnsObj():
+    # ESTABLISH
+    x_monthgridrow = MonthGridRow([])
+    jan_monthgridunit = MonthGridUnit("January", None, 0, 7, 31, 1)
+    feb_monthgridunit = MonthGridUnit("February", None, 3, 7, 29, 1)
+    mar_monthgridunit = MonthGridUnit("March", None, 4, 7, 31, 1)
+    x_weekday_2char_abvs = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]
+    jan_monthgridunit.weekday_2char_abvs = x_weekday_2char_abvs
+    feb_monthgridunit.weekday_2char_abvs = x_weekday_2char_abvs
+    mar_monthgridunit.weekday_2char_abvs = x_weekday_2char_abvs
+    x_monthgridrow.months.append(jan_monthgridunit)
+    x_monthgridrow.months.append(feb_monthgridunit)
+    x_monthgridrow.months.append(mar_monthgridunit)
+
+    # WHEN
+    x_str = x_monthgridrow.markdown_str()
+
+    # THEN
+    print(f"{x_str}")
+    expected_str = """
+      January                   February                   March        
+Mo Tu We Th Fr Sa Su      Mo Tu We Th Fr Sa Su      Mo Tu We Th Fr Sa Su
+ 1  2  3  4  5  6  7                1  2  3  4                   1  2  3
+ 8  9 10 11 12 13 14       5  6  7  8  9 10 11       4  5  6  7  8  9 10
+15 16 17 18 19 20 21      12 13 14 15 16 17 18      11 12 13 14 15 16 17
+22 23 24 25 26 27 28      19 20 21 22 23 24 25      18 19 20 21 22 23 24
+29 30 31                  26 27 28 29               25 26 27 28 29 30 31"""
+    assert x_str == expected_str
+
+
+def test_CalendarGrid_Exists():
+    # ESTABLISH / WHEN
+    x_calendargrid = CalendarGrid()
+
+    # THEN
+    assert not x_calendargrid.timelineunit
+    assert not x_calendargrid.timeline_config
+    assert not x_calendargrid.monthgridrows
+    assert not x_calendargrid.timelineunit
+    assert not x_calendargrid.week_length
+    assert not x_calendargrid.month_char_width
+    assert not x_calendargrid.monthgridrow_length
+    assert not x_calendargrid.display_md_width
+    assert x_calendargrid.max_md_width == 84
+
+
+def test_CalendarGrid_create_2char_weekday_list_ReturnObj():
+    # ESTABLISH
+    creg_config = get_default_timeline_config_dict()
+    creg_calendergrid = CalendarGrid(timeline_config=creg_config)
+    creg_calendergrid.set_timelineunit("Monday", "Tuesday")
+    display_init_day = "Monday"
+
+    # WHEN
+    weekday_2char_list = creg_calendergrid.create_2char_weekday_list(display_init_day)
+
+    # THEN
+    expected_weekday_2char_abvs = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]
+    assert weekday_2char_list == expected_weekday_2char_abvs
+
+
+def test_CalendarGrid_set_timelineunit_SetsAttr():
+    # ESTABLISH
+    creg_config = get_default_timeline_config_dict()
+    creg_calendergrid = CalendarGrid(timeline_config=creg_config)
+    x_weekday_2char_abvs = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]
+    monday_str = "Monday"
+    assert not creg_calendergrid.timelineunit
+
+    # WHEN
+    creg_calendergrid.set_timelineunit(monday_str, "Tuesday")
+
+    # THEN
+    expected_timelineunit = timelineunit_shop(creg_config)
+    assert creg_calendergrid.timelineunit == expected_timelineunit
+    assert creg_calendergrid.week_length == 7
+    assert creg_calendergrid.month_char_width == 26
+    assert creg_calendergrid.monthgridrow_length == 3
+    assert creg_calendergrid.display_md_width == 72
+    assert len(creg_calendergrid.monthgridrows) == 4
+    assert len(creg_calendergrid.monthgridrows[0].months) == 3
+    monthgridunit0 = creg_calendergrid.monthgridrows[0].months[0]
+    assert monthgridunit0.name == "March"
+    assert monthgridunit0.cumlative_days == 31
+    assert monthgridunit0.month_days_int == 31
+    assert monthgridunit0.week_length == 7
+    assert monthgridunit0.monthday_distortion == 1
+    assert monthgridunit0.weekday_2char_abvs == x_weekday_2char_abvs
+    assert monthgridunit0.first_weekday == 1
+    monthgridunit7 = creg_calendergrid.monthgridrows[2].months[0]
+    assert monthgridunit7.name == "September"
+    assert monthgridunit7.cumlative_days == 214
+    assert monthgridunit7.month_days_int == 30
+    assert monthgridunit7.week_length == 7
+    assert monthgridunit7.monthday_distortion == 1
+    assert monthgridunit7.weekday_2char_abvs == x_weekday_2char_abvs
+    # assert monthgridunit7.first_weekday == 4
+
+
+def test_CalendarGrid_create_markdown_ReturnsObj_Scernario0_creg_config():
+    # ESTABLISH
+    creg_config = get_default_timeline_config_dict()
+    creg_calendergrid = CalendarGrid(timeline_config=creg_config)
+    creg_calendergrid.set_timelineunit("Monday", "Tuesday")
+    year_int = 2024
+
+    # WHEN
+    cal_markdown = creg_calendergrid.create_markdown(year_int)
+
+    # THEN
+    print(cal_markdown)
+    expected_calendar_markdown = """
+                               Year 2024                                
+
+       March                     April                      May         
+Mo Tu We Th Fr Sa Su      Mo Tu We Th Fr Sa Su      Mo Tu We Th Fr Sa Su
+    1  2  3  4  5  6                   1  2  3                         1
+ 7  8  9 10 11 12 13       4  5  6  7  8  9 10       2  3  4  5  6  7  8
+14 15 16 17 18 19 20      11 12 13 14 15 16 17       9 10 11 12 13 14 15
+21 22 23 24 25 26 27      18 19 20 21 22 23 24      16 17 18 19 20 21 22
+28 29 30 31               25 26 27 28 29 30         23 24 25 26 27 28 29
+                                                    30 31               
+
+        June                      July                     August       
+Mo Tu We Th Fr Sa Su      Mo Tu We Th Fr Sa Su      Mo Tu We Th Fr Sa Su
+       1  2  3  4  5                   1  2  3       1  2  3  4  5  6  7
+ 6  7  8  9 10 11 12       4  5  6  7  8  9 10       8  9 10 11 12 13 14
+13 14 15 16 17 18 19      11 12 13 14 15 16 17      15 16 17 18 19 20 21
+20 21 22 23 24 25 26      18 19 20 21 22 23 24      22 23 24 25 26 27 28
+27 28 29 30               25 26 27 28 29 30 31      29 30 31            
+
+     September                  October                   November      
+Mo Tu We Th Fr Sa Su      Mo Tu We Th Fr Sa Su      Mo Tu We Th Fr Sa Su
+          1  2  3  4                      1  2          1  2  3  4  5  6
+ 5  6  7  8  9 10 11       3  4  5  6  7  8  9       7  8  9 10 11 12 13
+12 13 14 15 16 17 18      10 11 12 13 14 15 16      14 15 16 17 18 19 20
+19 20 21 22 23 24 25      17 18 19 20 21 22 23      21 22 23 24 25 26 27
+26 27 28 29 30            24 25 26 27 28 29 30      28 29 30            
+                          31                                            
+
+      December                  January                   February      
+Mo Tu We Th Fr Sa Su      Mo Tu We Th Fr Sa Su      Mo Tu We Th Fr Sa Su
+          1  2  3  4                         1             1  2  3  4  5
+ 5  6  7  8  9 10 11       2  3  4  5  6  7  8       6  7  8  9 10 11 12
+12 13 14 15 16 17 18       9 10 11 12 13 14 15      13 14 15 16 17 18 19
+19 20 21 22 23 24 25      16 17 18 19 20 21 22      20 21 22 23 24 25 26
+26 27 28 29 30 31         23 24 25 26 27 28 29      27 28               
+                          30 31                                         """
+    assert cal_markdown == expected_calendar_markdown
+
+
+def test_CalendarGrid_create_markdown_ReturnsObj_Scernario1_five_config():
+    # ESTABLISH
+    five_calendergrid = CalendarGrid(timeline_config=get_five_config())
+    five_calendergrid.set_timelineunit("Anaday", "Chiday")
+    year_int = 5224
+
+    # WHEN
+    cal_markdown = five_calendergrid.create_markdown(year_int)
+
+    # THEN
+    # print(cal_markdown)
+    expected_calendar_markdown = """
+                                Year 5224                                 
+
+   Fredrick              Geo               Holocene             Iguana    
+An Ba Ch Da Ea      An Ba Ch Da Ea      An Ba Ch Da Ea      An Ba Ch Da Ea
+       0  1  2             0  1  2             0  1  2             0  1  2
+ 3  4  5  6  7       3  4  5  6  7       3  4  5  6  7       3  4  5  6  7
+ 8  9 10 11 12       8  9 10 11 12       8  9 10 11 12       8  9 10 11 12
+13 14 15 16 17      13 14 15 16 17      13 14 15 16 17      13 14 15 16 17
+18 19 20 21 22      18 19 20 21 22      18 19 20 21 22      18 19 20 21 22
+23 24               23 24               23 24               23 24         
+
+    Jesus                Keel               LeBron             Mikayla    
+An Ba Ch Da Ea      An Ba Ch Da Ea      An Ba Ch Da Ea      An Ba Ch Da Ea
+       0  1  2             0  1  2             0  1  2             0  1  2
+ 3  4  5  6  7       3  4  5  6  7       3  4  5  6  7       3  4  5  6  7
+ 8  9 10 11 12       8  9 10 11 12       8  9 10 11 12       8  9 10 11 12
+13 14 15 16 17      13 14 15 16 17      13 14 15 16 17      13 14 15 16 17
+18 19 20 21 22      18 19 20 21 22      18 19 20 21 22      18 19 20 21 22
+23 24               23 24               23 24               23 24         
+
+    Ninon               Obama              Preston              Quorum    
+An Ba Ch Da Ea      An Ba Ch Da Ea      An Ba Ch Da Ea      An Ba Ch Da Ea
+       0  1  2             0  1  2             0  1  2             0  1  2
+ 3  4  5  6  7       3  4  5  6  7       3  4  5  6  7       3  4  5  6  7
+ 8  9 10 11 12       8  9 10 11 12       8  9 10 11 12       8  9 10 11 12
+13 14 15 16 17      13 14 15 16 17      13 14 15 16 17      13 14 15 16 17
+18 19 20 21 22      18 19 20 21 22      18 19 20 21 22      18 19 20 21 22
+23 24               23 24               23 24               23 24         
+
+  RioGrande             Simon               Trump     
+An Ba Ch Da Ea      An Ba Ch Da Ea      An Ba Ch Da Ea
+       0  1  2             0  1  2             0  1  2
+ 3  4  5  6  7       3  4  5  6  7       3  4  5  6  7
+ 8  9 10 11 12       8  9 10 11 12       8  9 10 11 12
+13 14 15 16 17      13 14 15 16 17      13 14         
+18 19 20 21 22      18 19 20 21 22                    
+23 24               23 24                             """
+    assert cal_markdown == expected_calendar_markdown

--- a/src/a15_vow_logic/_util/a15_str.py
+++ b/src/a15_vow_logic/_util/a15_str.py
@@ -8,14 +8,11 @@ from src.a02_finance_logic._util.a02_str import (
 )
 from src.a03_group_logic._util.a03_str import respect_bit_str
 from src.a06_plan_logic._util.a06_str import timeline_str
+from src.a07_calendar_logic._util.a07_str import cumlative_day_str
 
 
 def brokerunits_str() -> str:
     return "brokerunits"
-
-
-def cumlative_day_str() -> str:
-    return "cumlative_day"
 
 
 def cumlative_minute_str() -> str:

--- a/src/a15_vow_logic/_util/test_a15_str.py
+++ b/src/a15_vow_logic/_util/test_a15_str.py
@@ -1,6 +1,5 @@
 from src.a15_vow_logic._util.a15_str import (
     brokerunits_str,
-    cumlative_day_str,
     cumlative_minute_str,
     hour_label_str,
     job_listen_rotations_str,
@@ -24,7 +23,6 @@ def test_str_functions_ReturnsObj():
     assert month_label_str() == "month_label"
     assert hour_label_str() == "hour_label"
     assert cumlative_minute_str() == "cumlative_minute"
-    assert cumlative_day_str() == "cumlative_day"
     assert weekday_label_str() == "weekday_label"
     assert weekday_order_str() == "weekday_order"
     assert vowunit_str() == "vowunit"


### PR DESCRIPTION
…ine_config file returns string of months that very readable. closes #802

## Summary by Sourcery

Introduce a calendar rendering tool that produces year and month displays in markdown based on timeline configurations, while centralizing the cumlative_day_str utility in the calendar logic module and updating related documentation and tests.

New Features:
- Add calendar_markdown module with MonthGridUnit, MonthGridRow, and CalendarGrid classes to generate formatted calendar markdown from timeline configurations

Enhancements:
- Relocate cumlative_day_str from vow_logic to calendar_logic and update string utility imports accordingly
- Update str_funcs.md registry to move cumlative_day entry under a07_calendar_logic

Documentation:
- Update docs/str_funcs.md to reflect the new location of cumlative_day_str

Tests:
- Add comprehensive tests for calendar_markdown rendering and new cumlative_day_str behavior
- Remove duplicate cumlative_day_str test from a15_vow_logic tests