### PR TITLE
812 create cli tool for executing mud to clarity etl

### DIFF
--- a/docs/str_funcs.md
+++ b/docs/str_funcs.md
@@ -18,7 +18,7 @@
 - a14_keep_logic: 
 - a15_belief_logic: belief_budunit, belief_paybook, belief_timeline_hour, belief_timeline_month, belief_timeline_weekday, belief_timeoffi, beliefunit, brokerunits, cumulative_minute, hour_label, job_listen_rotations, month_label, paybook, weekday_label, weekday_order
 - a16_pidgin_logic: inx_knot, inx_label, inx_name, inx_rope, inx_title, map_otx2inx, otx2inx, otx_key, otx_knot, otx_label, otx_name, otx_rope, otx_title, pidgin_core, pidgin_label, pidgin_name, pidgin_rope, pidgin_title, pidginunit, unknown_str
-- a17_idea_logic: allowed_crud, build_order, delete_insert, delete_insert_update, delete_update, error_message, idea_category, idea_number, insert_multiple, insert_one_time, insert_update, world_id
+- a17_idea_logic: allowed_crud, build_order, delete_insert, delete_insert_update, delete_update, error_message, idea_category, idea_number, insert_multiple, insert_one_time, insert_update, world_name
 - a18_etl_toolbox: belief_acct_nets, belief_event_time_agg, brick_agg, brick_raw, brick_valid, events_brick_agg, events_brick_valid, owner_net_amount, sound_agg, sound_raw, voice_agg, voice_raw
 - a19_kpi_toolbox: belief_kpi001_acct_nets
 - a20_world_logic: 

--- a/src/a00_data_toolbox/csv_toolbox.py
+++ b/src/a00_data_toolbox/csv_toolbox.py
@@ -1,4 +1,9 @@
-from csv import reader as csv_reader, writer as csv_writer
+from csv import (
+    DictReader as csv_DictReader,
+    DictWriter as csv_DictWriter,
+    reader as csv_reader,
+    writer as csv_writer,
+)
 from os import makedirs as os_makedirs
 from os.path import exists as os_path_exists, join as os_path_join
 from sqlite3 import connect as sqlite3_connect
@@ -90,3 +95,28 @@ def export_sqlite_tables_to_csv(db_path, output_dir="."):
                 writer = csv_writer(f)
                 writer.writerow(column_names)
                 writer.writerows(rows)
+
+
+def replace_csv_column(csv_path, column_name, new_value):
+    """
+    Replace all values in the specified column with new_value and write to a new CSV file.
+
+    Args:
+        csv_path (str): Path to the input CSV file.
+        column_name (str): Name of the column to replace.
+        new_value (str): Value to replace in the column.
+    """
+    with open(csv_path, "r", newline="", encoding="utf-8") as infile:
+        reader = csv_DictReader(infile)
+        fieldnames = reader.fieldnames
+
+        if column_name not in fieldnames:
+            raise ValueError(f"Column '{column_name}' not found in CSV headers.")
+
+        with open(csv_path, "w", newline="", encoding="utf-8") as outfile:
+            writer = csv_DictWriter(outfile, fieldnames=fieldnames)
+            writer.writeheader()
+
+            for row in reader:
+                row[column_name] = new_value
+                writer.writerow(row)

--- a/src/a00_data_toolbox/test/test_csv_tool.py
+++ b/src/a00_data_toolbox/test/test_csv_tool.py
@@ -1,14 +1,11 @@
-from csv import (
-    DictReader as csv_DictReader,
-    DictWriter as csv_DictWriter,
-    reader as csv_reader,
-)
+from csv import DictReader as csv_DictReader, reader as csv_reader
+from io import StringIO as io_StringIO
 from pathlib import Path
 from sqlite3 import connect as sqlite3_connect
 from src.a00_data_toolbox.csv_toolbox import (
     export_sqlite_tables_to_csv,
     open_csv_with_types,
-    replace_csv_column,
+    replace_csv_column_from_string,
 )
 from src.a00_data_toolbox.file_toolbox import create_path, save_file, set_dir
 from src.a00_data_toolbox.test._util.a00_env import (
@@ -104,33 +101,26 @@ def test_export_sqlite_tables_to_csv(env_dir_setup_cleanup):
         assert reader[1] == ["ABC", "9.99"]
 
 
-def test_replace_csv_column(env_dir_setup_cleanup):
+def test_replace_csv_column_from_string():
     # ESTABLISH
-    # Create a temporary input CSV file
-    # Use the provided temp directory
-    temp_dir = get_module_temp_dir()
-    file_path = create_path(temp_dir, "temp_file.csv")
-    set_dir(temp_dir)
-    # Create the input CSV file
-    with open(file_path, mode="w", newline="", encoding="utf-8") as f:
-        writer = csv_DictWriter(f, fieldnames=["id", "name", "status"])
-        writer.writeheader()
-        writer.writerows(
-            [
-                {"id": "1", "name": "Alice", "status": "pending"},
-                {"id": "2", "name": "Bob", "status": "in progress"},
-            ]
-        )
+    csv_string = """id,name,status
+1,Alice,pending
+2,Bob,in progress
+"""
 
     # WHEN
-    replace_csv_column(file_path, "status", "complete")
+    modified_csv = replace_csv_column_from_string(csv_string, "status", "complete")
 
     # THEN
-    # Read and verify the output CSV
-    with open(file_path, newline="", encoding="utf-8") as f:
-        reader = csv_DictReader(f)
-        rows = list(reader)
+    expected_csv = """id,name,status
+1,Alice,complete
+2,Bob,complete
+"""
+    assert modified_csv == expected_csv
+    reader = csv_DictReader(io_StringIO(modified_csv))
+    rows = list(reader)
 
+    # Assertions
     assert all(row["status"] == "complete" for row in rows)
     assert rows[0]["name"] == "Alice"
     assert rows[1]["name"] == "Bob"

--- a/src/a17_idea_logic/idea_config.py
+++ b/src/a17_idea_logic/idea_config.py
@@ -39,7 +39,7 @@ def get_idea_formats_dir() -> str:
 def get_idea_elements_sort_order() -> list[str]:
     """Contains the standard sort order for all idea and plan_calc columns"""
     return [
-        "world_id",
+        "world_name",
         "idea_number",
         "source_dimen",
         "pidgin_event_int",
@@ -232,7 +232,7 @@ def get_idea_sqlite_types() -> dict[str, str]:
     """Returns dictionary of sqlite_type for all idea elements (reference source: get_idea_elements_sort_order)"""
 
     return {
-        "world_id": "TEXT",
+        "world_name": "TEXT",
         "idea_number": "TEXT",
         "face_name": "TEXT",
         "face_name_otx": "TEXT",

--- a/src/a17_idea_logic/test/_util/a17_str.py
+++ b/src/a17_idea_logic/test/_util/a17_str.py
@@ -45,5 +45,5 @@ def insert_update_str() -> str:
     return "insert_update"
 
 
-def world_id_str() -> str:
-    return "world_id"
+def world_name_str() -> str:
+    return "world_name"

--- a/src/a17_idea_logic/test/_util/test_a17_str.py
+++ b/src/a17_idea_logic/test/_util/test_a17_str.py
@@ -10,7 +10,7 @@ from src.a17_idea_logic.test._util.a17_str import (
     insert_multiple_str,
     insert_one_time_str,
     insert_update_str,
-    world_id_str,
+    world_name_str,
 )
 
 
@@ -28,4 +28,4 @@ def test_str_functions_ReturnsObj():
     assert insert_one_time_str() == "insert_one_time"
     assert insert_multiple_str() == "insert_multiple"
     assert insert_update_str() == "insert_update"
-    assert world_id_str() == "world_id"
+    assert world_name_str() == "world_name"

--- a/src/a17_idea_logic/test/test_idea_/test_idea__config.py
+++ b/src/a17_idea_logic/test/test_idea_/test_idea__config.py
@@ -166,7 +166,7 @@ from src.a17_idea_logic.test._util.a17_str import (
     insert_multiple_str,
     insert_one_time_str,
     insert_update_str,
-    world_id_str,
+    world_name_str,
 )
 
 
@@ -204,7 +204,7 @@ def test_get_idea_elements_sort_order_ReturnsObj():
     assert pidginable_delete_inx_cols.issubset(table_sorting_priority)
 
     # all the suffix otx/inx columns are only used in one table
-    assert table_sorting_priority[0] == "world_id"
+    assert table_sorting_priority[0] == "world_name"
     assert table_sorting_priority[1] == "idea_number"
     assert table_sorting_priority[2] == "source_dimen"
     assert table_sorting_priority[3] == "pidgin_event_int"
@@ -399,7 +399,7 @@ def test_get_idea_elements_sort_order_ReturnsObj():
     all_args.add("source_dimen")
     all_args.add("pidgin_event_int")
     all_args.add(error_message_str())
-    all_args.add(world_id_str())
+    all_args.add(world_name_str())
     all_args.add("funds")  # kpi columns
     all_args.add("fund_rank")  # kpi columns
     all_args.add("tasks_count")  # kpi columns

--- a/src/a18_etl_toolbox/stance_tool.py
+++ b/src/a18_etl_toolbox/stance_tool.py
@@ -1,4 +1,5 @@
 from os.path import exists as os_path_exists
+from src.a00_data_toolbox.csv_toolbox import replace_csv_column_from_string
 from src.a00_data_toolbox.file_toolbox import create_path, get_level1_dirs
 from src.a12_hub_toolbox.hub_tool import open_plan_file
 from src.a15_belief_logic.belief import get_default_path_beliefunit
@@ -29,6 +30,10 @@ def collect_stance_csv_strs(belief_mstr_dir: str) -> dict[str, str]:
     return x_csv_strs
 
 
-def create_stance0001_file(belief_mstr_dir: str, output_dir: str):
+def create_stance0001_file(belief_mstr_dir: str, output_dir: str, world_name: str):
     stance_csv_strs = collect_stance_csv_strs(belief_mstr_dir)
-    csv_dict_to_excel(stance_csv_strs, output_dir, STANCE0001_FILENAME)
+    with_face_name_csvs = {}
+    for csv_key, csv_str in stance_csv_strs.items():
+        csv_str = replace_csv_column_from_string(csv_str, "face_name", world_name)
+        with_face_name_csvs[csv_key] = csv_str
+    csv_dict_to_excel(with_face_name_csvs, output_dir, STANCE0001_FILENAME)

--- a/src/a18_etl_toolbox/test/test_stance/test_stance_tool.py
+++ b/src/a18_etl_toolbox/test/test_stance/test_stance_tool.py
@@ -84,13 +84,14 @@ def test_create_stance0001_file_CreatesFile_Scenario0_NoBeliefUnits(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
+    sue_str = "Sue"
     belief_mstr_dir = create_path(get_module_temp_dir(), "belief_mstr")
     output_dir = create_path(get_module_temp_dir(), "output")
     stance0001_path = create_stance0001_path(output_dir)
     assert os_path_exists(stance0001_path) is False
 
     # WHEN
-    create_stance0001_file(belief_mstr_dir, output_dir)
+    create_stance0001_file(belief_mstr_dir, output_dir, sue_str)
 
     # THEN
     assert os_path_exists(stance0001_path)

--- a/src/a20_world_logic/test/test_/test_world_.py
+++ b/src/a20_world_logic/test/test_/test_world_.py
@@ -5,17 +5,17 @@ from src.a20_world_logic.test._util.a20_env import (
     get_module_temp_dir as worlds_dir,
 )
 from src.a20_world_logic.world import (
-    WorldID,
+    WorldName,
     WorldUnit,
     init_beliefunits_from_dirs,
     worldunit_shop,
 )
 
 
-def test_WorldID_Exists():
+def test_WorldName_Exists():
     # ESTABLISH / WHEN / THEN
-    assert WorldID() == ""
-    assert WorldID("cookie") == "cookie"
+    assert WorldName() == ""
+    assert WorldName("cookie") == "cookie"
 
 
 def test_WorldUnit_Exists():
@@ -165,58 +165,20 @@ def test_worldunit_shop_ReturnsObj_Scenario2_ThirdParameterIs_output_dir(
     assert x_world.output_dir == output_dir
 
 
-# def test_WorldUnit_popen_event_from_files_ReturnsObj(env_dir_setup_cleanup):
-#     # ESTABLISH
-#     x_world = worldunit_shop()
-#     sue_str = "Sue"
-#     bob_str = "Bob"
-#     x_world.add_pidginunit(sue_str)
-#     x_world.add_pidginunit(bob_str)
-#     sue_dir = create_path(x_world._syntax_otz_dir, sue_str)
-#     bob_dir = create_path(x_world._syntax_otz_dir, bob_str)
-#     assert os_path_exists(sue_dir) is False
-#     assert os_path_exists(bob_dir) is False
+def test_worldunit_shop_ReturnsObj_Scenario3_RaiseErrorIf_knot_In_world_name(
+    env_dir_setup_cleanup,
+):
+    # ESTABLISH
+    a23_str = "amy23"
+    output_dir = create_path(worlds_dir(), "output")
 
-#     # WHEN
-#     x_world.save_pidginunit_files(sue_str)
+    # WHEN
+    x_world = worldunit_shop(a23_str, worlds_dir(), output_dir)
 
-#     # THEN
-#     assert os_path_exists(sue_dir)
-#     assert os_path_exists(bob_dir) is False
-
-
-# def test_WorldUnit_save_pidginunit_ChangesFiles(env_dir_setup_cleanup):
-#     # ESTABLISH
-#     x_world = worldunit_shop()
-#     sue_str = "Sue"
-#     bob_str = "Bob"
-#     zia_str = "Zia"
-#     save_file(x_world._syntax_otz_dir, sue_str, "temp.txt", "")
-#     save_file(x_world._syntax_otz_dir, bob_str, "temp.txt", "")
-#     save_file(x_world._syntax_otz_dir, zia_str, "temp.txt", "")
-#     assert x_world.pidginunit_exists(sue_str) is False
-#     assert x_world.pidginunit_exists(bob_str) is False
-#     assert x_world.pidginunit_exists(zia_str) is False
-#     assert x_world.pidgins_empty()
-
-#     # WHEN
-#     x_world._set_all_pidginunits_from_dirs()
-
-#     # THEN
-#     assert x_world.pidginunit_exists(sue_str)
-#     assert x_world.pidginunit_exists(bob_str)
-#     assert x_world.pidginunit_exists(zia_str)
-#     assert x_world.pidgins_empty() is False
-
-#     # WHEN
-#     delete_dir(x_world._syntax_otz_dir, zia_str)
-#     x_world._set_all_pidginunits_from_dirs()
-
-#     # THEN
-#     assert x_world.pidginunit_exists(sue_str)
-#     assert x_world.pidginunit_exists(bob_str)
-#     assert x_world.pidginunit_exists(zia_str) is False
-#     assert x_world.pidgins_empty() is False
+    # THEN
+    assert x_world.world_name == a23_str
+    assert x_world.worlds_dir == worlds_dir()
+    assert x_world.output_dir == output_dir
 
 
 def test_init_beliefunits_from_dirs_ReturnsObj_Scenario0(env_dir_setup_cleanup):

--- a/src/a20_world_logic/test/test_/test_world_.py
+++ b/src/a20_world_logic/test/test_/test_world_.py
@@ -23,7 +23,7 @@ def test_WorldUnit_Exists():
     x_world = WorldUnit()
 
     # THEN
-    assert not x_world.world_id
+    assert not x_world.world_name
     assert not x_world.worlds_dir
     assert not x_world.output_dir
     assert not x_world.world_time_pnigh
@@ -65,7 +65,7 @@ def test_WorldUnit_set_input_dir_SetsCorrectDirsAndFiles(env_dir_setup_cleanup):
 def test_WorldUnit_set_world_dirs_SetsCorrectDirsAndFiles(env_dir_setup_cleanup):
     # ESTABLISH
     fizz_str = "fizz"
-    fizz_world = WorldUnit(world_id=fizz_str, worlds_dir=worlds_dir())
+    fizz_world = WorldUnit(world_name=fizz_str, worlds_dir=worlds_dir())
     x_world_dir = create_path(worlds_dir(), fizz_str)
     x_syntax_otz_dir = create_path(x_world_dir, "syntax_otz")
     x_input_dir = create_path(x_world_dir, "input")
@@ -103,13 +103,13 @@ def test_worldunit_shop_ReturnsObj_Scenario0_WithParameters(env_dir_setup_cleanu
     worlds2_dir = create_path(worlds_dir(), "worlds2")
     example_input_dir = create_path(worlds_dir(), "example_input")
     output_dir = create_path(worlds_dir(), "output")
-    five_world_id = "five"
+    five_world_name = "five"
     world2_time_pnigh = 55
     world2_beliefunits = {"amy45"}
 
     # WHEN
     x_world = worldunit_shop(
-        world_id=five_world_id,
+        world_name=five_world_name,
         worlds_dir=worlds2_dir,
         output_dir=output_dir,
         input_dir=example_input_dir,
@@ -118,8 +118,8 @@ def test_worldunit_shop_ReturnsObj_Scenario0_WithParameters(env_dir_setup_cleanu
     )
 
     # THEN
-    world_dir = create_path(worlds2_dir, x_world.world_id)
-    assert x_world.world_id == five_world_id
+    world_dir = create_path(worlds2_dir, x_world.world_name)
+    assert x_world.world_name == five_world_name
     assert x_world.worlds_dir == worlds2_dir
     assert x_world.output_dir == output_dir
     assert x_world._input_dir == example_input_dir
@@ -138,8 +138,8 @@ def test_worldunit_shop_ReturnsObj_Scenario1_WithoutParameters(env_dir_setup_cle
     x_world = worldunit_shop(a23_str, worlds_dir())
 
     # THEN
-    world_dir = create_path(worlds_dir(), x_world.world_id)
-    assert x_world.world_id == a23_str
+    world_dir = create_path(worlds_dir(), x_world.world_name)
+    assert x_world.world_name == a23_str
     assert x_world.worlds_dir == worlds_dir()
     assert not x_world.output_dir
     assert x_world.world_time_pnigh == 0
@@ -160,7 +160,7 @@ def test_worldunit_shop_ReturnsObj_Scenario2_ThirdParameterIs_output_dir(
     x_world = worldunit_shop(a23_str, worlds_dir(), output_dir)
 
     # THEN
-    assert x_world.world_id == a23_str
+    assert x_world.world_name == a23_str
     assert x_world.worlds_dir == worlds_dir()
     assert x_world.output_dir == output_dir
 

--- a/src/a20_world_logic/test/test_/test_world_json.py
+++ b/src/a20_world_logic/test/test_/test_world_json.py
@@ -9,8 +9,8 @@ from src.a20_world_logic.world import worldunit_shop
 def test_WorldUnit_get_dict_ReturnsObj_Scenario0MinimalParameters():
     # ESTABLISH
     worlds2_dir = create_path(get_module_temp_dir(), "worlds2")
-    five_world_id = "five"
-    x_world = worldunit_shop(five_world_id, worlds2_dir)
+    five_world_name = "five"
+    x_world = worldunit_shop(five_world_name, worlds2_dir)
 
     # WHEN
     x_world_dict = x_world.get_dict()
@@ -18,22 +18,22 @@ def test_WorldUnit_get_dict_ReturnsObj_Scenario0MinimalParameters():
     # THEN
     assert x_world_dict
     assert set(x_world_dict.keys()) == {
-        "world_id",
+        "world_name",
         "world_time_pnigh",
     }
-    assert x_world_dict.get("world_id") == five_world_id
+    assert x_world_dict.get("world_name") == five_world_name
     assert x_world_dict.get("world_time_pnigh") == 0
 
 
 def test_WorldUnit_get_dict_ReturnsObj_Scenario1():
     # ESTABLISH
     worlds2_dir = create_path(get_module_temp_dir(), "worlds2")
-    five_world_id = "five"
+    five_world_name = "five"
     world2_time_pnigh = 55
     amy45_str = "amy45"
     world2_beliefunits = {"amy45"}
     x_world = worldunit_shop(
-        world_id=five_world_id,
+        world_name=five_world_name,
         worlds_dir=worlds2_dir,
         world_time_pnigh=world2_time_pnigh,
         _beliefunits=world2_beliefunits,
@@ -44,5 +44,5 @@ def test_WorldUnit_get_dict_ReturnsObj_Scenario1():
 
     # THEN
     assert x_world_dict
-    assert x_world_dict.get("world_id") == five_world_id
+    assert x_world_dict.get("world_name") == five_world_name
     assert x_world_dict.get("world_time_pnigh") == world2_time_pnigh

--- a/src/a20_world_logic/test/test_output/test_stance_output.py
+++ b/src/a20_world_logic/test/test_output/test_stance_output.py
@@ -68,11 +68,16 @@ def test_WorldUnit_create_stances_Senario1_Add_CreatesFile(env_dir_setup_cleanup
 
     # THEN
     assert os_path_exists(fizz_stance0001_path)
+    print(get_sheet_names(fizz_stance0001_path))
+    br00021_sheet_df = pandas_read_excel(fizz_stance0001_path, "br00021")
+    print(f"{br00021_sheet_df=}")
+    assert br00021_sheet_df.iloc[0]["face_name"] == "fizz"
 
 
 def test_WorldUnit_create_stances_Senario2_CreatedStanceCanBeIdeasForOtherWorldUnit(
     env_dir_setup_cleanup,
 ):
+    # sourcery skip: no-loop-in-tests
     # ESTABLISH
     fizz_str = "fizz"
     fizz_output_dir = create_path(worlds_dir(), "fizz_output")

--- a/src/a20_world_logic/test/test_z_examples/test_pipelines.py
+++ b/src/a20_world_logic/test/test_z_examples/test_pipelines.py
@@ -32,7 +32,7 @@ def test_input_to_clarity_mstr_Examples(env_dir_setup_cleanup):
         input_dir = create_path(examples_dir, example_name)
         print(f"{input_dir=} {get_dir_filenames(input_dir)}")
         example_worldunit = worldunit_shop(
-            world_id=example_name,
+            world_name=example_name,
             worlds_dir=worlds_dir,
             input_dir=input_dir,
             output_dir=output_dir,

--- a/src/a20_world_logic/world.py
+++ b/src/a20_world_logic/world.py
@@ -55,7 +55,7 @@ class WorldID(str):
 
 @dataclass
 class WorldUnit:
-    world_id: WorldID = None
+    world_name: WorldID = None
     worlds_dir: str = None
     output_dir: str = None
     world_time_pnigh: TimeLinePoint = None
@@ -92,7 +92,7 @@ class WorldUnit:
         set_dir(self._input_dir)
 
     def _set_world_dirs(self):
-        self._world_dir = create_path(self.worlds_dir, self.world_id)
+        self._world_dir = create_path(self.worlds_dir, self.world_name)
         self._syntax_otz_dir = create_path(self._world_dir, "syntax_otz")
         self._brick_dir = create_path(self._world_dir, "brick")
         self._belief_mstr_dir = create_path(self._world_dir, "belief_mstr")
@@ -176,13 +176,13 @@ class WorldUnit:
 
     def get_dict(self) -> dict:
         return {
-            "world_id": self.world_id,
+            "world_name": self.world_name,
             "world_time_pnigh": self.world_time_pnigh,
         }
 
 
 def worldunit_shop(
-    world_id: WorldID,
+    world_name: WorldID,
     worlds_dir: str,
     output_dir: str = None,
     input_dir: str = None,
@@ -190,7 +190,7 @@ def worldunit_shop(
     _beliefunits: set[BeliefLabel] = None,
 ) -> WorldUnit:
     x_worldunit = WorldUnit(
-        world_id=world_id,
+        world_name=world_name,
         worlds_dir=worlds_dir,
         output_dir=output_dir,
         world_time_pnigh=get_0_if_None(world_time_pnigh),

--- a/src/a20_world_logic/world.py
+++ b/src/a20_world_logic/world.py
@@ -49,13 +49,13 @@ from src.a19_kpi_toolbox.kpi_mstr import (
 )
 
 
-class WorldID(str):
+class WorldName(str):
     pass
 
 
 @dataclass
 class WorldUnit:
-    world_name: WorldID = None
+    world_name: WorldName = None
     worlds_dir: str = None
     output_dir: str = None
     world_time_pnigh: TimeLinePoint = None
@@ -168,7 +168,7 @@ class WorldUnit:
         # if store_tracing_files:
 
     def create_stances(self):
-        create_stance0001_file(self._belief_mstr_dir, self.output_dir)
+        create_stance0001_file(self._belief_mstr_dir, self.output_dir, self.world_name)
         create_calendar_markdown_files(self._belief_mstr_dir, self.output_dir)
 
     def create_kpi_csvs(self):
@@ -182,7 +182,7 @@ class WorldUnit:
 
 
 def worldunit_shop(
-    world_name: WorldID,
+    world_name: WorldName,
     worlds_dir: str,
     output_dir: str = None,
     input_dir: str = None,

--- a/src/a21_lobby_logic/lobby.py
+++ b/src/a21_lobby_logic/lobby.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from src.a09_pack_logic.pack import PackUnit
-from src.a20_world_logic.world import WorldID, WorldUnit
+from src.a20_world_logic.world import WorldName, WorldUnit
 
 
 @dataclass
@@ -8,13 +8,13 @@ class LobbyUnit:
     lobby_id: str = None
     option_packs: list[PackUnit] = None
     selected_pack: PackUnit = None
-    worlds: list[WorldID] = None
+    worlds: list[WorldName] = None
 
 
 def lobbyunit_shop(
     lobby_id: str,
     option_packs: list[PackUnit] = None,
     selected_pack: PackUnit = None,
-    worlds: list[WorldID] = None,
+    worlds: list[WorldName] = None,
 ) -> LobbyUnit:
     return LobbyUnit(lobby_id=lobby_id)

--- a/src/a21_lobby_logic/lobby_path.py
+++ b/src/a21_lobby_logic/lobby_path.py
@@ -1,5 +1,5 @@
 from src.a00_data_toolbox.file_toolbox import create_path
-from src.a20_world_logic.world import WorldID
+from src.a20_world_logic.world import WorldName
 
 
 class LobbyID(str):
@@ -13,7 +13,7 @@ def create_lobby_dir_path(lobby_mstr_dir: str, lobby_id: LobbyID) -> str:
 
 
 def create_world_dir_path(
-    lobby_mstr_dir: str, lobby_id: LobbyID, world_name: WorldID
+    lobby_mstr_dir: str, lobby_id: LobbyID, world_name: WorldName
 ) -> str:
     """Returns path: lobby_mstr_dir\\lobbys\\lobby_id\\worlds\\world_name"""
     lobbys_dir = create_path(lobby_mstr_dir, "lobbys")
@@ -23,7 +23,7 @@ def create_world_dir_path(
 
 
 def create_belief_mstr_dir_path(
-    lobby_mstr_dir: str, lobby_id: LobbyID, world_name: WorldID
+    lobby_mstr_dir: str, lobby_id: LobbyID, world_name: WorldName
 ) -> str:
     """Returns path: lobby_mstr_dir\\lobbys\\lobby_id\\worlds\\world_name\\belief_mstr_dir"""
     lobbys_dir = create_path(lobby_mstr_dir, "lobbys")

--- a/src/a21_lobby_logic/lobby_path.py
+++ b/src/a21_lobby_logic/lobby_path.py
@@ -13,21 +13,21 @@ def create_lobby_dir_path(lobby_mstr_dir: str, lobby_id: LobbyID) -> str:
 
 
 def create_world_dir_path(
-    lobby_mstr_dir: str, lobby_id: LobbyID, world_id: WorldID
+    lobby_mstr_dir: str, lobby_id: LobbyID, world_name: WorldID
 ) -> str:
-    """Returns path: lobby_mstr_dir\\lobbys\\lobby_id\\worlds\\world_id"""
+    """Returns path: lobby_mstr_dir\\lobbys\\lobby_id\\worlds\\world_name"""
     lobbys_dir = create_path(lobby_mstr_dir, "lobbys")
     lobby_dir = create_path(lobbys_dir, lobby_id)
     worlds_dir = create_path(lobby_dir, "worlds")
-    return create_path(worlds_dir, world_id)
+    return create_path(worlds_dir, world_name)
 
 
 def create_belief_mstr_dir_path(
-    lobby_mstr_dir: str, lobby_id: LobbyID, world_id: WorldID
+    lobby_mstr_dir: str, lobby_id: LobbyID, world_name: WorldID
 ) -> str:
-    """Returns path: lobby_mstr_dir\\lobbys\\lobby_id\\worlds\\world_id\\belief_mstr_dir"""
+    """Returns path: lobby_mstr_dir\\lobbys\\lobby_id\\worlds\\world_name\\belief_mstr_dir"""
     lobbys_dir = create_path(lobby_mstr_dir, "lobbys")
     lobby_dir = create_path(lobbys_dir, lobby_id)
     worlds_dir = create_path(lobby_dir, "worlds")
-    world_id_dir = create_path(worlds_dir, world_id)
-    return create_path(world_id_dir, "belief_mstr_dir")
+    world_name_dir = create_path(worlds_dir, world_name)
+    return create_path(world_name_dir, "belief_mstr_dir")

--- a/src/a21_lobby_logic/test/test_lobby_path_doc.py
+++ b/src/a21_lobby_logic/test/test_lobby_path_doc.py
@@ -1,6 +1,6 @@
 from inspect import getdoc as inspect_getdoc
 from platform import system as platform_system
-from src.a17_idea_logic.test._util.a17_str import world_id_str
+from src.a17_idea_logic.test._util.a17_str import world_name_str
 from src.a21_lobby_logic.lobby_path import (
     create_belief_mstr_dir_path,
     create_lobby_dir_path,
@@ -22,7 +22,7 @@ def test_create_lobby_dir_path_HasDocString():
 def test_create_world_dir_path_HasDocString():
     # ESTABLISH
     doc_str = create_world_dir_path(
-        lobby_mstr_dir_str(), lobby_id_str(), world_id_str()
+        lobby_mstr_dir_str(), lobby_id_str(), world_name_str()
     )
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
@@ -32,7 +32,7 @@ def test_create_world_dir_path_HasDocString():
 def test_create_belief_mstr_dir_path_HasDocString():
     # ESTABLISH
     doc_str = create_belief_mstr_dir_path(
-        lobby_mstr_dir_str(), lobby_id_str(), world_id_str()
+        lobby_mstr_dir_str(), lobby_id_str(), world_name_str()
     )
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN


### PR DESCRIPTION
## Summary by Sourcery

Refactor the codebase to use world_name instead of world_id throughout, introduce a CSV utility for column replacement, and enhance stance export to inject world names into CSV outputs

New Features:
- Add replace_csv_column_from_string utility for globally replacing values in a specified CSV column

Enhancements:
- Rename WorldID to WorldName across world and lobby modules, including path builders, data models, and tests
- Update create_stance0001_file to accept world_name and inject it into the face_name column in stance CSVs
- Update CSV toolbox to use DictReader and StringIO for enhanced CSV manipulation

Documentation:
- Update documentation in str_funcs.md to reflect the world_name naming change

Tests:
- Add tests for replace_csv_column_from_string
- Update existing world and lobby tests to reference world_name instead of world_id