### PR TITLE
812 create cli tool for executing mud to clarity etl

### DIFF
--- a/src/a00_data_toolbox/csv_toolbox.py
+++ b/src/a00_data_toolbox/csv_toolbox.py
@@ -96,6 +96,7 @@ def export_sqlite_tables_to_csv(db_path, output_dir="."):
                 writer = csv_writer(f)
                 writer.writerow(column_names)
                 writer.writerows(rows)
+    conn.close()
 
 
 def replace_csv_column_from_string(

--- a/src/a00_data_toolbox/test/test_db_tool_.py
+++ b/src/a00_data_toolbox/test/test_db_tool_.py
@@ -432,6 +432,7 @@ def test_insert_csv_ChangesDBState(env_dir_setup_cleanup):
             (2, "Jane Smith", 25, "jane@example.com"),
         ]
         assert rows == expected_data
+    conn.close()
 
 
 def test_insert_csv_ChangesDBState_WhenPassedCursorObj(
@@ -456,6 +457,7 @@ def test_insert_csv_ChangesDBState_WhenPassedCursorObj(
             (2, "Jane Smith", 25, "jane@example.com"),
         ]
         assert rows == expected_data
+    conn.close()
 
 
 def test_insert_csv_ChangesNotCommitted(
@@ -480,6 +482,9 @@ def test_insert_csv_ChangesNotCommitted(
         cursor2.execute(f"SELECT * FROM {test_tablename}")
         rows = cursor2.fetchall()
         assert rows == []
+
+    conn.close()
+    conn2.close()
 
 
 def test_create_table_from_csv_ChangesDBState(env_dir_setup_cleanup):
@@ -513,6 +518,8 @@ def test_create_table_from_csv_ChangesDBState(env_dir_setup_cleanup):
         ]
         assert columns == expected_columns
 
+    conn.close()
+
 
 def test_create_table_from_csv_DoesNotEmptyTable(
     env_dir_setup_cleanup: tuple[sqlite3_Connection, str, str],
@@ -540,6 +547,8 @@ def test_create_table_from_csv_DoesNotEmptyTable(
         cursor.execute(f"SELECT * FROM {test_table}")
         assert cursor.fetchall() == before_data
     delete_dir(test_csv_filepath)
+
+    conn.close()
 
 
 def test_table_exists_ReturnsObjWhenPassedConnectionObj():

--- a/src/a17_idea_logic/idea_csv_tool.py
+++ b/src/a17_idea_logic/idea_csv_tool.py
@@ -821,3 +821,8 @@ def add_packunit_to_stance_csv_strs(
     belief_csv_strs["br00027"] = br00027_csv
     belief_csv_strs["br00028"] = br00028_csv
     belief_csv_strs["br00029"] = br00029_csv
+
+
+# TODO #834
+# def add_pidginunits_to_stance_csv_strs():
+#     pass

--- a/src/a17_idea_logic/idea_db_tool.py
+++ b/src/a17_idea_logic/idea_db_tool.py
@@ -574,3 +574,8 @@ def update_event_int_in_excel_files(directory: str, value) -> None:
             with ExcelWriter(filepath, engine="xlsxwriter") as writer:
                 for sheet_name, df in updated_sheets.items():
                     df.to_excel(writer, sheet_name=sheet_name, index=False)
+
+
+# # TODO #834
+# def add_pidginunits_to_stance_csv_strs(csv_strs: dict[str, str], db_path: str):
+#     pass

--- a/src/a18_etl_toolbox/test/test_stance/test_stance_tool.py
+++ b/src/a18_etl_toolbox/test/test_stance/test_stance_tool.py
@@ -1,14 +1,24 @@
 from os.path import exists as os_path_exists
-from src.a00_data_toolbox.file_toolbox import create_path, open_file, save_file
+from sqlite3 import connect as sqlite3_connect
+from src.a00_data_toolbox.file_toolbox import create_path, open_file, save_file, set_dir
 from src.a06_plan_logic.plan import planunit_shop
+from src.a06_plan_logic.test._util.a06_str import plan_concept_awardlink_str
+from src.a09_pack_logic.test._util.a09_str import event_int_str, face_name_str
 from src.a12_hub_toolbox.hub_path import create_belief_json_path, create_gut_path
 from src.a15_belief_logic.belief import beliefunit_shop
+from src.a16_pidgin_logic.test._util.a16_str import (
+    inx_name_str,
+    otx_name_str,
+    pidgin_name_str,
+)
 from src.a17_idea_logic.idea_csv_tool import (
     add_beliefunit_to_stance_csv_strs,
     add_planunit_to_stance_csv_strs,
     create_init_stance_idea_csv_strs,
 )
-from src.a17_idea_logic.idea_db_tool import get_sheet_names
+from src.a17_idea_logic.idea_db_tool import (  # add_pidginunits_to_stance_csv_strs,
+    get_sheet_names,
+)
 from src.a18_etl_toolbox.stance_tool import (
     collect_stance_csv_strs,
     create_stance0001_file,
@@ -18,6 +28,12 @@ from src.a18_etl_toolbox.test._util.a18_env import (
     get_module_temp_dir,
 )
 from src.a18_etl_toolbox.tran_path import create_stance0001_path
+from src.a18_etl_toolbox.tran_sqlstrs import (
+    create_prime_tablename as prime_tbl,
+    create_sound_and_voice_tables,
+    create_update_voice_raw_empty_inx_col_sqlstr,
+    create_update_voice_raw_existing_inx_col_sqlstr,
+)
 
 
 def test_collect_stance_csv_strs_ReturnsObj_Scenario0_NoBeliefUnits(
@@ -78,6 +94,93 @@ def test_collect_stance_csv_strs_ReturnsObj_Scenario2_gut_PlanUnits(
     add_beliefunit_to_stance_csv_strs(a23_belief, expected_stance_csv_strs, ",")
     add_planunit_to_stance_csv_strs(bob_gut, expected_stance_csv_strs, ",")
     assert gen_stance_csv_strs == expected_stance_csv_strs
+
+
+# # TODO #834
+# # def test_collect_stance_csv_strs_ReturnsObj_Scenario3_gut_PlanUnits(
+# #     env_dir_setup_cleanup,
+# # ):
+# #     # ESTABLISH
+# #     belief_mstr_dir = get_module_temp_dir()
+# #     bob_str = "Bob"
+# #     a23_str = "amy23"
+# #     a23_belief = beliefunit_shop(a23_str, belief_mstr_dir)
+# #     belief_json_path = create_belief_json_path(belief_mstr_dir, a23_str)
+# #     save_file(belief_json_path, None, a23_belief.get_json())
+# #     # create plan gut file
+# #     bob_gut = planunit_shop(bob_str, a23_str)
+# #     bob_gut.add_acctunit("Yao", 44, 55)
+# #     a23_bob_gut_path = create_gut_path(belief_mstr_dir, a23_str, bob_str)
+# #     save_file(a23_bob_gut_path, None, bob_gut.get_json())
+
+# #     # WHEN
+# #     gen_stance_csv_strs = collect_stance_csv_strs(belief_mstr_dir)
+
+# #     # THEN
+# #     expected_stance_csv_strs = create_init_stance_idea_csv_strs()
+# #     add_beliefunit_to_stance_csv_strs(a23_belief, expected_stance_csv_strs, ",")
+# #     add_planunit_to_stance_csv_strs(bob_gut, expected_stance_csv_strs, ",")
+# #     assert gen_stance_csv_strs == expected_stance_csv_strs
+
+
+# def test_add_pidginunits_to_stance_csv_strs_ReturnsObj_Scenario0(env_dir_setup_cleanup):
+#     # ESTABLISH database with pidgin data
+#     bob_otx = "Bob"
+#     bob_inx = "Bobby"
+#     sue_otx = "Sue"
+#     sue_inx = "Suzy"
+#     yao_otx = "Yao"
+#     event1 = 1
+#     event2 = 2
+#     event5 = 5
+#     event7 = 7
+#     temp_dir = get_module_temp_dir()
+#     db_path = create_path(temp_dir, "example3.db")
+#     print(f"{db_path=}")
+#     set_dir(temp_dir)
+
+#     with sqlite3_connect(db_path) as db_conn:
+#         cursor = db_conn.cursor()
+#         create_sound_and_voice_tables(cursor)
+#         pidname_dimen = pidgin_name_str()
+#         pidname_s_vld_tablename = prime_tbl(pidname_dimen, "s", "vld")
+#         print(f"{pidname_s_vld_tablename=}")
+#         insert_pidname_sqlstr = f"""INSERT INTO {pidname_s_vld_tablename}
+#         ({event_int_str()}, {face_name_str()}, {otx_name_str()}, {inx_name_str()})
+#         VALUES
+#           ({event1}, '{sue_otx}', '{sue_otx}', '{sue_inx}')
+#         , ({event7}, '{bob_otx}', '{bob_otx}', '{bob_inx}')
+#         ;
+#         """
+#         cursor.execute(insert_pidname_sqlstr)
+
+#         pidcore_s_vld_tablename = prime_tbl("pidcore", "s", "vld")
+#         insert_pidcore_sqlstr = f"""INSERT INTO {pidcore_s_vld_tablename}
+#         ({event_int_str()}, {face_name_str()}, {otx_name_str()}, {inx_name_str()})
+#         VALUES
+#           ({event1}, '{sue_otx}', '{sue_otx}', '{sue_inx}')
+#         , ({event7}, '{bob_otx}', '{bob_otx}', '{bob_inx}')
+#         ;
+#         """
+#         cursor.execute(insert_pidname_sqlstr)
+#     csv_strs = create_init_stance_idea_csv_strs()
+#     br00042_str = "br00042"
+#     br00043_str = "br00043"
+#     br00044_str = "br00044"
+#     br00045_str = "br00045"
+#     print(f"{csv_strs.get(br00042_str)=}")
+#     print(f"{csv_strs.get(br00043_str)=}")
+#     print(f"{csv_strs.get(br00044_str)=}")
+#     print(f"{csv_strs.get(br00045_str)=}")
+#     print(f"{csv_strs.keys()=}")
+
+#     # WHEN
+#     csv_strs = add_pidginunits_to_stance_csv_strs(csv_strs, db_path)
+
+#     # THEN csv_strs have added rows
+#     expected_stance_csv_strs = create_init_stance_idea_csv_strs()
+
+#     assert 1 == 2
 
 
 def test_create_stance0001_file_CreatesFile_Scenario0_NoBeliefUnits(

--- a/src/a19_kpi_toolbox/kpi_mstr.py
+++ b/src/a19_kpi_toolbox/kpi_mstr.py
@@ -63,6 +63,7 @@ def create_kpi_csvs(db_path: str, dst_dir: str):
         kpi_tables = get_db_tables(db_conn, "kpi")
         for kpi_table in kpi_tables:
             save_table_to_csv(cursor, dst_dir, kpi_table)
+    db_conn.close()
 
 
 def create_calendar_markdown_files(belief_mstr_dir: str, output_dir: str):

--- a/src/a19_kpi_toolbox/test/test_z_kpi_file.py
+++ b/src/a19_kpi_toolbox/test/test_z_kpi_file.py
@@ -29,6 +29,7 @@ def test_create_kpi_csvs_Scenario0_NotCreateFileWhenNoKPITables(env_dir_setup_cl
 
     # THEN
     assert count_files(temp_dir) == 1
+    db_conn.close()
 
 
 def test_create_kpi_csvs_Scenario1_CreateFile(env_dir_setup_cleanup):
@@ -51,3 +52,4 @@ def test_create_kpi_csvs_Scenario1_CreateFile(env_dir_setup_cleanup):
     assert os_path_exists(kpi_csv_path)
     expected_df = DataFrame(["Fay"], columns=["belief_label"])
     assert_frame_equal(open_csv(kpi_csv_path), expected_df)
+    db_conn.close()

--- a/src/a20_world_logic/test/test_etl_pipeline/test_input_to_clarity.py
+++ b/src/a20_world_logic/test/test_etl_pipeline/test_input_to_clarity.py
@@ -659,3 +659,4 @@ def test_WorldUnit_sheets_input_to_clarity_mstr_Scenario0_CreatesDatabaseFile(
         assert get_row_count(cursor, plnunit_voice_put_agg) == 1
         assert get_row_count(cursor, plnacct_voice_put_agg) == 1
         assert get_row_count(cursor, belief_ote1_agg_str()) == 1
+    db_conn.close()

--- a/src/a20_world_logic/test/test_etl_pipeline/test_stance_to_clarity.py
+++ b/src/a20_world_logic/test/test_etl_pipeline/test_stance_to_clarity.py
@@ -126,3 +126,4 @@ def test_WorldUnit_stance_sheets_to_clarity_mstr_Scenario0_CreatesDatabaseFile(
         assert get_row_count(cursor, plnunit_voice_put_agg) == 1
         assert get_row_count(cursor, plnacct_voice_put_agg) == 1
         assert get_row_count(cursor, belief_ote1_agg_str()) == 1
+    db_conn.close()

--- a/src/a20_world_logic/world.py
+++ b/src/a20_world_logic/world.py
@@ -161,6 +161,9 @@ class WorldUnit:
         # if store_tracing_files:
 
     def create_stances(self, prettify_excel_bool=True):
+        # TODO why is create_stance0001_file not drawing from world db instead of files?
+        # it should be the database because that's the end of the core pipeline so it should
+        # be the source of truth.
         create_stance0001_file(
             self._belief_mstr_dir, self.output_dir, self.world_name, prettify_excel_bool
         )

--- a/src/a20_world_logic/world.py
+++ b/src/a20_world_logic/world.py
@@ -111,6 +111,7 @@ class WorldUnit:
             cursor = db_conn.cursor()
             self.sheets_input_to_clarity_with_cursor(db_conn, cursor)
             db_conn.commit()
+        db_conn.close()
 
     def stance_sheets_to_clarity_mstr(self):
         update_event_int_in_excel_files(self._input_dir, 1)

--- a/src/a99_module_logic/test/test_module_dirs.py
+++ b/src/a99_module_logic/test/test_module_dirs.py
@@ -188,7 +188,7 @@ def test_Modules_StrFunctionsAppearWhereTheyShould():
     all_str_functions = get_all_str_functions()
     str_first_ref = {str_function: None for str_function in all_str_functions}
     # TODO change excluded_strs to empty set by editing codebase
-    excluded_strs = {"time", "day", "days"}
+    excluded_strs = {"close", "day", "days", "time"}
 
     # WHEN / THEN
 


### PR DESCRIPTION
## Summary by Sourcery

Ensure proper closure of SQLite connections across the codebase, improve related test coverage, and add scaffolding for future pidginunits integration.

Enhancements:
- Close database connections in export_sqlite_tables_to_csv, create_kpi_csvs, world ETL methods, and other core functions
- Add TODO stubs for pidginunits integration in stance CSV generation modules

Tests:
- Introduce tests to verify database connection closure (test_database_connection_not_closing1/2)
- Refactor existing tests to call conn.close() for proper cleanup
- Update export_sqlite_tables_to_csv tests to use create_path and os_path_exists utilities

Chores:
- Replace tempfile import with time in CSV toolbox tests
- Update excluded_strs set in module_dirs tests