### PR TITLE
812 create cli tool for executing mud to clarity etl

### DIFF
--- a/src/a20_world_logic/test/test_etl_pipeline/test_stance_to_clarity.py
+++ b/src/a20_world_logic/test/test_etl_pipeline/test_stance_to_clarity.py
@@ -4,7 +4,7 @@ from sqlite3 import connect as sqlite3_connect
 from src.a00_data_toolbox.db_toolbox import get_row_count
 from src.a00_data_toolbox.file_toolbox import create_path
 from src.a06_believer_logic.test._util.a06_str import person_name_str
-from src.a09_pack_logic.test._util.a09_str import face_name_str
+from src.a09_pack_logic.test._util.a09_str import event_int_str, face_name_str
 from src.a11_bud_logic.test._util.a11_str import (
     belief_label_str,
     believer_name_str,
@@ -12,19 +12,25 @@ from src.a11_bud_logic.test._util.a11_str import (
     celldepth_str,
     quota_str,
 )
+from src.a15_belief_logic.test._util.a15_str import (
+    cumulative_minute_str,
+    hour_label_str,
+)
 from src.a16_pidgin_logic.test._util.a16_str import inx_name_str, otx_name_str
-from src.a17_idea_logic.idea_db_tool import upsert_sheet
+from src.a17_idea_logic.idea_db_tool import create_idea_sorted_table, upsert_sheet
 from src.a18_etl_toolbox.test._util.a18_str import (
     belief_ote1_agg_str,
+    brick_agg_str,
     events_brick_agg_str,
     events_brick_valid_str,
 )
 from src.a18_etl_toolbox.tran_sqlstrs import create_prime_tablename
+from src.a18_etl_toolbox.transformers import get_max_brick_agg_event_int
 from src.a20_world_logic.test._util.a20_env import (
     env_dir_setup_cleanup,
     get_module_temp_dir as worlds_dir,
 )
-from src.a20_world_logic.world import worldunit_shop
+from src.a20_world_logic.world import WorldUnit, worldunit_shop
 
 
 def test_WorldUnit_stance_sheets_to_clarity_mstr_Scenario0_CreatesDatabaseFile(
@@ -135,3 +141,82 @@ def test_WorldUnit_stance_sheets_to_clarity_mstr_Scenario0_CreatesDatabaseFile(
         assert get_row_count(cursor, blrpern_voice_put_agg) == 1
         assert get_row_count(cursor, belief_ote1_agg_str()) == 1
     db_conn.close()
+
+
+def create_brick_agg_record(world: WorldUnit, event_int: int):
+    sue_str = "Sue"
+    minute_360 = 360
+    hour6am = "6am"
+    agg_br00003_tablename = f"br00003_{brick_agg_str()}"
+    agg_br00003_columns = [
+        event_int_str(),
+        face_name_str(),
+        belief_label_str(),
+        cumulative_minute_str(),
+        hour_label_str(),
+    ]
+    with sqlite3_connect(world.get_world_db_path()) as db_conn:
+        cursor = db_conn.cursor()
+        create_idea_sorted_table(cursor, agg_br00003_tablename, agg_br00003_columns)
+        insert_into_clause = f"""INSERT INTO {agg_br00003_tablename} (
+  {event_int_str()}
+, {face_name_str()}
+, {belief_label_str()}
+, {cumulative_minute_str()}
+, {hour_label_str()}
+)"""
+        values_clause = f"""VALUES ('{event_int}', '{sue_str}', '{world.world_name}', '{minute_360}', '{hour6am}');"""
+        insert_sqlstr = f"{insert_into_clause} {values_clause}"
+        cursor.execute(insert_sqlstr)
+    db_conn.close()
+
+
+def test_WorldUnit_stance_sheets_to_clarity_mstr_Scenario1_DatabaseFileExists(
+    env_dir_setup_cleanup,
+):  # sourcery skip: extract-method
+    # ESTABLISH:
+    fay_str = "Fay34"
+    fay_world = worldunit_shop(fay_str, worlds_dir())
+    event5 = 5
+    create_brick_agg_record(fay_world, event5)
+    # delete_dir(fay_world.worlds_dir)
+    sue_str = "Sue"
+    sue_inx = "Suzy"
+    ex_filename = "stance_Faybob.xlsx"
+    input_file_path = create_path(fay_world._input_dir, ex_filename)
+    br00113_columns = [
+        face_name_str(),
+        belief_label_str(),
+        believer_name_str(),
+        person_name_str(),
+        otx_name_str(),
+        inx_name_str(),
+    ]
+    a23_str = "amy2345"
+    br00113_str = "br00113"
+    br00113row0 = [sue_str, a23_str, sue_str, sue_str, sue_str, sue_inx]
+    br00113_df = DataFrame([br00113row0], columns=br00113_columns)
+    br00113_ex0_str = f"example0_{br00113_str}"
+    upsert_sheet(input_file_path, br00113_ex0_str, br00113_df)
+    fay_db_path = fay_world.get_world_db_path()
+    assert os_path_exists(fay_db_path)
+    with sqlite3_connect(fay_db_path) as db_conn0:
+        cursor0 = db_conn0.cursor()
+        assert get_max_brick_agg_event_int(cursor0) == event5
+    db_conn0.close()
+    assert os_path_exists(input_file_path)
+
+    # WHEN
+    fay_world.stance_sheets_to_clarity_mstr()
+
+    # THEN
+    assert os_path_exists(fay_db_path)
+    with sqlite3_connect(fay_db_path) as db_conn1:
+        cursor1 = db_conn1.cursor()
+        assert get_max_brick_agg_event_int(cursor1) != event5
+        assert get_max_brick_agg_event_int(cursor1) == event5 + 1
+        select_sqlstr = f"SELECT * FROM {events_brick_agg_str()}"
+        cursor1.execute(select_sqlstr)
+        print(cursor1.fetchall())
+    db_conn1.close()
+    assert not os_path_exists(input_file_path)

--- a/src/a20_world_logic/world.py
+++ b/src/a20_world_logic/world.py
@@ -94,12 +94,6 @@ class WorldUnit:
         set_dir(self._brick_dir)
         set_dir(self._belief_mstr_dir)
 
-    def input_dfs_to_brick_raw_tables(self, conn: sqlite3_Connection):
-        etl_input_dfs_to_brick_raw_tables(conn, self._input_dir)
-
-    def event_pack_json_to_event_inherited_believerunits(self):
-        etl_event_pack_json_to_event_inherited_believerunits(self._belief_mstr_dir)
-
     def calc_belief_bud_person_mandate_net_ledgers(self):
         mstr_dir = self._belief_mstr_dir
         etl_create_buds_root_cells(mstr_dir)

--- a/src/a20_world_logic/world.py
+++ b/src/a20_world_logic/world.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from os.path import exists as os_path_exists
 from sqlite3 import (
     Connection as sqlite3_Connection,
     Cursor as sqlite3_Cursor,
@@ -43,6 +44,7 @@ from src.a18_etl_toolbox.transformers import (
     etl_voice_agg_to_event_believer_csvs,
     etl_voice_raw_tables_to_belief_ote1_agg,
     etl_voice_raw_tables_to_voice_agg_tables,
+    get_max_brick_agg_event_int,
 )
 from src.a19_kpi_toolbox.kpi_mstr import (
     create_calendar_markdown_files,
@@ -109,9 +111,17 @@ class WorldUnit:
             self.sheets_input_to_clarity_with_cursor(cursor)
             db_conn.commit()
         db_conn.close()
+        delete_dir(self._input_dir)
 
     def stance_sheets_to_clarity_mstr(self):
-        update_event_int_in_excel_files(self._input_dir, 1)
+        max_brick_agg_event_int = 0
+        if os_path_exists(self.get_world_db_path()):
+            with sqlite3_connect(self.get_world_db_path()) as db_conn0:
+                cursor0 = db_conn0.cursor()
+                max_brick_agg_event_int = get_max_brick_agg_event_int(cursor0)
+            db_conn0.close()
+        next_event_int = max_brick_agg_event_int + 1
+        update_event_int_in_excel_files(self._input_dir, next_event_int)
         self.sheets_input_to_clarity_mstr()
 
     def sheets_input_to_clarity_with_cursor(self, cursor: sqlite3_Cursor):


### PR DESCRIPTION
## Summary by Sourcery

Enable incremental event numbering and input cleanup for the stance-to-clarity ETL pipeline, remove obsolete ETL methods, and add tests to verify the new behaviors

Enhancements:
- Update test imports to include brick aggregate and time-label utilities from ETL toolbox

Tests:
- Add create_brick_agg_record helper to seed brick aggregate data in tests
- Add scenario test to verify event integer incrementation and ensure input files are cleaned up after running stance_sheets_to_clarity_mstr