### PR TITLE
812 create cli tool for executing mud to clarity etl

### DIFF
--- a/main_listen.py
+++ b/main_listen.py
@@ -53,5 +53,5 @@ if __name__ == "__main__":
     x_worldunit.create_stances()
     x_worldunit.create_kpi_csvs()
     output_db_dir = create_path(output_directory, "db")
-    export_sqlite_tables_to_csv(x_worldunit.get_db_path(), output_db_dir)
+    export_sqlite_tables_to_csv(x_worldunit.get_world_db_path(), output_db_dir)
     print(f"after  output_dir file/dir count= {count_dirs_files(output_directory)}")

--- a/src/a12_hub_toolbox/hubunit.py
+++ b/src/a12_hub_toolbox/hubunit.py
@@ -12,9 +12,7 @@ from src.a00_data_toolbox.file_toolbox import (
     get_json_filename,
     get_max_file_number,
     open_file,
-    open_json,
     save_file,
-    save_json,
     set_dir,
 )
 from src.a01_term_logic.rope import (

--- a/src/a18_etl_toolbox/a18_path.py
+++ b/src/a18_etl_toolbox/a18_path.py
@@ -2,6 +2,11 @@ from src.a00_data_toolbox.file_toolbox import create_path
 from src.a01_term_logic.term import BelieverName, LabelTerm
 
 
+def create_belief_mstr_path(world_dir: str):
+    """Returns path: world_dir\\belief_mstr"""
+    return create_path(world_dir, "belief_mstr")
+
+
 def create_belief_ote1_csv_path(belief_mstr_dir: str, belief_label: LabelTerm):
     """Returns path: belief_mstr_dir\\beliefs\\belief_label\\belief_ote1_agg.csv"""
     beliefs_dir = create_path(belief_mstr_dir, "beliefs")

--- a/src/a18_etl_toolbox/a18_path.py
+++ b/src/a18_etl_toolbox/a18_path.py
@@ -1,16 +1,6 @@
 from src.a00_data_toolbox.file_toolbox import create_path
 from src.a01_term_logic.term import BelieverName, LabelTerm
 
-STANCE0001_FILENAME = "stance0001.xlsx"
-BELIEF_OTE1_AGG_CSV_FILENAME = "belief_ote1_agg.csv"
-BELIEF_OTE1_AGG_JSON_FILENAME = "belief_ote1_agg.json"
-LAST_RUN_METRICS_JSON_FILENAME = "last_run_metrics.json"
-
-
-def create_last_run_metrics_path(belief_mstr_dir: str):
-    """Returns path: belief_mstr_dir\\last_run_metrics.json"""
-    return create_path(belief_mstr_dir, LAST_RUN_METRICS_JSON_FILENAME)
-
 
 def create_belief_ote1_csv_path(belief_mstr_dir: str, belief_label: LabelTerm):
     """Returns path: belief_mstr_dir\\beliefs\\belief_label\\belief_ote1_agg.csv"""
@@ -42,3 +32,13 @@ def create_stances_believer_dir_path(
 def create_stance0001_path(output_dir: str) -> str:
     """Returns path: output_dir\\stance0001.xlsx"""
     return create_path(output_dir, "stance0001.xlsx")
+
+
+def create_last_run_metrics_path(world_dir: str) -> str:
+    """Returns path: world_dir\\last_run_metrics.json"""
+    return create_path(world_dir, "last_run_metrics.json")
+
+
+def create_world_db_path(world_dir: str) -> str:
+    "Returns path: belief_mstr_dir\\world.db"
+    return create_path(world_dir, "world.db")

--- a/src/a18_etl_toolbox/stance_tool.py
+++ b/src/a18_etl_toolbox/stance_tool.py
@@ -1,5 +1,5 @@
 from os.path import exists as os_path_exists
-from sqlite3 import Cursor as sqlite3_Cursor
+from sqlite3 import Cursor as sqlite3_Cursor, connect as sqlite3_connect
 from src.a00_data_toolbox.csv_toolbox import (
     delete_column_from_csv_string,
     replace_csv_column_from_string,
@@ -13,8 +13,15 @@ from src.a17_idea_logic.idea_csv_tool import (
     create_init_stance_idea_csv_strs,
 )
 from src.a17_idea_logic.idea_db_tool import csv_dict_to_excel, prettify_excel
-from src.a18_etl_toolbox.a18_path import create_stance0001_path
-from src.a18_etl_toolbox.tran_sqlstrs import create_prime_tablename as prime_tbl
+from src.a18_etl_toolbox.a18_path import (
+    create_belief_mstr_path,
+    create_stance0001_path,
+    create_world_db_path,
+)
+from src.a18_etl_toolbox.tran_sqlstrs import (
+    create_prime_tablename as prime_tbl,
+    create_sound_and_voice_tables,
+)
 
 
 # TODO #842
@@ -52,7 +59,6 @@ ORDER BY
 def add_to_br00043_csv(x_csv: str, cursor: sqlite3_Cursor, csv_delimiter: str) -> str:
     pidname_s_vld_tablename = prime_tbl("PIDNAME", "s", "vld")
     pidcore_s_vld_tablename = prime_tbl("PIDCORE", "s", "vld")
-
     select_sqlstr = f"""
 SELECT
   "" event_int
@@ -159,7 +165,8 @@ def add_pidgin_rows_to_stance_csv_strs(
     belief_csv_strs["br00045"] = br00045_csv
 
 
-def collect_stance_csv_strs(belief_mstr_dir: str) -> dict[str, str]:
+def collect_stance_csv_strs(world_dir: str) -> dict[str, str]:
+    belief_mstr_dir = create_belief_mstr_path(world_dir)
     x_csv_strs = create_init_stance_idea_csv_strs()
     beliefs_dir = create_path(belief_mstr_dir, "beliefs")
     for belief_label in get_level1_dirs(beliefs_dir):
@@ -174,21 +181,29 @@ def collect_stance_csv_strs(belief_mstr_dir: str) -> dict[str, str]:
             if os_path_exists(gut_believer_path):
                 gut_believer = open_believer_file(gut_believer_path)
                 add_believerunit_to_stance_csv_strs(gut_believer, x_csv_strs, ",")
+    world_db_path = create_world_db_path(world_dir)
+    with sqlite3_connect(world_db_path) as db_conn:
+        cursor = db_conn.cursor()
+        create_sound_and_voice_tables(cursor)
+        add_pidgin_rows_to_stance_csv_strs(cursor, x_csv_strs, ",")
+    db_conn.close()
+
     return x_csv_strs
 
 
 def create_stance0001_file(
-    belief_mstr_dir: str,
+    world_dir: str,
     output_dir: str,
     world_name: str,
     prettify_excel_bool: bool = True,
 ):
-    stance_csv_strs = collect_stance_csv_strs(belief_mstr_dir)
+    stance_csv_strs = collect_stance_csv_strs(world_dir)
     with_face_name_csvs = {}
     for csv_key, csv_str in stance_csv_strs.items():
         csv_str = replace_csv_column_from_string(csv_str, "face_name", world_name)
         csv_str = delete_column_from_csv_string(csv_str, "event_int")
         with_face_name_csvs[csv_key] = csv_str
+
     csv_dict_to_excel(with_face_name_csvs, output_dir, "stance0001.xlsx")
 
     # Hard to test function to prettify the excel file

--- a/src/a18_etl_toolbox/stance_tool.py
+++ b/src/a18_etl_toolbox/stance_tool.py
@@ -13,7 +13,7 @@ from src.a17_idea_logic.idea_csv_tool import (
     create_init_stance_idea_csv_strs,
 )
 from src.a17_idea_logic.idea_db_tool import csv_dict_to_excel, prettify_excel
-from src.a18_etl_toolbox.a18_path import STANCE0001_FILENAME, create_stance0001_path
+from src.a18_etl_toolbox.a18_path import create_stance0001_path
 from src.a18_etl_toolbox.tran_sqlstrs import create_prime_tablename as prime_tbl
 
 
@@ -189,7 +189,7 @@ def create_stance0001_file(
         csv_str = replace_csv_column_from_string(csv_str, "face_name", world_name)
         csv_str = delete_column_from_csv_string(csv_str, "event_int")
         with_face_name_csvs[csv_key] = csv_str
-    csv_dict_to_excel(with_face_name_csvs, output_dir, STANCE0001_FILENAME)
+    csv_dict_to_excel(with_face_name_csvs, output_dir, "stance0001.xlsx")
 
     # Hard to test function to prettify the excel file
     if prettify_excel_bool:

--- a/src/a18_etl_toolbox/test/_util/test_a18_path.py
+++ b/src/a18_etl_toolbox/test/_util/test_a18_path.py
@@ -4,6 +4,7 @@ from src.a00_data_toolbox.file_toolbox import create_path
 from src.a04_reason_logic.test._util.a04_str import belief_label_str
 from src.a09_pack_logic.test._util.a09_str import believer_name_str
 from src.a18_etl_toolbox.a18_path import (
+    create_belief_mstr_path,
     create_belief_ote1_csv_path,
     create_belief_ote1_json_path,
     create_last_run_metrics_path,
@@ -31,6 +32,26 @@ def test_a18_path_constants_are_values():
     assert LAST_RUN_METRICS_JSON_FILENAME == "last_run_metrics.json"
     assert STANCE0001_FILENAME == "stance0001.xlsx"
     assert WORLD_DB_FILENAME == "world.db"
+
+
+def test_create_belief_mstr_path_ReturnsObj():
+    # ESTABLISH
+    x_world_dir = get_module_temp_dir()
+
+    # WHEN
+    gen_last_run_metrics_path = create_belief_mstr_path(x_world_dir)
+
+    # THEN
+    expected_path = create_path(x_world_dir, "belief_mstr")
+    assert gen_last_run_metrics_path == expected_path
+
+
+def test_create_belief_mstr_path_HasDocString():
+    # ESTABLISH
+    doc_str = create_belief_mstr_path(world_dir="world_dir")
+    doc_str = f"Returns path: {doc_str}"
+    # WHEN / THEN
+    assert LINUX_OS or inspect_getdoc(create_belief_mstr_path) == doc_str
 
 
 def test_create_last_run_metrics_path_ReturnsObj():

--- a/src/a18_etl_toolbox/test/_util/test_a18_path.py
+++ b/src/a18_etl_toolbox/test/_util/test_a18_path.py
@@ -4,21 +4,24 @@ from src.a00_data_toolbox.file_toolbox import create_path
 from src.a04_reason_logic.test._util.a04_str import belief_label_str
 from src.a09_pack_logic.test._util.a09_str import believer_name_str
 from src.a18_etl_toolbox.a18_path import (
-    BELIEF_OTE1_AGG_CSV_FILENAME,
-    BELIEF_OTE1_AGG_JSON_FILENAME,
-    LAST_RUN_METRICS_JSON_FILENAME,
-    STANCE0001_FILENAME,
     create_belief_ote1_csv_path,
     create_belief_ote1_json_path,
     create_last_run_metrics_path,
     create_stance0001_path,
     create_stances_believer_dir_path,
     create_stances_dir_path,
+    create_world_db_path,
 )
 from src.a18_etl_toolbox.test._util.a18_env import (
     env_dir_setup_cleanup,
     get_module_temp_dir,
 )
+
+STANCE0001_FILENAME = "stance0001.xlsx"
+BELIEF_OTE1_AGG_CSV_FILENAME = "belief_ote1_agg.csv"
+BELIEF_OTE1_AGG_JSON_FILENAME = "belief_ote1_agg.json"
+LAST_RUN_METRICS_JSON_FILENAME = "last_run_metrics.json"
+WORLD_DB_FILENAME = "world.db"
 
 
 def test_a18_path_constants_are_values():
@@ -27,17 +30,18 @@ def test_a18_path_constants_are_values():
     assert BELIEF_OTE1_AGG_JSON_FILENAME == "belief_ote1_agg.json"
     assert LAST_RUN_METRICS_JSON_FILENAME == "last_run_metrics.json"
     assert STANCE0001_FILENAME == "stance0001.xlsx"
+    assert WORLD_DB_FILENAME == "world.db"
 
 
 def test_create_last_run_metrics_path_ReturnsObj():
     # ESTABLISH
-    x_belief_mstr_dir = get_module_temp_dir()
+    x_world_dir = get_module_temp_dir()
 
     # WHEN
-    gen_last_run_metrics_path = create_last_run_metrics_path(x_belief_mstr_dir)
+    gen_last_run_metrics_path = create_last_run_metrics_path(x_world_dir)
 
     # THEN
-    expected_path = create_path(x_belief_mstr_dir, LAST_RUN_METRICS_JSON_FILENAME)
+    expected_path = create_path(x_world_dir, LAST_RUN_METRICS_JSON_FILENAME)
     assert gen_last_run_metrics_path == expected_path
 
 
@@ -84,7 +88,7 @@ LINUX_OS = platform_system() == "Linux"
 
 def test_create_last_run_metrics_path_HasDocString():
     # ESTABLISH
-    doc_str = create_last_run_metrics_path("belief_mstr_dir")
+    doc_str = create_last_run_metrics_path("world_dir")
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
     assert LINUX_OS or inspect_getdoc(create_last_run_metrics_path) == doc_str
@@ -146,6 +150,19 @@ def test_create_belief_ote1_json_path_ReturnsObj():
     assert gen_a23_te_csv_path == expected_a23_te_path
 
 
+def test_create_world_db_path_ReturnsObj():
+    # ESTABLISH
+    x_belief_mstr_dir = get_module_temp_dir()
+    a23_str = "amy23"
+
+    # WHEN
+    gen_world_db_path = create_world_db_path(x_belief_mstr_dir)
+
+    # THEN
+    expected_path = create_path(x_belief_mstr_dir, WORLD_DB_FILENAME)
+    assert gen_world_db_path == expected_path
+
+
 def test_create_belief_ote1_csv_path_HasDocString():
     # ESTABLISH
     doc_str = create_belief_ote1_csv_path(
@@ -164,3 +181,11 @@ def test_create_belief_ote1_json_path_HasDocString():
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
     assert LINUX_OS or inspect_getdoc(create_belief_ote1_json_path) == doc_str
+
+
+def test_create_world_db_path_HasDocString():
+    # ESTABLISH
+    doc_str = create_world_db_path("belief_mstr_dir")
+    doc_str = f"Returns path: {doc_str}"
+    # WHEN / THEN
+    assert LINUX_OS or inspect_getdoc(create_world_db_path) == doc_str

--- a/src/a18_etl_toolbox/test/_util/test_a18_path.py
+++ b/src/a18_etl_toolbox/test/_util/test_a18_path.py
@@ -165,9 +165,7 @@ def test_create_world_db_path_ReturnsObj():
 
 def test_create_belief_ote1_csv_path_HasDocString():
     # ESTABLISH
-    doc_str = create_belief_ote1_csv_path(
-        "belief_mstr_dir", belief_label=belief_label_str()
-    )
+    doc_str = create_belief_ote1_csv_path("belief_mstr_dir", belief_label_str())
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
     assert LINUX_OS or inspect_getdoc(create_belief_ote1_csv_path) == doc_str
@@ -175,9 +173,7 @@ def test_create_belief_ote1_csv_path_HasDocString():
 
 def test_create_belief_ote1_json_path_HasDocString():
     # ESTABLISH
-    doc_str = create_belief_ote1_json_path(
-        "belief_mstr_dir", belief_label=belief_label_str()
-    )
+    doc_str = create_belief_ote1_json_path("belief_mstr_dir", belief_label_str())
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
     assert LINUX_OS or inspect_getdoc(create_belief_ote1_json_path) == doc_str

--- a/src/a18_etl_toolbox/test/test_stance/test_stance_tool.py
+++ b/src/a18_etl_toolbox/test/test_stance/test_stance_tool.py
@@ -16,11 +16,10 @@ from src.a17_idea_logic.idea_csv_tool import (
     add_believerunit_to_stance_csv_strs,
     create_init_stance_idea_csv_strs,
 )
-from src.a17_idea_logic.idea_db_tool import (  # add_pidginunits_to_stance_csv_strs,
-    get_sheet_names,
-)
+from src.a17_idea_logic.idea_db_tool import get_sheet_names
 from src.a18_etl_toolbox.a18_path import create_stance0001_path
 from src.a18_etl_toolbox.stance_tool import (
+    add_pidgin_rows_to_stance_csv_strs,
     collect_stance_csv_strs,
     create_stance0001_file,
 )
@@ -175,7 +174,7 @@ def test_collect_stance_csv_strs_ReturnsObj_Scenario2_gut_BelieverUnits(
 #     print(f"{csv_strs.keys()=}")
 
 #     # WHEN
-#     csv_strs = add_pidginunits_to_stance_csv_strs(csv_strs, db_path)
+#     csv_strs = add_pidgin_rows_to_stance_csv_strs(csv_strs, db_path)
 
 #     # THEN csv_strs have added rows
 #     expected_stance_csv_strs = create_init_stance_idea_csv_strs()

--- a/src/a18_etl_toolbox/test/test_stance/test_stance_tool.py
+++ b/src/a18_etl_toolbox/test/test_stance/test_stance_tool.py
@@ -1,4 +1,5 @@
 from os.path import exists as os_path_exists
+from pandas import read_excel as pandas_read_excel
 from sqlite3 import connect as sqlite3_connect
 from src.a00_data_toolbox.file_toolbox import create_path, open_file, save_file, set_dir
 from src.a06_believer_logic.believer import believerunit_shop
@@ -7,9 +8,12 @@ from src.a09_pack_logic.test._util.a09_str import event_int_str, face_name_str
 from src.a12_hub_toolbox.a12_path import create_belief_json_path, create_gut_path
 from src.a15_belief_logic.belief import beliefunit_shop
 from src.a16_pidgin_logic.test._util.a16_str import (
+    inx_knot_str,
     inx_name_str,
+    otx_knot_str,
     otx_name_str,
     pidgin_name_str,
+    unknown_str_str,
 )
 from src.a17_idea_logic.idea_csv_tool import (
     add_beliefunit_to_stance_csv_strs,
@@ -17,9 +21,12 @@ from src.a17_idea_logic.idea_csv_tool import (
     create_init_stance_idea_csv_strs,
 )
 from src.a17_idea_logic.idea_db_tool import get_sheet_names
-from src.a18_etl_toolbox.a18_path import create_stance0001_path
+from src.a18_etl_toolbox.a18_path import (
+    create_belief_mstr_path,
+    create_stance0001_path,
+    create_world_db_path,
+)
 from src.a18_etl_toolbox.stance_tool import (
-    add_pidgin_rows_to_stance_csv_strs,
     collect_stance_csv_strs,
     create_stance0001_file,
 )
@@ -39,11 +46,11 @@ def test_collect_stance_csv_strs_ReturnsObj_Scenario0_NoBeliefUnits(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
-    belief_mstr_dir = get_module_temp_dir()
+    world_dir = get_module_temp_dir()
     bob_str = "Bob"
 
     # WHEN
-    gen_stance_csv_strs = collect_stance_csv_strs(belief_mstr_dir)
+    gen_stance_csv_strs = collect_stance_csv_strs(world_dir)
 
     # THEN
     expected_stance_csv_strs = create_init_stance_idea_csv_strs()
@@ -54,14 +61,15 @@ def test_collect_stance_csv_strs_ReturnsObj_Scenario1_SingleBeliefUnit_NoBelieve
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
-    belief_mstr_dir = get_module_temp_dir()
+    world_dir = get_module_temp_dir()
+    belief_mstr_dir = create_belief_mstr_path(world_dir)
     a23_str = "amy23"
     a23_belief = beliefunit_shop(a23_str, belief_mstr_dir)
     belief_json_path = create_belief_json_path(belief_mstr_dir, a23_str)
     save_file(belief_json_path, None, a23_belief.get_json())
 
     # WHEN
-    gen_stance_csv_strs = collect_stance_csv_strs(belief_mstr_dir)
+    gen_stance_csv_strs = collect_stance_csv_strs(world_dir)
 
     # THEN
     expected_stance_csv_strs = create_init_stance_idea_csv_strs()
@@ -73,7 +81,8 @@ def test_collect_stance_csv_strs_ReturnsObj_Scenario2_gut_BelieverUnits(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
-    belief_mstr_dir = get_module_temp_dir()
+    world_dir = get_module_temp_dir()
+    belief_mstr_dir = create_belief_mstr_path(world_dir)
     bob_str = "Bob"
     a23_str = "amy23"
     a23_belief = beliefunit_shop(a23_str, belief_mstr_dir)
@@ -86,7 +95,7 @@ def test_collect_stance_csv_strs_ReturnsObj_Scenario2_gut_BelieverUnits(
     save_file(a23_bob_gut_path, None, bob_gut.get_json())
 
     # WHEN
-    gen_stance_csv_strs = collect_stance_csv_strs(belief_mstr_dir)
+    gen_stance_csv_strs = collect_stance_csv_strs(world_dir)
 
     # THEN
     expected_stance_csv_strs = create_init_stance_idea_csv_strs()
@@ -95,108 +104,94 @@ def test_collect_stance_csv_strs_ReturnsObj_Scenario2_gut_BelieverUnits(
     assert gen_stance_csv_strs == expected_stance_csv_strs
 
 
-# # TODO #834
-# # def test_collect_stance_csv_strs_ReturnsObj_Scenario3_gut_BelieverUnits(
-# #     env_dir_setup_cleanup,
-# # ):
-# #     # ESTABLISH
-# #     belief_mstr_dir = get_module_temp_dir()
-# #     bob_str = "Bob"
-# #     a23_str = "amy23"
-# #     a23_belief = beliefunit_shop(a23_str, belief_mstr_dir)
-# #     belief_json_path = create_belief_json_path(belief_mstr_dir, a23_str)
-# #     save_file(belief_json_path, None, a23_belief.get_json())
-# #     # create believer gut file
-# #     bob_gut = believerunit_shop(bob_str, a23_str)
-# #     bob_gut.add_personunit("Yao", 44, 55)
-# #     a23_bob_gut_path = create_gut_path(belief_mstr_dir, a23_str, bob_str)
-# #     save_file(a23_bob_gut_path, None, bob_gut.get_json())
-
-# #     # WHEN
-# #     gen_stance_csv_strs = collect_stance_csv_strs(belief_mstr_dir)
-
-# #     # THEN
-# #     expected_stance_csv_strs = create_init_stance_idea_csv_strs()
-# #     add_beliefunit_to_stance_csv_strs(a23_belief, expected_stance_csv_strs, ",")
-# #     add_believerunit_to_stance_csv_strs(bob_gut, expected_stance_csv_strs, ",")
-# #     assert gen_stance_csv_strs == expected_stance_csv_strs
-
-
-# def test_add_pidginunits_to_stance_csv_strs_ReturnsObj_Scenario0(env_dir_setup_cleanup):
-#     # ESTABLISH database with pidgin data
-#     bob_otx = "Bob"
-#     bob_inx = "Bobby"
-#     sue_otx = "Sue"
-#     sue_inx = "Suzy"
-#     yao_otx = "Yao"
-#     event1 = 1
-#     event2 = 2
-#     event5 = 5
-#     event7 = 7
-#     temp_dir = get_module_temp_dir()
-#     db_path = create_path(temp_dir, "example3.db")
-#     print(f"{db_path=}")
-#     set_dir(temp_dir)
-
-#     with sqlite3_connect(db_path) as db_conn:
-#         cursor = db_conn.cursor()
-#         create_sound_and_voice_tables(cursor)
-#         pidname_dimen = pidgin_name_str()
-#         pidname_s_vld_tablename = prime_tbl(pidname_dimen, "s", "vld")
-#         print(f"{pidname_s_vld_tablename=}")
-#         insert_pidname_sqlstr = f"""INSERT INTO {pidname_s_vld_tablename}
-#         ({event_int_str()}, {face_name_str()}, {otx_name_str()}, {inx_name_str()})
-#         VALUES
-#           ({event1}, '{sue_otx}', '{sue_otx}', '{sue_inx}')
-#         , ({event7}, '{bob_otx}', '{bob_otx}', '{bob_inx}')
-#         ;
-#         """
-#         cursor.execute(insert_pidname_sqlstr)
-
-#         pidcore_s_vld_tablename = prime_tbl("pidcore", "s", "vld")
-#         insert_pidcore_sqlstr = f"""INSERT INTO {pidcore_s_vld_tablename}
-#         ({event_int_str()}, {face_name_str()}, {otx_name_str()}, {inx_name_str()})
-#         VALUES
-#           ({event1}, '{sue_otx}', '{sue_otx}', '{sue_inx}')
-#         , ({event7}, '{bob_otx}', '{bob_otx}', '{bob_inx}')
-#         ;
-#         """
-#         cursor.execute(insert_pidname_sqlstr)
-#     csv_strs = create_init_stance_idea_csv_strs()
-#     br00042_str = "br00042"
-#     br00043_str = "br00043"
-#     br00044_str = "br00044"
-#     br00045_str = "br00045"
-#     print(f"{csv_strs.get(br00042_str)=}")
-#     print(f"{csv_strs.get(br00043_str)=}")
-#     print(f"{csv_strs.get(br00044_str)=}")
-#     print(f"{csv_strs.get(br00045_str)=}")
-#     print(f"{csv_strs.keys()=}")
-
-#     # WHEN
-#     csv_strs = add_pidgin_rows_to_stance_csv_strs(csv_strs, db_path)
-
-#     # THEN csv_strs have added rows
-#     expected_stance_csv_strs = create_init_stance_idea_csv_strs()
-
-#     assert 1 == 2
-
-
 def test_create_stance0001_file_CreatesFile_Scenario0_NoBeliefUnits(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
     sue_str = "Sue"
-    belief_mstr_dir = create_path(get_module_temp_dir(), "belief_mstr")
-    output_dir = create_path(get_module_temp_dir(), "output")
+    world_dir = get_module_temp_dir()
+    output_dir = create_path(world_dir, "output")
     stance0001_path = create_stance0001_path(output_dir)
     assert os_path_exists(stance0001_path) is False
 
     # WHEN
-    create_stance0001_file(belief_mstr_dir, output_dir, sue_str)
+    create_stance0001_file(world_dir, output_dir, sue_str)
 
     # THEN
     assert os_path_exists(stance0001_path)
     bob_stance0001_sheetnames = get_sheet_names(stance0001_path)
     stance_csv_strs = create_init_stance_idea_csv_strs()
     assert set(bob_stance0001_sheetnames) == set(stance_csv_strs.keys())
+
+
+def test_create_stance0001_file_CreatesFile_Scenario1_PidginRowsInDB(
+    env_dir_setup_cleanup,
+):
+    # ESTABLISH database with pidgin data
+    yao_str = "Yao"
+    bob_otx = "Bob"
+    bob_inx = "Bobby"
+    sue_otx = "Sue"
+    sue_inx = "Suzy"
+    event1 = 1
+    event7 = 7
+    slash_str = "/"
+    colon_str = ":"
+    sue_unknown_str = "SueUnknown"
+    bob_unknown_str = "BobUnknown"
+    world_dir = get_module_temp_dir()
+    output_dir = create_path(get_module_temp_dir(), "output")
+    world_db_path = create_world_db_path(world_dir)
+    print(f"{world_db_path=}")
+    set_dir(world_dir)
+
+    with sqlite3_connect(world_db_path) as db_conn:
+        cursor = db_conn.cursor()
+        create_sound_and_voice_tables(cursor)
+        pidname_dimen = pidgin_name_str()
+        pidname_s_vld_tablename = prime_tbl(pidname_dimen, "s", "vld")
+        print(f"{pidname_s_vld_tablename=}")
+        insert_pidname_sqlstr = f"""INSERT INTO {pidname_s_vld_tablename}
+        ({event_int_str()}, {face_name_str()}, {otx_name_str()}, {inx_name_str()})
+        VALUES
+          ({event1}, '{sue_otx}', '{sue_otx}', '{sue_inx}')
+        , ({event7}, '{bob_otx}', '{bob_otx}', '{bob_inx}')
+        ;
+        """
+        cursor.execute(insert_pidname_sqlstr)
+
+        pidcore_s_vld_tablename = prime_tbl("pidcore", "s", "vld")
+        insert_pidcore_sqlstr = f"""INSERT INTO {pidcore_s_vld_tablename}
+        ({face_name_str()}, {otx_knot_str()}, {inx_knot_str()}, {unknown_str_str()})
+        VALUES
+          ('{sue_otx}', '{slash_str}', '{colon_str}', '{sue_unknown_str}')
+        , ('{bob_otx}', '{slash_str}', '{colon_str}', '{bob_unknown_str}')
+        ;
+        """
+        cursor.execute(insert_pidcore_sqlstr)
+    db_conn.close()
+
+    stance0001_path = create_stance0001_path(output_dir)
+    assert os_path_exists(stance0001_path) is False
+
+    # WHEN
+    create_stance0001_file(world_dir, output_dir, yao_str, False)
+
+    # THEN
+    assert os_path_exists(stance0001_path)
+    bob_stance0001_sheetnames = get_sheet_names(stance0001_path)
+    print(f"{bob_stance0001_sheetnames=}")
+    stance_csv_strs = create_init_stance_idea_csv_strs()
+    assert set(bob_stance0001_sheetnames) == set(stance_csv_strs.keys())
+    br00042_str = "br00042"
+    br00043_str = "br00043"
+    br00044_str = "br00044"
+    br00045_str = "br00045"
+    br00042_df = pandas_read_excel(stance0001_path, br00042_str)
+    br00043_df = pandas_read_excel(stance0001_path, br00043_str)
+    br00044_df = pandas_read_excel(stance0001_path, br00044_str)
+    br00045_df = pandas_read_excel(stance0001_path, br00045_str)
+    assert len(br00042_df) == 0
+    assert len(br00043_df) == 2
+    assert len(br00044_df) == 0
+    assert len(br00045_df) == 0

--- a/src/a18_etl_toolbox/transformers.py
+++ b/src/a18_etl_toolbox/transformers.py
@@ -141,8 +141,9 @@ def etl_input_dfs_to_brick_raw_tables(cursor: sqlite3_Cursor, input_dir: str):
         cursor.execute(create_table_sqlstr)
 
         for idx, row in df.iterrows():
+            row_dict = row.to_dict()
             nonconvertible_columns = get_nonconvertible_columns(
-                row.to_dict(), idea_sqlite_types
+                row_dict, idea_sqlite_types
             )
             error_message = None
             if nonconvertible_columns:

--- a/src/a20_world_logic/test/test_/test_world_.py
+++ b/src/a20_world_logic/test/test_/test_world_.py
@@ -216,4 +216,5 @@ def test_WorldUnit_get_db_path_ReturnsObj(env_dir_setup_cleanup):
     # WHEN
     a23_db_path = a23_world.get_db_path()
 
+    # THEN
     assert a23_db_path == create_path(a23_world._world_dir, "world.db")

--- a/src/a20_world_logic/test/test_/test_world_.py
+++ b/src/a20_world_logic/test/test_/test_world_.py
@@ -209,12 +209,12 @@ def test_WorldUnit_get_event_ReturnsObj(env_dir_setup_cleanup):
     assert x_world.get_event(e5_event_int) == e5_face_name
 
 
-def test_WorldUnit_get_db_path_ReturnsObj(env_dir_setup_cleanup):
+def test_WorldUnit_get_world_db_path_ReturnsObj(env_dir_setup_cleanup):
     # ESTABLISH
     a23_world = worldunit_shop("amy23", worlds_dir())
 
     # WHEN
-    a23_db_path = a23_world.get_db_path()
+    a23_db_path = a23_world.get_world_db_path()
 
     # THEN
     assert a23_db_path == create_path(a23_world._world_dir, "world.db")

--- a/src/a20_world_logic/test/test_etl_pipeline/test_input_to_clarity.py
+++ b/src/a20_world_logic/test/test_etl_pipeline/test_input_to_clarity.py
@@ -157,7 +157,7 @@ def test_WorldUnit_sheets_input_to_clarity_with_cursor_Scenario0_br000113Populat
         # self.calc_belief_bud_person_mandate_net_ledgers()
 
         # WHEN
-        fay_world.sheets_input_to_clarity_with_cursor(db_conn, cursor)
+        fay_world.sheets_input_to_clarity_with_cursor(cursor)
 
         # THEN
         # select_pidgin_core = f"SELECT * FROM {pidcore_sound_vld}"
@@ -333,7 +333,7 @@ def test_WorldUnit_sheets_input_to_clarity_with_cursor_Scenario1_PopulateBudPayR
         # self.calc_belief_bud_person_mandate_net_ledgers()
 
         # WHEN
-        fay_world.sheets_input_to_clarity_with_cursor(db_conn, cursor)
+        fay_world.sheets_input_to_clarity_with_cursor(cursor)
 
         # THEN
         assert get_row_count(cursor, br00113_raw) == 1
@@ -407,7 +407,7 @@ def test_WorldUnit_sheets_input_to_clarity_with_cursor_Scenario2_PopulateBeliefT
         assert not db_table_exists(cursor, belief_person_nets_str())
 
         # WHEN
-        fay_world.sheets_input_to_clarity_with_cursor(db_conn, cursor)
+        fay_world.sheets_input_to_clarity_with_cursor(cursor)
 
         # THEN
         assert get_row_count(cursor, belief_person_nets_str()) == 1
@@ -441,7 +441,7 @@ def test_WorldUnit_sheets_input_to_clarity_with_cursor_Scenario3_WhenNoBeliefIde
         assert os_path_exists(a23_ote1_csv_path) is False
 
         # WHEN
-        fay_world.sheets_input_to_clarity_with_cursor(db_conn, cursor)
+        fay_world.sheets_input_to_clarity_with_cursor(cursor)
 
     # THEN
     assert os_path_exists(a23_ote1_csv_path)
@@ -469,7 +469,7 @@ def test_WorldUnit_sheets_input_to_clarity_with_cursor_Scenario4_DeletesPrevious
         cursor = db_conn.cursor()
 
         # WHEN
-        fay_world.sheets_input_to_clarity_with_cursor(db_conn, cursor)
+        fay_world.sheets_input_to_clarity_with_cursor(cursor)
 
     # THEN
     assert os_path_exists(testing2_path)
@@ -553,7 +553,7 @@ def test_WorldUnit_sheets_input_to_clarity_with_cursor_Scenario5_CreatesFiles(
         assert count_dirs_files(fay_world.worlds_dir) == 5
 
         # WHEN
-        fay_world.sheets_input_to_clarity_with_cursor(db_conn, cursor)
+        fay_world.sheets_input_to_clarity_with_cursor(cursor)
 
         # THEN
         assert os_path_exists(wrong_a23_belief_dir) is False

--- a/src/a20_world_logic/test/test_etl_pipeline/test_input_to_clarity.py
+++ b/src/a20_world_logic/test/test_etl_pipeline/test_input_to_clarity.py
@@ -43,7 +43,7 @@ from src.a18_etl_toolbox.test._util.a18_str import (
     events_brick_agg_str,
     events_brick_valid_str,
 )
-from src.a18_etl_toolbox.tran_sqlstrs import create_prime_tablename
+from src.a18_etl_toolbox.tran_sqlstrs import create_prime_tablename as prime_tbl
 from src.a19_kpi_toolbox.test._util.a19_str import belief_kpi001_person_nets_str
 from src.a20_world_logic.test._util.a20_env import (
     env_dir_setup_cleanup,
@@ -83,34 +83,34 @@ def test_WorldUnit_sheets_input_to_clarity_with_cursor_Scenario0_br000113Populat
     br00113_agg = f"{br00113_str}_brick_agg"
     br00113_valid = f"{br00113_str}_brick_valid"
     events_brick_valid_tablename = events_brick_valid_str()
-    pidname_sound_raw = create_prime_tablename("pidname", "s", "raw")
-    pidname_sound_agg = create_prime_tablename("pidname", "s", "agg")
-    pidname_sound_vld = create_prime_tablename("pidname", "s", "vld")
-    pidcore_sound_raw = create_prime_tablename("pidcore", "s", "raw")
-    pidcore_sound_agg = create_prime_tablename("pidcore", "s", "agg")
-    pidcore_sound_vld = create_prime_tablename("pidcore", "s", "vld")
-    beliefunit_sound_raw = create_prime_tablename("beliefunit", "s", "raw")
-    beliefunit_sound_agg = create_prime_tablename("beliefunit", "s", "agg")
-    beliefunit_sound_vld = create_prime_tablename("beliefunit", "s", "vld")
-    blrunit_sound_put_raw = create_prime_tablename("believerunit", "s", "raw", "put")
-    blrunit_sound_put_agg = create_prime_tablename("believerunit", "s", "agg", "put")
-    blrunit_sound_put_vld = create_prime_tablename("believerunit", "s", "vld", "put")
-    blrpern_sound_put_raw = create_prime_tablename("blrpern", "s", "raw", "put")
-    blrpern_sound_put_agg = create_prime_tablename("blrpern", "s", "agg", "put")
-    blrpern_sound_put_vld = create_prime_tablename("blrpern", "s", "vld", "put")
-    beliefunit_voice_raw = create_prime_tablename("beliefunit", "v", "raw")
-    beliefunit_voice_agg = create_prime_tablename("beliefunit", "v", "agg")
-    blrunit_voice_put_raw = create_prime_tablename("believerunit", "v", "raw", "put")
-    blrunit_voice_put_agg = create_prime_tablename("believerunit", "v", "agg", "put")
-    blrpern_voice_put_raw = create_prime_tablename("blrpern", "v", "raw", "put")
-    blrpern_voice_put_agg = create_prime_tablename("blrpern", "v", "agg", "put")
+    pidname_sound_raw = prime_tbl("pidname", "s", "raw")
+    pidname_sound_agg = prime_tbl("pidname", "s", "agg")
+    pidname_sound_vld = prime_tbl("pidname", "s", "vld")
+    pidcore_sound_raw = prime_tbl("pidcore", "s", "raw")
+    pidcore_sound_agg = prime_tbl("pidcore", "s", "agg")
+    pidcore_sound_vld = prime_tbl("pidcore", "s", "vld")
+    beliefunit_sound_raw = prime_tbl("beliefunit", "s", "raw")
+    beliefunit_sound_agg = prime_tbl("beliefunit", "s", "agg")
+    beliefunit_sound_vld = prime_tbl("beliefunit", "s", "vld")
+    blrunit_sound_put_raw = prime_tbl("believerunit", "s", "raw", "put")
+    blrunit_sound_put_agg = prime_tbl("believerunit", "s", "agg", "put")
+    blrunit_sound_put_vld = prime_tbl("believerunit", "s", "vld", "put")
+    blrpern_sound_put_raw = prime_tbl("blrpern", "s", "raw", "put")
+    blrpern_sound_put_agg = prime_tbl("blrpern", "s", "agg", "put")
+    blrpern_sound_put_vld = prime_tbl("blrpern", "s", "vld", "put")
+    beliefunit_voice_raw = prime_tbl("beliefunit", "v", "raw")
+    beliefunit_voice_agg = prime_tbl("beliefunit", "v", "agg")
+    blrunit_voice_put_raw = prime_tbl("believerunit", "v", "raw", "put")
+    blrunit_voice_put_agg = prime_tbl("believerunit", "v", "agg", "put")
+    blrpern_voice_put_raw = prime_tbl("blrpern", "v", "raw", "put")
+    blrpern_voice_put_agg = prime_tbl("blrpern", "v", "agg", "put")
     mstr_dir = fay_world._belief_mstr_dir
     a23_json_path = create_belief_json_path(mstr_dir, a23_str)
     a23_e1_all_pack_path = create_event_all_pack_path(mstr_dir, a23_str, sue_inx, e3)
     a23_e1_expressed_pack_path = expressed_path(mstr_dir, a23_str, sue_inx, e3)
     a23_sue_gut_path = create_gut_path(mstr_dir, a23_str, sue_inx)
     a23_sue_job_path = create_job_path(mstr_dir, a23_str, sue_inx)
-    blrpern_job = create_prime_tablename("blrpern", "job", None)
+    blrpern_job = prime_tbl("blrpern", "job", None)
     last_run_metrics_path = create_last_run_metrics_path(mstr_dir)
 
     with sqlite3_connect(":memory:") as db_conn:
@@ -266,24 +266,24 @@ def test_WorldUnit_sheets_input_to_clarity_with_cursor_Scenario1_PopulateBudPayR
     br00113_agg = f"{br00113_str}_brick_agg"
     br00113_valid = f"{br00113_str}_brick_valid"
     events_brick_valid_tablename = events_brick_valid_str()
-    pidname_sound_raw = create_prime_tablename("pidname", "s", "raw")
-    pidname_sound_agg = create_prime_tablename("pidname", "s", "agg")
-    pidname_sound_vld = create_prime_tablename("pidname", "s", "vld")
-    pidcore_sound_raw = create_prime_tablename("pidcore", "s", "raw")
-    pidcore_sound_agg = create_prime_tablename("pidcore", "s", "agg")
-    pidcore_sound_vld = create_prime_tablename("pidcore", "s", "vld")
-    beliefunit_sound_raw = create_prime_tablename("beliefunit", "s", "raw")
-    beliefunit_sound_agg = create_prime_tablename("beliefunit", "s", "agg")
-    blrunit_sound_put_raw = create_prime_tablename("believerunit", "s", "raw", "put")
-    blrunit_sound_put_agg = create_prime_tablename("believerunit", "s", "agg", "put")
-    blrpern_sound_put_raw = create_prime_tablename("blrpern", "s", "raw", "put")
-    blrpern_sound_put_agg = create_prime_tablename("blrpern", "s", "agg", "put")
-    beliefunit_voice_raw = create_prime_tablename("beliefunit", "v", "raw")
-    beliefunit_voice_agg = create_prime_tablename("beliefunit", "v", "agg")
-    blrunit_voice_put_raw = create_prime_tablename("believerunit", "v", "raw", "put")
-    blrunit_voice_put_agg = create_prime_tablename("believerunit", "v", "agg", "put")
-    blrpern_voice_put_raw = create_prime_tablename("blrpern", "v", "raw", "put")
-    blrpern_voice_put_agg = create_prime_tablename("blrpern", "v", "agg", "put")
+    pidname_sound_raw = prime_tbl("pidname", "s", "raw")
+    pidname_sound_agg = prime_tbl("pidname", "s", "agg")
+    pidname_sound_vld = prime_tbl("pidname", "s", "vld")
+    pidcore_sound_raw = prime_tbl("pidcore", "s", "raw")
+    pidcore_sound_agg = prime_tbl("pidcore", "s", "agg")
+    pidcore_sound_vld = prime_tbl("pidcore", "s", "vld")
+    beliefunit_sound_raw = prime_tbl("beliefunit", "s", "raw")
+    beliefunit_sound_agg = prime_tbl("beliefunit", "s", "agg")
+    blrunit_sound_put_raw = prime_tbl("believerunit", "s", "raw", "put")
+    blrunit_sound_put_agg = prime_tbl("believerunit", "s", "agg", "put")
+    blrpern_sound_put_raw = prime_tbl("blrpern", "s", "raw", "put")
+    blrpern_sound_put_agg = prime_tbl("blrpern", "s", "agg", "put")
+    beliefunit_voice_raw = prime_tbl("beliefunit", "v", "raw")
+    beliefunit_voice_agg = prime_tbl("beliefunit", "v", "agg")
+    blrunit_voice_put_raw = prime_tbl("believerunit", "v", "raw", "put")
+    blrunit_voice_put_agg = prime_tbl("believerunit", "v", "agg", "put")
+    blrpern_voice_put_raw = prime_tbl("blrpern", "v", "raw", "put")
+    blrpern_voice_put_agg = prime_tbl("blrpern", "v", "agg", "put")
     mstr_dir = fay_world._belief_mstr_dir
     a23_json_path = create_belief_json_path(mstr_dir, a23_str)
     a23_e1_all_pack_path = create_event_all_pack_path(mstr_dir, a23_str, sue_inx, e3)
@@ -610,7 +610,7 @@ def test_WorldUnit_sheets_input_to_clarity_mstr_Scenario0_CreatesDatabaseFile(
     br00001_1df = DataFrame([br1row0], columns=br00001_columns)
     br00001_ex0_str = "example0_br00001"
     upsert_sheet(input_file_path, br00001_ex0_str, br00001_1df)
-    fay_db_path = fay_world.get_db_path()
+    fay_db_path = fay_world.get_world_db_path()
     assert not os_path_exists(fay_db_path)
 
     # WHEN
@@ -623,32 +623,24 @@ def test_WorldUnit_sheets_input_to_clarity_mstr_Scenario0_CreatesDatabaseFile(
         br00113_agg = f"{br00113_str}_brick_agg"
         br00113_valid = f"{br00113_str}_brick_valid"
         events_brick_valid_tablename = events_brick_valid_str()
-        pidname_sound_raw = create_prime_tablename("pidname", "s", "raw")
-        pidname_sound_agg = create_prime_tablename("pidname", "s", "agg")
-        pidname_sound_vld = create_prime_tablename("pidname", "s", "vld")
-        pidcore_sound_raw = create_prime_tablename("pidcore", "s", "raw")
-        pidcore_sound_agg = create_prime_tablename("pidcore", "s", "agg")
-        pidcore_sound_vld = create_prime_tablename("pidcore", "s", "vld")
-        beliefunit_sound_raw = create_prime_tablename("beliefunit", "s", "raw")
-        beliefunit_sound_agg = create_prime_tablename("beliefunit", "s", "agg")
-        blrunit_sound_put_raw = create_prime_tablename(
-            "believerunit", "s", "raw", "put"
-        )
-        blrunit_sound_put_agg = create_prime_tablename(
-            "believerunit", "s", "agg", "put"
-        )
-        blrpern_sound_put_raw = create_prime_tablename("blrpern", "s", "raw", "put")
-        blrpern_sound_put_agg = create_prime_tablename("blrpern", "s", "agg", "put")
-        beliefunit_voice_raw = create_prime_tablename("beliefunit", "v", "raw")
-        beliefunit_voice_agg = create_prime_tablename("beliefunit", "v", "agg")
-        blrunit_voice_put_raw = create_prime_tablename(
-            "believerunit", "v", "raw", "put"
-        )
-        blrunit_voice_put_agg = create_prime_tablename(
-            "believerunit", "v", "agg", "put"
-        )
-        blrpern_voice_put_raw = create_prime_tablename("blrpern", "v", "raw", "put")
-        blrpern_voice_put_agg = create_prime_tablename("blrpern", "v", "agg", "put")
+        pidname_sound_raw = prime_tbl("pidname", "s", "raw")
+        pidname_sound_agg = prime_tbl("pidname", "s", "agg")
+        pidname_sound_vld = prime_tbl("pidname", "s", "vld")
+        pidcore_sound_raw = prime_tbl("pidcore", "s", "raw")
+        pidcore_sound_agg = prime_tbl("pidcore", "s", "agg")
+        pidcore_sound_vld = prime_tbl("pidcore", "s", "vld")
+        beliefunit_sound_raw = prime_tbl("beliefunit", "s", "raw")
+        beliefunit_sound_agg = prime_tbl("beliefunit", "s", "agg")
+        blrunit_sound_put_raw = prime_tbl("believerunit", "s", "raw", "put")
+        blrunit_sound_put_agg = prime_tbl("believerunit", "s", "agg", "put")
+        blrpern_sound_put_raw = prime_tbl("blrpern", "s", "raw", "put")
+        blrpern_sound_put_agg = prime_tbl("blrpern", "s", "agg", "put")
+        beliefunit_voice_raw = prime_tbl("beliefunit", "v", "raw")
+        beliefunit_voice_agg = prime_tbl("beliefunit", "v", "agg")
+        blrunit_voice_put_raw = prime_tbl("believerunit", "v", "raw", "put")
+        blrunit_voice_put_agg = prime_tbl("believerunit", "v", "agg", "put")
+        blrpern_voice_put_raw = prime_tbl("blrpern", "v", "raw", "put")
+        blrpern_voice_put_agg = prime_tbl("blrpern", "v", "agg", "put")
 
         cursor = db_conn.cursor()
         assert get_row_count(cursor, br00113_raw) == 1

--- a/src/a20_world_logic/test/test_etl_pipeline/test_stance_to_clarity.py
+++ b/src/a20_world_logic/test/test_etl_pipeline/test_stance_to_clarity.py
@@ -69,7 +69,7 @@ def test_WorldUnit_stance_sheets_to_clarity_mstr_Scenario0_CreatesDatabaseFile(
     br00001_1df = DataFrame([br1row0], columns=br00001_columns)
     br00001_ex0_str = "example0_br00001"
     upsert_sheet(input_file_path, br00001_ex0_str, br00001_1df)
-    fay_db_path = fay_world.get_db_path()
+    fay_db_path = fay_world.get_world_db_path()
     assert not os_path_exists(fay_db_path)
 
     # WHEN

--- a/src/a20_world_logic/world.py
+++ b/src/a20_world_logic/world.py
@@ -69,7 +69,7 @@ class WorldUnit:
     _events: dict[EventInt, FaceName] = None
     _pidgin_events: dict[FaceName, set[EventInt]] = None
 
-    def get_db_path(self) -> str:
+    def get_world_db_path(self) -> str:
         "Returns path: world_dir/world.db"
         return create_world_db_path(self._world_dir)
 
@@ -110,7 +110,7 @@ class WorldUnit:
         etl_create_bud_mandate_ledgers(mstr_dir)
 
     def sheets_input_to_clarity_mstr(self):
-        with sqlite3_connect(self.get_db_path()) as db_conn:
+        with sqlite3_connect(self.get_world_db_path()) as db_conn:
             cursor = db_conn.cursor()
             self.sheets_input_to_clarity_with_cursor(cursor)
             db_conn.commit()
@@ -171,7 +171,7 @@ class WorldUnit:
         create_calendar_markdown_files(self._belief_mstr_dir, self.output_dir)
 
     def create_kpi_csvs(self):
-        create_kpi_csvs(self.get_db_path(), self.output_dir)
+        create_kpi_csvs(self.get_world_db_path(), self.output_dir)
 
     def get_dict(self) -> dict:
         return {

--- a/src/a20_world_logic/world.py
+++ b/src/a20_world_logic/world.py
@@ -166,7 +166,7 @@ class WorldUnit:
         # it should be the database because that's the end of the core pipeline so it should
         # be the source of truth.
         create_stance0001_file(
-            self._belief_mstr_dir, self.output_dir, self.world_name, prettify_excel_bool
+            self._world_dir, self.output_dir, self.world_name, prettify_excel_bool
         )
         create_calendar_markdown_files(self._belief_mstr_dir, self.output_dir)
 

--- a/src/a20_world_logic/world.py
+++ b/src/a20_world_logic/world.py
@@ -10,7 +10,7 @@ from src.a01_term_logic.term import BeliefLabel, EventInt, FaceName
 from src.a11_bud_logic.bud import TimeLinePoint
 from src.a15_belief_logic.belief import BeliefUnit
 from src.a17_idea_logic.idea_db_tool import update_event_int_in_excel_files
-from src.a18_etl_toolbox.a18_path import create_world_db_path
+from src.a18_etl_toolbox.a18_path import create_belief_mstr_path, create_world_db_path
 from src.a18_etl_toolbox.stance_tool import create_stance0001_file
 from src.a18_etl_toolbox.transformers import (
     add_belief_timeline_to_guts,
@@ -89,7 +89,7 @@ class WorldUnit:
     def _set_world_dirs(self):
         self._world_dir = create_path(self.worlds_dir, self.world_name)
         self._brick_dir = create_path(self._world_dir, "brick")
-        self._belief_mstr_dir = create_path(self._world_dir, "belief_mstr")
+        self._belief_mstr_dir = create_belief_mstr_path(self._world_dir)
         set_dir(self._world_dir)
         set_dir(self._brick_dir)
         set_dir(self._belief_mstr_dir)

--- a/src/a20_world_logic/world.py
+++ b/src/a20_world_logic/world.py
@@ -10,6 +10,7 @@ from src.a01_term_logic.term import BeliefLabel, EventInt, FaceName
 from src.a11_bud_logic.bud import TimeLinePoint
 from src.a15_belief_logic.belief import BeliefUnit
 from src.a17_idea_logic.idea_db_tool import update_event_int_in_excel_files
+from src.a18_etl_toolbox.a18_path import create_world_db_path
 from src.a18_etl_toolbox.stance_tool import create_stance0001_file
 from src.a18_etl_toolbox.transformers import (
     add_belief_timeline_to_guts,
@@ -70,8 +71,7 @@ class WorldUnit:
 
     def get_db_path(self) -> str:
         "Returns path: world_dir/world.db"
-
-        return create_path(self._world_dir, "world.db")
+        return create_world_db_path(self._world_dir)
 
     def set_event(self, event_int: EventInt, face_name: FaceName):
         self._events[event_int] = face_name

--- a/src/a20_world_logic/world.py
+++ b/src/a20_world_logic/world.py
@@ -112,7 +112,7 @@ class WorldUnit:
     def sheets_input_to_clarity_mstr(self):
         with sqlite3_connect(self.get_db_path()) as db_conn:
             cursor = db_conn.cursor()
-            self.sheets_input_to_clarity_with_cursor(db_conn, cursor)
+            self.sheets_input_to_clarity_with_cursor(cursor)
             db_conn.commit()
         db_conn.close()
 
@@ -120,15 +120,11 @@ class WorldUnit:
         update_event_int_in_excel_files(self._input_dir, 1)
         self.sheets_input_to_clarity_mstr()
 
-    def sheets_input_to_clarity_with_cursor(
-        self,
-        db_conn: sqlite3_Connection,
-        cursor: sqlite3_Cursor,
-    ):
+    def sheets_input_to_clarity_with_cursor(self, cursor: sqlite3_Cursor):
         delete_dir(self._belief_mstr_dir)
         set_dir(self._belief_mstr_dir)
         # collect excel file data into central location
-        etl_input_dfs_to_brick_raw_tables(db_conn, self._input_dir)
+        etl_input_dfs_to_brick_raw_tables(cursor, self._input_dir)
         # brick raw to sound raw, check by event_ints
         etl_brick_raw_tables_to_brick_agg_tables(cursor)
         etl_brick_agg_tables_to_events_brick_agg_table(cursor)


### PR DESCRIPTION
## Summary by Sourcery

Refactor ETL tooling and world logic to introduce a unified world context, replacing the belief master directory with a world directory and world database, simplify ETL APIs, and extend stance processing to include pidgin data; update paths, table naming, CLI export, and tests to align with the new abstractions.

Enhancements:
- Add utilities for world‐scoped paths (world_db, belief_mstr, last_run_metrics) and update WorldUnit to use them
- Rename WorldUnit.get_db_path to get_world_db_path and propagate change in CLI, ETL and tests
- Simplify sheets_input_to_clarity_with_cursor API to take only a cursor and adjust internal ETL calls
- Extend stance ETL to load pidgin rows from the world database in collect_stance_csv_strs and reflect them in create_stance0001_file
- Standardize table naming by replacing create_prime_tablename with prime_tbl
- Minor improvement in transformers to reuse row.to_dict for nonconvertible column checks

Tests:
- Revise and expand tests to use world_dir/world_db paths across a18_etl_toolbox and a20_world_logic
- Add test coverage for pidgin row integration in stance CSV generation and Excel output