### PR TITLE
699 create tool for validating sound excel files data types given idea schema

### DIFF
--- a/src/a18_etl_toolbox/stance_tool.py
+++ b/src/a18_etl_toolbox/stance_tool.py
@@ -29,8 +29,6 @@ def collect_stance_csv_strs(vow_mstr_dir: str) -> dict[str, str]:
     return x_csv_strs
 
 
-def create_stance0001_file(vow_mstr_dir: str, output_dir: str = None):
+def create_stance0001_file(vow_mstr_dir: str, output_dir: str):
     stance_csv_strs = collect_stance_csv_strs(vow_mstr_dir)
-    if not output_dir:
-        output_dir = create_stances_dir_path(vow_mstr_dir)
     csv_dict_to_excel(stance_csv_strs, output_dir, STANCE0001_FILENAME)

--- a/src/a18_etl_toolbox/test/test_/test__tran_path_.py
+++ b/src/a18_etl_toolbox/test/test_/test__tran_path_.py
@@ -44,12 +44,11 @@ def test_create_stances_owner_dir_path_ReturnsObj():
 
 def test_create_stance0001_path_ReturnsObj():
     # ESTABLISH
-    x_vow_mstr_dir = get_module_temp_dir()
+    output_dir = get_module_temp_dir()
 
     # WHEN
-    gen_stance0001_xlsx_path = create_stance0001_path(x_vow_mstr_dir)
+    gen_stance0001_xlsx_path = create_stance0001_path(output_dir)
 
     # THEN
-    stances_dir = create_stances_dir_path(x_vow_mstr_dir)
-    expected_stance000001_path = create_path(stances_dir, STANCE0001_FILENAME)
+    expected_stance000001_path = create_path(output_dir, STANCE0001_FILENAME)
     assert gen_stance0001_xlsx_path == expected_stance000001_path

--- a/src/a18_etl_toolbox/test/test_/test__tran_path_doc.py
+++ b/src/a18_etl_toolbox/test/test_/test__tran_path_doc.py
@@ -31,7 +31,7 @@ def test_create_stances_owner_dir_path_HasDocString():
 
 def test_create_stance0001_path_HasDocString():
     # ESTABLISH
-    doc_str = create_stance0001_path(vow_mstr_dir="vow_mstr_dir")
+    doc_str = create_stance0001_path(output_dir="output_dir")
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
     assert LINUX_OS or inspect_getdoc(create_stance0001_path) == doc_str

--- a/src/a18_etl_toolbox/test/test_stance/test_stance_tool.py
+++ b/src/a18_etl_toolbox/test/test_stance/test_stance_tool.py
@@ -84,12 +84,13 @@ def test_create_stance0001_file_CreatesFile_Scenario0_NoVowUnits(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
-    vow_mstr_dir = get_module_temp_dir()
-    stance0001_path = create_stance0001_path(vow_mstr_dir)
+    vow_mstr_dir = create_path(get_module_temp_dir(), "vow_mstr")
+    output_dir = create_path(get_module_temp_dir(), "output")
+    stance0001_path = create_stance0001_path(output_dir)
     assert os_path_exists(stance0001_path) is False
 
     # WHEN
-    create_stance0001_file(vow_mstr_dir)
+    create_stance0001_file(vow_mstr_dir, output_dir)
 
     # THEN
     assert os_path_exists(stance0001_path)

--- a/src/a18_etl_toolbox/tran_path.py
+++ b/src/a18_etl_toolbox/tran_path.py
@@ -15,7 +15,6 @@ def create_stances_owner_dir_path(vow_mstr_dir: str, owner_name: OwnerName) -> s
     return create_path(stances_dir, owner_name)
 
 
-def create_stance0001_path(vow_mstr_dir: str) -> str:
-    """Returns path: vow_mstr_dir\\stances\\stance0001.xlsx"""
-    stances_dir = create_path(vow_mstr_dir, "stances")
-    return create_path(stances_dir, "stance0001.xlsx")
+def create_stance0001_path(output_dir: str) -> str:
+    """Returns path: output_dir\\stance0001.xlsx"""
+    return create_path(output_dir, "stance0001.xlsx")

--- a/src/a20_world_logic/test/test_output/test_calendar_markdown.py
+++ b/src/a20_world_logic/test/test_output/test_calendar_markdown.py
@@ -39,7 +39,7 @@ def test_WorldUnit_create_calendar_markdown_files_Senario0_NoFileIfWorldIsEmpty(
     assert count_files(output_dir) == 0
 
 
-def test_WorldUnit_create_calendar_markdown_files_Senario1_Add_CreatesFile(
+def test_WorldUnit_create_calendar_markdown_files_Senario1_FromVowUnitJsonCreateFile(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -64,38 +64,38 @@ def test_WorldUnit_create_calendar_markdown_files_Senario1_Add_CreatesFile(
     assert open(a23_calendar_md_path).read() == expected_csv_str
 
 
-# def test_WorldUnit_create_calendar_markdown_files_Senario1_Add_CreatesFile(
-#     env_dir_setup_cleanup,
-# ):
-#     # ESTABLISH
-#     fizz_str = "fizz"
-#     output_dir = create_path(worlds_dir(), "output")
-#     fizz_world = worldunit_shop(fizz_str, worlds_dir(), output_dir)
-#     sue_str = "Sue"
-#     event2 = 2
-#     ex_filename = "fizzbuzz.xlsx"
-#     mud_file_path = create_path(fizz_world._mud_dir, ex_filename)
-#     a23_str = "accord23"
-#     br00011_columns = [
-#         event_int_str(),
-#         face_name_str(),
-#         vow_label_str(),
-#         owner_name_str(),
-#         acct_name_str()
-#     ]
-#     br00011_rows = [[event2, sue_str, a23_str, sue_str, sue_str]]
-#     br00011_df = DataFrame(br00011_rows, columns=br00011_columns)
-#     upsert_sheet(mud_file_path, "br00011_ex3", br00011_df)
-#     fizz_world.mud_to_clarity_mstr()
+def test_WorldUnit_create_calendar_markdown_files_Senario2_CreatesFileAfter_mud_to_clarity_mstr(
+    env_dir_setup_cleanup,
+):
+    # ESTABLISH
+    fizz_str = "fizz"
+    output_dir = create_path(worlds_dir(), "output")
+    fizz_world = worldunit_shop(fizz_str, worlds_dir(), output_dir)
+    sue_str = "Sue"
+    event2 = 2
+    ex_filename = "fizzbuzz.xlsx"
+    mud_file_path = create_path(fizz_world._mud_dir, ex_filename)
+    a23_str = "accord23"
+    br00011_columns = [
+        event_int_str(),
+        face_name_str(),
+        vow_label_str(),
+        owner_name_str(),
+        acct_name_str(),
+    ]
+    br00011_rows = [[event2, sue_str, a23_str, sue_str, sue_str]]
+    br00011_df = DataFrame(br00011_rows, columns=br00011_columns)
+    upsert_sheet(mud_file_path, "br00011_ex3", br00011_df)
+    fizz_world.mud_to_clarity_mstr()
 
-#     a23_calendar_md_path = create_path(output_dir, f"{a23_str}_calendar.md")
-#     print(f"      {a23_calendar_md_path=}")
-#     assert not os_path_exists(a23_calendar_md_path)
+    a23_calendar_md_path = create_path(output_dir, f"{a23_str}_calendar.md")
+    print(f"      {a23_calendar_md_path=}")
+    assert not os_path_exists(a23_calendar_md_path)
 
-#     # WHEN
-#     fizz_world.create_calendar_markdown_files()
+    # WHEN
+    fizz_world.create_calendar_markdown_files()
 
-#     # THEN
-#     assert os_path_exists(a23_calendar_md_path)
-#     expected_csv_str = "vow_label,owner_name,funds,fund_rank,tasks_count\n"
-#     assert open(a23_calendar_md_path).read() == expected_csv_str
+    # THEN
+    assert os_path_exists(a23_calendar_md_path)
+    expected_csv_str = get_expected_creg_year0_markdown()
+    assert open(a23_calendar_md_path).read() == expected_csv_str

--- a/src/a20_world_logic/test/test_output/test_stance_output.py
+++ b/src/a20_world_logic/test/test_output/test_stance_output.py
@@ -23,9 +23,10 @@ def test_WorldUnit_create_stances_Senario0_EmptyWorld_CreatesFile(
 ):
     # ESTABLISH
     fizz_str = "fizz"
-    fizz_world = worldunit_shop(fizz_str, worlds_dir())
+    output_dir = create_path(worlds_dir(), "output")
+    fizz_world = worldunit_shop(fizz_str, worlds_dir(), output_dir)
     fizz_world.mud_to_clarity_mstr()
-    fizz_stance0001_path = create_stance0001_path(fizz_world._vow_mstr_dir)
+    fizz_stance0001_path = create_stance0001_path(fizz_world.output_dir)
     assert os_path_exists(fizz_stance0001_path) is False
 
     # WHEN
@@ -38,7 +39,8 @@ def test_WorldUnit_create_stances_Senario0_EmptyWorld_CreatesFile(
 def test_WorldUnit_create_stances_Senario1_Add_CreatesFile(env_dir_setup_cleanup):
     # ESTABLISH
     fizz_str = "fizz"
-    fizz_world = worldunit_shop(fizz_str, worlds_dir())
+    output_dir = create_path(worlds_dir(), "output")
+    fizz_world = worldunit_shop(fizz_str, worlds_dir(), output_dir)
     sue_str = "Sue"
     event2 = 2
     ex_filename = "fizzbuzz.xlsx"
@@ -55,7 +57,7 @@ def test_WorldUnit_create_stances_Senario1_Add_CreatesFile(env_dir_setup_cleanup
     br00011_df = DataFrame(br00011_rows, columns=br00011_columns)
     upsert_sheet(mud_file_path, "br00011_ex3", br00011_df)
     fizz_world.mud_to_clarity_mstr()
-    fizz_stance0001_path = create_stance0001_path(fizz_world._vow_mstr_dir)
+    fizz_stance0001_path = create_stance0001_path(fizz_world.output_dir)
     assert os_path_exists(fizz_stance0001_path) is False
 
     # WHEN
@@ -70,7 +72,8 @@ def test_WorldUnit_create_stances_Senario2_CreatedStanceCanBeIdeasForOtherWorldU
 ):
     # ESTABLISH
     fizz_str = "fizz"
-    fizz_world = worldunit_shop(fizz_str, worlds_dir())
+    fizz_output_dir = create_path(worlds_dir(), "fizz_output")
+    fizz_world = worldunit_shop(fizz_str, worlds_dir(), fizz_output_dir)
     sue_str = "Sue"
     event2 = 2
     ex_filename = "fizzbuzz.xlsx"
@@ -87,9 +90,10 @@ def test_WorldUnit_create_stances_Senario2_CreatedStanceCanBeIdeasForOtherWorldU
     br00011_df = DataFrame(br00011_rows, columns=br00011_columns)
     upsert_sheet(mud_file_path, "br00011_ex3", br00011_df)
     fizz_world.mud_to_clarity_mstr()
-    fizz_stance0001_path = create_stance0001_path(fizz_world._vow_mstr_dir)
+    fizz_stance0001_path = create_stance0001_path(fizz_world.output_dir)
     fizz_world.create_stances()
-    buzz_world = worldunit_shop("buzz", worlds_dir())
+    buzz_output_dir = create_path(worlds_dir(), "buzz_output")
+    buzz_world = worldunit_shop("buzz", worlds_dir(), buzz_output_dir)
     buzz_mud_st0001_path = create_path(buzz_world._vow_mstr_dir, "buzz_mud.xlsx")
     set_dir(create_stances_dir_path(buzz_world._vow_mstr_dir))
     shutil_copy2(fizz_stance0001_path, dst=buzz_mud_st0001_path)
@@ -98,7 +102,7 @@ def test_WorldUnit_create_stances_Senario2_CreatedStanceCanBeIdeasForOtherWorldU
     print(f"{buzz_mud_st0001_path=}")
     print(f"{get_sheet_names(buzz_mud_st0001_path)=}")
     buzz_world.mud_to_clarity_mstr()
-    buzz_stance0001_path = create_stance0001_path(buzz_world._vow_mstr_dir)
+    buzz_stance0001_path = create_stance0001_path(buzz_world.output_dir)
     assert os_path_exists(buzz_stance0001_path) is False
 
     # WHEN
@@ -115,6 +119,41 @@ def test_WorldUnit_create_stances_Senario2_CreatedStanceCanBeIdeasForOtherWorldU
         #     print(f"{fizz_sheet_df=}")
         #     print(f"{buzz_sheet_df=}")
         assert_frame_equal(fizz_sheet_df, buzz_sheet_df)
+
+
+def test_WorldUnit_create_stances_Senario3_Create_calendar_markdown(
+    env_dir_setup_cleanup,
+):
+    # ESTABLISH
+    fizz_str = "fizz"
+    output_dir = create_path(worlds_dir(), "output")
+    fizz_world = worldunit_shop(fizz_str, worlds_dir(), output_dir)
+    sue_str = "Sue"
+    event2 = 2
+    ex_filename = "fizzbuzz.xlsx"
+    mud_file_path = create_path(fizz_world._mud_dir, ex_filename)
+    a23_str = "accord23"
+    br00011_columns = [
+        event_int_str(),
+        face_name_str(),
+        vow_label_str(),
+        owner_name_str(),
+        acct_name_str(),
+    ]
+    br00011_rows = [[event2, sue_str, a23_str, sue_str, sue_str]]
+    br00011_df = DataFrame(br00011_rows, columns=br00011_columns)
+    upsert_sheet(mud_file_path, "br00011_ex3", br00011_df)
+    fizz_world.mud_to_clarity_mstr()
+
+    a23_calendar_md_path = create_path(output_dir, f"{a23_str}_calendar.md")
+    print(f"      {a23_calendar_md_path=}")
+    assert not os_path_exists(a23_calendar_md_path)
+
+    # WHEN
+    fizz_world.create_stances()
+
+    # THEN
+    assert os_path_exists(a23_calendar_md_path)
 
 
 # def test_WorldUnit_mud_to_clarity_CreatesFiles(env_dir_setup_cleanup):

--- a/src/a20_world_logic/world.py
+++ b/src/a20_world_logic/world.py
@@ -164,8 +164,6 @@ class WorldUnit:
         # if store_tracing_files:
 
     def create_stances(self):
-        print(f"{self.output_dir=}")
-        print(f"{self._vow_mstr_dir=}")
         create_stance0001_file(self._vow_mstr_dir, self.output_dir)
         create_calendar_markdown_files(self._vow_mstr_dir, self.output_dir)
 

--- a/src/a20_world_logic/world.py
+++ b/src/a20_world_logic/world.py
@@ -164,7 +164,10 @@ class WorldUnit:
         # if store_tracing_files:
 
     def create_stances(self):
+        print(f"{self.output_dir=}")
+        print(f"{self._vow_mstr_dir=}")
         create_stance0001_file(self._vow_mstr_dir, self.output_dir)
+        create_calendar_markdown_files(self._vow_mstr_dir, self.output_dir)
 
     def create_kpi_csvs(self):
         create_kpi_csvs(self.get_db_path(), self.output_dir)


### PR DESCRIPTION
## Summary by Sourcery

Refactor stance output tooling to use a flat output directory, update associated path helpers and methods to accept an explicit output_dir, wire calendar markdown generation into the create_stances flow, and revise tests to match the new signatures and behaviors

New Features:
- Generate calendar markdown files as part of the create_stances method

Enhancements:
- Refactor create_stance0001_path and create_stance0001_file to operate on a provided output_dir instead of a nested stances folder
- Update WorldUnit.create_stances to invoke calendar markdown file creation

Tests:
- Adjust tests to supply output_dir to worldunit_shop, create_stance0001_path, and create_stance0001_file
- Rename and expand calendar markdown and stance output tests, including a new scenario for calendar generation
- Use get_expected_creg_year0_markdown in calendar markdown tests and remove legacy commented code