### PR TITLE
812 create cli tool for executing mud to clarity etl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,9 +135,6 @@ dmypy.json
 cython_debug/
 
 # local testing
-main_cli_app2.py
-src/keep/examples/keeps/ex4/
-src/keep/examples/keeps/ex6/
-sql_workspace/*
+*.xlsx#
 src/a20_world_logic/test/test_z_examples/output
 src/a20_world_logic/test/test_z_examples/worlds

--- a/src/a00_data_toolbox/csv_toolbox.py
+++ b/src/a00_data_toolbox/csv_toolbox.py
@@ -17,7 +17,7 @@ def open_csv_with_types(csv_path, column_types):
 
     :param csv_path: Path to the CSV file.
     :param column_types: Dictionary mapping column names to data types.
-    :return: List of tuples with correctly typed values.
+    :return: List of tuples with typed values.
     """
     with open(csv_path, newline="", encoding="utf-8") as csv_file:
         reader = csv_reader(csv_file)

--- a/src/a00_data_toolbox/test/test__file_.py
+++ b/src/a00_data_toolbox/test/test__file_.py
@@ -260,7 +260,7 @@ def test_save_file_DoesNotRequireSeperateFilename(env_dir_setup_cleanup):
     assert os_path_exist(swim_file_path)
 
 
-def test_get_dir_file_strs_correctlyGrabsFileData(env_dir_setup_cleanup):
+def test_get_dir_file_strs_GrabsFileData(env_dir_setup_cleanup):
     # ESTABLISH
     env_dir = get_module_temp_dir()
     x1_filename = "x1.txt"
@@ -500,13 +500,13 @@ def test_is_path_valid_ReturnsObj():
 
 def test_can_usser_edit_paths_ReturnsObj():
     # ESTABLISH / WHEN / THEN
-    """I am not able to test this correctly. For now make sure it runs."""
+    """I am not able to test. For now make sure it runs."""
     assert can_usser_edit_paths()
 
 
 def test_is_path_existent_or_creatable_ReturnsObj():
     # ESTABLISH / WHEN / THEN
-    """I am not able to test this correctly. For now make sure it runs."""
+    """I am not able to test. For now make sure it runs."""
     assert is_path_existent_or_creatable("run")
     assert (
         platform_system() == "Windows"
@@ -517,7 +517,7 @@ def test_is_path_existent_or_creatable_ReturnsObj():
 
 def test_is_path_probably_creatable_ReturnsObj():
     # ESTABLISH / WHEN / THEN
-    """I am not able to test this correctly. For now make sure it runs."""
+    """I am not able to test. For now make sure it runs."""
     assert is_path_probably_creatable("run")
     assert is_path_probably_creatable("run/trail?") is False
     assert is_path_probably_creatable("run///trail") is False
@@ -525,7 +525,7 @@ def test_is_path_probably_creatable_ReturnsObj():
 
 def test_is_path_existent_or_probably_creatable_ReturnsObj():
     # ESTABLISH / WHEN / THEN
-    """I am not able to test this correctly. For now make sure it runs."""
+    """I am not able to test. For now make sure it runs."""
     assert is_path_existent_or_probably_creatable("run")
     assert is_path_existent_or_probably_creatable("run/trail?") is False
     assert is_path_existent_or_probably_creatable("run///trail") is False

--- a/src/a00_data_toolbox/test/test_db_tool_.py
+++ b/src/a00_data_toolbox/test/test_db_tool_.py
@@ -414,7 +414,7 @@ def test_insert_csv_ChangesDBState(env_dir_setup_cleanup):
         # WHEN Call the function to insert data from the CSV file into the database
         insert_csv(csv_path, conn, test_tablename)
 
-        # THEN Verify the data was inserted correctly
+        # THEN Verify the data was inserted
         cursor.execute(f"SELECT * FROM {test_tablename}")
         rows = cursor.fetchall()
         expected_data = [
@@ -439,7 +439,7 @@ def test_insert_csv_ChangesDBState_WhenPassedCursorObj(
         # WHEN
         insert_csv(csv_path, cursor, test_tablename)
 
-        # THEN Verify the data was inserted correctly
+        # THEN Verify the data was inserted
         cursor.execute(f"SELECT * FROM {test_tablename}")
         rows = cursor.fetchall()
         expected_data = [
@@ -499,7 +499,7 @@ def test_create_table_from_csv_ChangesDBState(env_dir_setup_cleanup):
         # WHEN
         create_table_from_csv(test_csv_filepath, conn, new_table, column_types)
 
-        # THEN Verify the table was created correctly
+        # THEN Verify the table was created
         cursor.execute(f"PRAGMA table_info({new_table})")
         columns = cursor.fetchall()
         expected_columns = [

--- a/src/a01_term_logic/test/test_rope_core.py
+++ b/src/a01_term_logic/test/test_rope_core.py
@@ -147,7 +147,7 @@ def test_rope_create_rope_ReturnsObj_Scenario5():
     assert create_rope(roses_rope, None) == roses_rope
 
 
-def test_rope_is_sub_rope_correctlyReturnsBool():
+def test_rope_is_sub_rope_ReturnsObj_Scenario0_WhenNone_default_knot_if_None():
     # WHEN
     casa_str = "casa"
     casa_rope = f"{root_rope()}{default_knot_if_None()}{casa_str}"
@@ -162,6 +162,31 @@ def test_rope_is_sub_rope_correctlyReturnsBool():
     assert is_sub_rope(cleaning_rope, cleaning_rope)
     assert is_sub_rope(laundrys_rope, cleaning_rope)
     assert is_sub_rope(cleaning_rope, laundrys_rope) is False
+
+
+def test_rope_is_sub_rope_ReturnsObj_Scenario1_WhenNone_default_knot_if_None():
+    # WHEN
+    casa_str = "casa"
+    slash_str = "/"
+    casa_rope = f"{root_rope()}{slash_str}{casa_str}"
+    cleaning_str = "cleaning"
+    slash_cleaning_rope = f"{casa_rope}{slash_str}{cleaning_str}"
+    default_cleaning_rope = f"{casa_rope}{default_knot_if_None()}{cleaning_str}"
+    laundrys_str = "laundrys"
+    slash_laundrys_rope = f"{slash_cleaning_rope}{slash_str}{laundrys_str}"
+    default_laundrys_rope = f"{default_cleaning_rope}{slash_str}{laundrys_str}"
+    print(f"{slash_cleaning_rope=}")
+    print(f"{slash_laundrys_rope=}")
+    print(f"{default_cleaning_rope=}")
+    print(f"{default_laundrys_rope=}")
+
+    # WHEN / THEN
+    assert is_sub_rope(slash_cleaning_rope, slash_cleaning_rope)
+    assert is_sub_rope(slash_laundrys_rope, slash_cleaning_rope)
+    assert is_sub_rope(slash_cleaning_rope, slash_laundrys_rope) is False
+    assert is_sub_rope(slash_cleaning_rope, default_cleaning_rope) is False
+    assert is_sub_rope(slash_laundrys_rope, default_cleaning_rope) is False
+    assert is_sub_rope(slash_cleaning_rope, default_laundrys_rope) is False
 
 
 def test_rope_rebuild_rope_ReturnsCorrectRopeTerm():

--- a/src/a06_believer_logic/test/test_believer_settle/test_z_agenda.py
+++ b/src/a06_believer_logic/test/test_believer_settle/test_z_agenda.py
@@ -386,7 +386,7 @@ def test_believerunit_get_from_json_CorrectlyLoadsTaskFromJSON():
     assert len(yao_believer.get_agenda_dict()) > 0
 
 
-def test_BelieverUnit_set_fact_Isue116Resolved_correctlySetsChoreAsTrue():
+def test_BelieverUnit_set_fact_Isue116Resolved_SetsChoreAsTrue():
     # ESTABLISH
     yao_believer = believerunit_v002()
     print(f"{yao_believer.get_reason_rcontexts()=}")

--- a/src/a06_believer_logic/test/test_believer_settle/test_z_tree_metrics.py
+++ b/src/a06_believer_logic/test/test_believer_settle/test_z_tree_metrics.py
@@ -20,7 +20,7 @@ def test_BelieverUnit_get_tree_metrics_exists():
     assert zia_believer_tree_metrics.awardlinks_metrics is not None
 
 
-def test_BelieverUnit_get_tree_metrics_get_plan_uid_max_correctlyGetsMaxPlanUID():
+def test_BelieverUnit_get_tree_metrics_get_plan_uid_max_GetsMaxPlanUID():
     # ESTABLISH
     yao_believer = believerunit_v001()
 

--- a/src/a12_hub_toolbox/a12_path.py
+++ b/src/a12_hub_toolbox/a12_path.py
@@ -254,3 +254,18 @@ def create_job_path(
     believer_dir = create_path(believers_dir, believer_name)
     job_dir = create_path(believer_dir, "job")
     return create_path(job_dir, f"{believer_name}.json")
+
+
+def get_keep_dutys_path(x_keep_path: str) -> str:
+    """Returns path: belief_mstr_dir\\beliefs\\belief_label\\believers\\believer_name\\keeps\\keep_rope_dirs\\dutys"""
+    return create_path(x_keep_path, "dutys")
+
+
+def get_keep_visions_path(x_keep_path: str) -> str:
+    """Returns path: belief_mstr_dir\\beliefs\\belief_label\\believers\\believer_name\\keeps\\keep_rope_dirs\\visions"""
+    return create_path(x_keep_path, "visions")
+
+
+def get_keep_grades_path(x_keep_path: str) -> str:
+    """Returns path: belief_mstr_dir\\beliefs\\belief_label\\believers\\believer_name\\keeps\\keep_rope_dirs\\grades"""
+    return create_path(x_keep_path, "grades")

--- a/src/a12_hub_toolbox/a12_path.py
+++ b/src/a12_hub_toolbox/a12_path.py
@@ -1,5 +1,6 @@
-from src.a00_data_toolbox.file_toolbox import create_path
-from src.a01_term_logic.term import BelieverName, LabelTerm
+from src.a00_data_toolbox.file_toolbox import create_directory_path, create_path
+from src.a01_term_logic.rope import get_all_rope_labels, rebuild_rope
+from src.a01_term_logic.term import BeliefLabel, BelieverName, LabelTerm
 
 BELIEF_FILENAME = "belief.json"
 BUDUNIT_FILENAME = "budunit.json"
@@ -57,6 +58,40 @@ def create_keeps_dir_path(
     believers_dir = create_path(belief_dir, "believers")
     believer_dir = create_path(believers_dir, believer_name)
     return create_path(believer_dir, "keeps")
+
+
+def create_keep_rope_path(
+    mstr_dir: str,
+    believer_name: BelieverName,
+    belief_label: BeliefLabel,
+    keep_rope: LabelTerm,
+    knot: str,
+) -> str:
+    """Returns path: belief_mstr_dir\\beliefs\\belief_label\\believers\\believer_name\\keeps\\planroot\\level1_label"""
+    keep_root = "planroot"
+    keep_rope = rebuild_rope(keep_rope, belief_label, keep_root)
+    x_list = get_all_rope_labels(keep_rope, knot)
+    keep_sub_path = create_directory_path(x_list=[*x_list])
+    keeps_dir = create_keeps_dir_path(mstr_dir, belief_label, believer_name)
+    return create_path(keeps_dir, keep_sub_path)
+
+
+# TODO relace "keeps\\keep_rope_dirs\\" with "keeps\\planroot\\level1_label\\"
+def get_keep_dutys_path(x_keep_path: str) -> str:
+    """Returns path: belief_mstr_dir\\beliefs\\belief_label\\believers\\believer_name\\keeps\\keep_rope_dirs\\dutys"""
+    return create_path(x_keep_path, "dutys")
+
+
+# TODO relace "keeps\\keep_rope_dirs\\" with "keeps\\planroot\\level1_label\\"
+def get_keep_visions_path(x_keep_path: str) -> str:
+    """Returns path: belief_mstr_dir\\beliefs\\belief_label\\believers\\believer_name\\keeps\\keep_rope_dirs\\visions"""
+    return create_path(x_keep_path, "visions")
+
+
+# TODO relace "keeps\\keep_rope_dirs\\" with "keeps\\planroot\\level1_label\\"
+def get_keep_grades_path(x_keep_path: str) -> str:
+    """Returns path: belief_mstr_dir\\beliefs\\belief_label\\believers\\believer_name\\keeps\\keep_rope_dirs\\grades"""
+    return create_path(x_keep_path, "grades")
 
 
 def create_atoms_dir_path(
@@ -254,18 +289,3 @@ def create_job_path(
     believer_dir = create_path(believers_dir, believer_name)
     job_dir = create_path(believer_dir, "job")
     return create_path(job_dir, f"{believer_name}.json")
-
-
-def get_keep_dutys_path(x_keep_path: str) -> str:
-    """Returns path: belief_mstr_dir\\beliefs\\belief_label\\believers\\believer_name\\keeps\\keep_rope_dirs\\dutys"""
-    return create_path(x_keep_path, "dutys")
-
-
-def get_keep_visions_path(x_keep_path: str) -> str:
-    """Returns path: belief_mstr_dir\\beliefs\\belief_label\\believers\\believer_name\\keeps\\keep_rope_dirs\\visions"""
-    return create_path(x_keep_path, "visions")
-
-
-def get_keep_grades_path(x_keep_path: str) -> str:
-    """Returns path: belief_mstr_dir\\beliefs\\belief_label\\believers\\believer_name\\keeps\\keep_rope_dirs\\grades"""
-    return create_path(x_keep_path, "grades")

--- a/src/a12_hub_toolbox/hubunit.py
+++ b/src/a12_hub_toolbox/hubunit.py
@@ -55,6 +55,9 @@ from src.a12_hub_toolbox.a12_path import (
     create_atoms_dir_path,
     create_keeps_dir_path,
     create_packs_dir_path,
+    get_keep_dutys_path,
+    get_keep_grades_path,
+    get_keep_visions_path,
     treasury_filename,
 )
 from src.a12_hub_toolbox.basis_believers import get_default_job
@@ -81,18 +84,6 @@ class get_keep_ropesException(Exception):
 
 class _keep_ropeMissingException(Exception):
     pass
-
-
-def get_keep_dutys_dir(x_keep_path: str) -> str:
-    return create_path(x_keep_path, "dutys")
-
-
-def get_keep_visions_dir(x_keep_path: str) -> str:
-    return create_path(x_keep_path, "visions")
-
-
-def get_keep_grades_dir(x_keep_path: str) -> str:
-    return create_path(x_keep_path, "grades")
 
 
 @dataclass
@@ -351,42 +342,42 @@ class HubUnit:
         return create_path(self.keep_path(), treasury_filename())
 
     def duty_path(self, believer_name: BelieverName) -> str:
-        "Returns path: dutys_dir/believer_name"
+        "Returns path: dutys_path/believer_name"
 
-        return create_path(self.dutys_dir(), get_json_filename(believer_name))
+        return create_path(self.dutys_path(), get_json_filename(believer_name))
 
     def vision_path(self, believer_name: BelieverName) -> str:
-        "Returns path: visions_dir/believer_name.json"
+        "Returns path: visions_path/believer_name.json"
 
-        return create_path(self.visions_dir(), get_json_filename(believer_name))
+        return create_path(self.visions_path(), get_json_filename(believer_name))
 
     def grade_path(self, believer_name: BelieverName) -> str:
-        "Returns path: grades_dir/believer_name.json"
+        "Returns path: grades_path/believer_name.json"
 
-        return create_path(self.grades_dir(), get_json_filename(believer_name))
+        return create_path(self.grades_path(), get_json_filename(believer_name))
 
-    def dutys_dir(self) -> str:
-        return get_keep_dutys_dir(self.keep_path())
+    def dutys_path(self) -> str:
+        return get_keep_dutys_path(self.keep_path())
 
-    def visions_dir(self) -> str:
-        return get_keep_visions_dir(self.keep_path())
+    def visions_path(self) -> str:
+        return get_keep_visions_path(self.keep_path())
 
-    def grades_dir(self) -> str:
-        return get_keep_grades_dir(self.keep_path())
+    def grades_path(self) -> str:
+        return get_keep_grades_path(self.keep_path())
 
-    def get_visions_dir_filenames_list(self) -> list[str]:
+    def get_visions_path_filenames_list(self) -> list[str]:
         try:
-            return list(get_dir_file_strs(self.visions_dir(), True).keys())
+            return list(get_dir_file_strs(self.visions_path(), True).keys())
         except Exception:
             return []
 
     def save_duty_believer(self, x_believer: BelieverUnit) -> None:
         x_filename = get_json_filename(x_believer.believer_name)
-        save_file(self.dutys_dir(), x_filename, x_believer.get_json())
+        save_file(self.dutys_path(), x_filename, x_believer.get_json())
 
     def save_vision_believer(self, x_believer: BelieverUnit) -> None:
         x_filename = get_json_filename(x_believer.believer_name)
-        save_file(self.visions_dir(), x_filename, x_believer.get_json())
+        save_file(self.visions_path(), x_filename, x_believer.get_json())
 
     def initialize_job_file(self, gut: BelieverUnit) -> None:
         save_job_file(self.belief_mstr_dir, get_default_job(gut))
@@ -400,13 +391,13 @@ class HubUnit:
     def get_duty_believer(self, believer_name: BelieverName) -> BelieverUnit:
         if self.duty_file_exists(believer_name) is False:
             return None
-        file_content = open_file(self.dutys_dir(), get_json_filename(believer_name))
+        file_content = open_file(self.dutys_path(), get_json_filename(believer_name))
         return believerunit_get_from_json(file_content)
 
     def get_vision_believer(self, believer_name: BelieverName) -> BelieverUnit:
         if self.vision_file_exists(believer_name) is False:
             return None
-        file_content = open_file(self.visions_dir(), get_json_filename(believer_name))
+        file_content = open_file(self.visions_path(), get_json_filename(believer_name))
         return believerunit_get_from_json(file_content)
 
     def delete_duty_file(self, believer_name: BelieverName) -> None:

--- a/src/a12_hub_toolbox/hubunit.py
+++ b/src/a12_hub_toolbox/hubunit.py
@@ -4,7 +4,6 @@ from os.path import exists as os_path_exists
 from sqlite3 import connect as sqlite3_connect
 from src.a00_data_toolbox.dict_toolbox import get_empty_set_if_None
 from src.a00_data_toolbox.file_toolbox import (
-    create_directory_path,
     create_path,
     delete_dir,
     get_dir_file_strs,
@@ -15,15 +14,10 @@ from src.a00_data_toolbox.file_toolbox import (
     save_file,
     set_dir,
 )
-from src.a01_term_logic.rope import (
-    get_all_rope_labels,
-    rebuild_rope,
-    validate_labelterm,
-)
+from src.a01_term_logic.rope import validate_labelterm
 from src.a01_term_logic.term import (
     BeliefLabel,
     BelieverName,
-    LabelTerm,
     RopeTerm,
     default_knot_if_None,
 )
@@ -53,6 +47,7 @@ from src.a09_pack_logic.pack import (
 )
 from src.a12_hub_toolbox.a12_path import (
     create_atoms_dir_path,
+    create_keep_rope_path,
     create_keeps_dir_path,
     create_packs_dir_path,
     get_keep_dutys_path,
@@ -331,7 +326,13 @@ class HubUnit:
             raise _keep_ropeMissingException(
                 f"HubUnit '{self.believer_name}' cannot save to keep_path because it does not have keep_rope."
             )
-        return create_keep_rope_path(self, self.keep_rope)
+        return create_keep_rope_path(
+            self.belief_mstr_dir,
+            self.believer_name,
+            self.belief_label,
+            self.keep_rope,
+            self.knot,
+        )
 
     def create_keep_path_if_missing(self):
         set_dir(self.keep_path())
@@ -505,12 +506,3 @@ def hubunit_shop(
     )
     x_hubunit.set_dir_attrs()
     return x_hubunit
-
-
-def create_keep_rope_path(x_hubunit: HubUnit, x_rope: LabelTerm) -> str:
-    """Returns path: belief_label/planroot/keep_rope_dirs."""
-    keep_root = "planroot"
-    x_rope = rebuild_rope(x_rope, x_hubunit.belief_label, keep_root)
-    x_list = get_all_rope_labels(x_rope, x_hubunit.knot)
-    keep_sub_path = create_directory_path(x_list=[*x_list])
-    return create_path(x_hubunit._keeps_dir, keep_sub_path)

--- a/src/a12_hub_toolbox/test/_util/test_a12_path.py
+++ b/src/a12_hub_toolbox/test/_util/test_a12_path.py
@@ -1,6 +1,7 @@
 from inspect import getdoc as inspect_getdoc
 from platform import system as platform_system
 from src.a00_data_toolbox.file_toolbox import create_path
+from src.a01_term_logic.rope import create_rope, create_rope_from_labels
 from src.a09_pack_logic.test._util.a09_str import (
     belief_label_str,
     believer_name_str,
@@ -34,6 +35,7 @@ from src.a12_hub_toolbox.a12_path import (
     create_event_expressed_pack_path,
     create_gut_path,
     create_job_path,
+    create_keep_rope_path,
     create_keeps_dir_path,
     create_packs_dir_path,
     get_keep_dutys_path,
@@ -126,6 +128,112 @@ def test_create_keeps_dir_path_ReturnsObj():
     sue_dir = create_path(believers_dir, sue_str)
     expected_keeps_dir = create_path(sue_dir, "keeps")
     assert keeps_dir == expected_keeps_dir
+
+
+def test_create_keep_rope_path_ReturnsObj_Scenario0_SimpleRope():
+    # ESTABLISH
+    x_belief_mstr_dir = get_module_temp_dir()
+    amy23_str = "amy23"
+    sue_str = "Sue"
+    casa_str = "casa"
+    casa_rope = create_rope(amy23_str, casa_str)
+
+    # WHEN
+    keep_casa_path = create_keep_rope_path(
+        x_belief_mstr_dir, sue_str, amy23_str, casa_rope, None
+    )
+
+    # THEN
+    keeps_dir = create_keeps_dir_path(x_belief_mstr_dir, amy23_str, sue_str)
+    keep_amy23_dir = create_path(keeps_dir, amy23_str)
+    expected_keep_casa_dir = create_path(keep_amy23_dir, casa_str)
+    assert keep_casa_path == expected_keep_casa_dir
+
+
+def test_create_keep_rope_path_ReturnsObj_Scenario1_MoreTestsForRopePathCreation():
+    # ESTABLISH
+    sue_str = "Sue"
+    peru_str = "peru"
+    belief_mstr_dir = get_module_temp_dir()
+    texas_str = "texas"
+    dallas_str = "dallas"
+    elpaso_str = "el paso"
+    kern_str = "kern"
+    planroot = "planroot"
+    texas_rope = create_rope_from_labels([peru_str, texas_str])
+    dallas_rope = create_rope_from_labels([peru_str, texas_str, dallas_str])
+    elpaso_rope = create_rope_from_labels([peru_str, texas_str, elpaso_str])
+    kern_rope = create_rope_from_labels([peru_str, texas_str, elpaso_str, kern_str])
+
+    # WHEN
+    # texas_path = create_keep_rope_path(sue_hubunit, texas_rope)
+    texas_path = create_keep_rope_path(
+        belief_mstr_dir,
+        believer_name=sue_str,
+        belief_label=peru_str,
+        keep_rope=texas_rope,
+        knot=None,
+    )
+    # dallas_path = createdallas_path_keep_rope_path(sue_hubunit, dallas_rope)
+    dallas_path = create_keep_rope_path(
+        belief_mstr_dir,
+        believer_name=sue_str,
+        belief_label=peru_str,
+        keep_rope=dallas_rope,
+        knot=None,
+    )
+    # elpaso_path = create_keep_rope_path(sue_hubunit, elpaso_rope)
+    elpaso_path = create_keep_rope_path(
+        belief_mstr_dir,
+        believer_name=sue_str,
+        belief_label=peru_str,
+        keep_rope=elpaso_rope,
+        knot=None,
+    )
+    # kern_path = create_keep_rope_path(sue_hubunit, kern_rope)
+    kern_path = create_keep_rope_path(
+        belief_mstr_dir,
+        believer_name=sue_str,
+        belief_label=peru_str,
+        keep_rope=kern_rope,
+        knot=None,
+    )
+
+    # THEN
+    keeps_dir = create_keeps_dir_path(belief_mstr_dir, peru_str, sue_str)
+    planroot_dir = create_path(keeps_dir, peru_str)
+    print(f"{kern_rope=}")
+    print(f"{planroot_dir=}")
+    assert texas_path == create_path(planroot_dir, texas_str)
+    assert dallas_path == create_path(texas_path, dallas_str)
+    assert elpaso_path == create_path(texas_path, elpaso_str)
+    assert kern_path == create_path(elpaso_path, kern_str)
+
+    # WHEN / THEN
+    diff_root_texas_rope = create_rope_from_labels([peru_str, texas_str])
+    diff_root_dallas_rope = create_rope_from_labels([peru_str, texas_str, dallas_str])
+    diff_root_elpaso_rope = create_rope_from_labels([peru_str, texas_str, elpaso_str])
+    assert texas_path == create_keep_rope_path(
+        belief_mstr_dir,
+        believer_name=sue_str,
+        belief_label=peru_str,
+        keep_rope=diff_root_texas_rope,
+        knot=None,
+    )
+    assert dallas_path == create_keep_rope_path(
+        belief_mstr_dir,
+        believer_name=sue_str,
+        belief_label=peru_str,
+        keep_rope=diff_root_dallas_rope,
+        knot=None,
+    )
+    assert elpaso_path == create_keep_rope_path(
+        belief_mstr_dir,
+        believer_name=sue_str,
+        belief_label=peru_str,
+        keep_rope=diff_root_elpaso_rope,
+        knot=None,
+    )
 
 
 def test_get_keep_dutys_path_ReturnsObj() -> None:
@@ -606,6 +714,22 @@ def test_create_keeps_dir_path_HasDocString():
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
     assert LINUX_OS or inspect_getdoc(create_keeps_dir_path) == doc_str
+
+
+def test_create_keep_rope_path_HasDocString() -> None:
+    # ESTABLISH
+    level1_label_str = "level1_label"
+    level1_rope = create_rope("planroot", level1_label_str)
+    doc_str = create_keep_rope_path(
+        mstr_dir="belief_mstr_dir",
+        believer_name=believer_name_str(),
+        belief_label=belief_label_str(),
+        keep_rope=level1_rope,
+        knot=None,
+    )
+    doc_str = f"Returns path: {doc_str}"
+    # WHEN / THEN
+    assert LINUX_OS or inspect_getdoc(create_keep_rope_path) == doc_str
 
 
 def test_get_keep_dutys_path_HasDocString() -> None:

--- a/src/a12_hub_toolbox/test/_util/test_a12_path.py
+++ b/src/a12_hub_toolbox/test/_util/test_a12_path.py
@@ -36,6 +36,9 @@ from src.a12_hub_toolbox.a12_path import (
     create_job_path,
     create_keeps_dir_path,
     create_packs_dir_path,
+    get_keep_dutys_path,
+    get_keep_grades_path,
+    get_keep_visions_path,
     treasury_filename,
 )
 from src.a12_hub_toolbox.test._util.a12_env import get_module_temp_dir
@@ -123,6 +126,42 @@ def test_create_keeps_dir_path_ReturnsObj():
     sue_dir = create_path(believers_dir, sue_str)
     expected_keeps_dir = create_path(sue_dir, "keeps")
     assert keeps_dir == expected_keeps_dir
+
+
+def test_get_keep_dutys_path_ReturnsObj() -> None:
+    # ESTABLISH
+    x_keep_dir = get_module_temp_dir()
+
+    # WHEN
+    gen_keep_dutys_path = get_keep_dutys_path(x_keep_dir)
+
+    # THEN
+    expected_keep_dutys_path = create_path(x_keep_dir, "dutys")
+    assert gen_keep_dutys_path == expected_keep_dutys_path
+
+
+def test_get_keep_grades_path_ReturnsObj() -> None:
+    # ESTABLISH
+    x_keep_dir = get_module_temp_dir()
+
+    # WHEN
+    gen_keep_dutys_path = get_keep_grades_path(x_keep_dir)
+
+    # THEN
+    expected_keep_dutys_path = create_path(x_keep_dir, "grades")
+    assert gen_keep_dutys_path == expected_keep_dutys_path
+
+
+def test_get_keep_visions_path_ReturnsObj() -> None:
+    # ESTABLISH
+    x_keep_dir = get_module_temp_dir()
+
+    # WHEN
+    gen_keep_dutys_path = get_keep_visions_path(x_keep_dir)
+
+    # THEN
+    expected_keep_dutys_path = create_path(x_keep_dir, "visions")
+    assert gen_keep_dutys_path == expected_keep_dutys_path
 
 
 def test_create_atoms_dir_path_ReturnsObj():
@@ -567,6 +606,50 @@ def test_create_keeps_dir_path_HasDocString():
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
     assert LINUX_OS or inspect_getdoc(create_keeps_dir_path) == doc_str
+
+
+def test_get_keep_dutys_path_HasDocString() -> None:
+    # ESTABLISH
+    keeps_dir = create_keeps_dir_path(
+        belief_mstr_dir="belief_mstr_dir",
+        belief_label=belief_label_str(),
+        believer_name=believer_name_str(),
+    )
+    keep_path = create_path(keeps_dir, "keep_rope_dirs")
+    doc_str = get_keep_dutys_path(x_keep_path=keep_path)
+    doc_str = f"Returns path: {doc_str}"
+    # WHEN / THEN
+    assert LINUX_OS or inspect_getdoc(get_keep_dutys_path) == doc_str
+
+
+def test_get_keep_grades_path_HasDocString() -> None:
+    # ESTABLISH
+    keeps_dir = create_keeps_dir_path(
+        belief_mstr_dir="belief_mstr_dir",
+        belief_label=belief_label_str(),
+        believer_name=believer_name_str(),
+    )
+    keep_path = create_path(keeps_dir, "keep_rope_dirs")
+    doc_str = get_keep_grades_path(x_keep_path=keep_path)
+    doc_str = f"Returns path: {doc_str}"
+    print(f"                             {doc_str=}")
+    print(f"{inspect_getdoc(get_keep_grades_path)=}")
+    # WHEN / THEN
+    assert LINUX_OS or inspect_getdoc(get_keep_grades_path) == doc_str
+
+
+def test_get_keep_visions_path_HasDocString() -> None:
+    # ESTABLISH
+    keeps_dir = create_keeps_dir_path(
+        belief_mstr_dir="belief_mstr_dir",
+        belief_label=belief_label_str(),
+        believer_name=believer_name_str(),
+    )
+    keep_path = create_path(keeps_dir, "keep_rope_dirs")
+    doc_str = get_keep_visions_path(x_keep_path=keep_path)
+    doc_str = f"Returns path: {doc_str}"
+    # WHEN / THEN
+    assert LINUX_OS or inspect_getdoc(get_keep_visions_path) == doc_str
 
 
 def test_create_atoms_dir_path_HasDocString():

--- a/src/a12_hub_toolbox/test/test_hubunit/test_hubunit__core.py
+++ b/src/a12_hub_toolbox/test/test_hubunit/test_hubunit__core.py
@@ -128,15 +128,15 @@ def test_hubunit_shop_ReturnsObjWhenEmpty():
     assert sue_hubunit.keep_rope == texas_rope
     assert sue_hubunit.keep_path() == create_keep_rope_path(x_hubunit, texas_rope)
     bob_str = "Bob"
-    assert sue_hubunit.dutys_dir() == x_dutys_path
-    assert sue_hubunit.visions_dir() == x_visions_path
-    assert sue_hubunit.grades_dir() == x_grades_path
-    sue_dutys_dir = sue_hubunit.dutys_dir()
-    sue_visions_dir = sue_hubunit.visions_dir()
-    sue_grades_dir = sue_hubunit.grades_dir()
-    x_duty_path = create_path(sue_dutys_dir, f"{bob_str}.json")
-    x_vision_path = create_path(sue_visions_dir, f"{bob_str}.json")
-    x_grade_path = create_path(sue_grades_dir, f"{bob_str}.json")
+    assert sue_hubunit.dutys_path() == x_dutys_path
+    assert sue_hubunit.visions_path() == x_visions_path
+    assert sue_hubunit.grades_path() == x_grades_path
+    sue_dutys_path = sue_hubunit.dutys_path()
+    sue_visions_path = sue_hubunit.visions_path()
+    sue_grades_path = sue_hubunit.grades_path()
+    x_duty_path = create_path(sue_dutys_path, f"{bob_str}.json")
+    x_vision_path = create_path(sue_visions_path, f"{bob_str}.json")
+    x_grade_path = create_path(sue_grades_path, f"{bob_str}.json")
     assert sue_hubunit.duty_path(bob_str) == x_duty_path
     assert sue_hubunit.vision_path(bob_str) == x_vision_path
     assert sue_hubunit.grade_path(bob_str) == x_grade_path

--- a/src/a12_hub_toolbox/test/test_hubunit/test_hubunit__core.py
+++ b/src/a12_hub_toolbox/test/test_hubunit/test_hubunit__core.py
@@ -1,10 +1,6 @@
 from pytest import raises as pytest_raises
 from src.a00_data_toolbox.file_toolbox import create_path
-from src.a01_term_logic.rope import (
-    create_rope,
-    create_rope_from_labels,
-    default_knot_if_None,
-)
+from src.a01_term_logic.rope import create_rope, default_knot_if_None
 from src.a02_finance_logic.finance_config import (
     default_fund_iota_if_None,
     default_RespectBit_if_None,
@@ -12,8 +8,8 @@ from src.a02_finance_logic.finance_config import (
     validate_fund_pool,
 )
 from src.a05_plan_logic.plan import get_default_belief_label as root_label
-from src.a12_hub_toolbox.a12_path import create_believer_dir_path
-from src.a12_hub_toolbox.hubunit import HubUnit, create_keep_rope_path, hubunit_shop
+from src.a12_hub_toolbox.a12_path import create_believer_dir_path, create_keep_rope_path
+from src.a12_hub_toolbox.hubunit import HubUnit, hubunit_shop
 from src.a12_hub_toolbox.test._util.a12_env import (
     env_dir_setup_cleanup,
     get_module_temp_dir,
@@ -48,10 +44,8 @@ def test_HubUnit_RaisesError_keep_rope_DoesNotExist():
     # WHEN / THEN
     with pytest_raises(Exception) as excinfo:
         bob_hubunit.keep_path()
-    assert (
-        str(excinfo.value)
-        == f"HubUnit '{bob_str}' cannot save to keep_path because it does not have keep_rope."
-    )
+    assertion_fail_str = f"HubUnit '{bob_str}' cannot save to keep_path because it does not have keep_rope."
+    assert str(excinfo.value) == assertion_fail_str
 
 
 def test_hubunit_shop_ReturnsObj():
@@ -124,9 +118,14 @@ def test_hubunit_shop_ReturnsObjWhenEmpty():
     assert sue_hubunit.fund_iota == default_fund_iota_if_None()
     assert sue_hubunit.respect_bit == default_RespectBit_if_None()
     assert sue_hubunit.penny == filter_penny()
-    x_hubunit = hubunit_shop(belief_mstr_dir, amy23_str, sue_str)
     assert sue_hubunit.keep_rope == texas_rope
-    assert sue_hubunit.keep_path() == create_keep_rope_path(x_hubunit, texas_rope)
+    assert sue_hubunit.keep_path() == create_keep_rope_path(
+        belief_mstr_dir,
+        believer_name=sue_str,
+        belief_label=amy23_str,
+        keep_rope=texas_rope,
+        knot=None,
+    )
     bob_str = "Bob"
     assert sue_hubunit.dutys_path() == x_dutys_path
     assert sue_hubunit.visions_path() == x_visions_path
@@ -153,48 +152,7 @@ def test_hubunit_shop_RaisesErrorIf_believer_name_Contains_knot():
     # WHEN / THEN
     with pytest_raises(Exception) as excinfo:
         hubunit_shop(None, None, believer_name=bob_str, knot=slash_str)
-    assert (
-        str(excinfo.value)
-        == f"'{bob_str}' needs to be a LabelTerm. Cannot contain knot: '{slash_str}'"
+    assertion_fail_str = (
+        f"'{bob_str}' needs to be a LabelTerm. Cannot contain knot: '{slash_str}'"
     )
-
-
-def test_create_keep_rope_path_ReturnsObj():
-    # ESTABLISH
-    sue_str = "Sue"
-    peru_str = "peru"
-    sue_hubunit = hubunit_shop(
-        get_module_temp_dir(), belief_label=peru_str, believer_name=sue_str
-    )
-    texas_str = "texas"
-    dallas_str = "dallas"
-    elpaso_str = "el paso"
-    kern_str = "kern"
-    planroot = "planroot"
-    texas_rope = create_rope_from_labels([peru_str, texas_str])
-    dallas_rope = create_rope_from_labels([peru_str, texas_str, dallas_str])
-    elpaso_rope = create_rope_from_labels([peru_str, texas_str, elpaso_str])
-    kern_rope = create_rope_from_labels([peru_str, texas_str, elpaso_str, kern_str])
-
-    # WHEN
-    texas_path = create_keep_rope_path(sue_hubunit, texas_rope)
-    dallas_path = create_keep_rope_path(sue_hubunit, dallas_rope)
-    elpaso_path = create_keep_rope_path(sue_hubunit, elpaso_rope)
-    kern_path = create_keep_rope_path(sue_hubunit, kern_rope)
-
-    # THEN
-    planroot_dir = create_path(sue_hubunit._keeps_dir, peru_str)
-    print(f"{kern_rope=}")
-    print(f"{planroot_dir=}")
-    assert texas_path == create_path(planroot_dir, texas_str)
-    assert dallas_path == create_path(texas_path, dallas_str)
-    assert elpaso_path == create_path(texas_path, elpaso_str)
-    assert kern_path == create_path(elpaso_path, kern_str)
-
-    # WHEN / THEN
-    diff_root_texas_rope = create_rope_from_labels([peru_str, texas_str])
-    diff_root_dallas_rope = create_rope_from_labels([peru_str, texas_str, dallas_str])
-    diff_root_elpaso_rope = create_rope_from_labels([peru_str, texas_str, elpaso_str])
-    assert texas_path == create_keep_rope_path(sue_hubunit, diff_root_texas_rope)
-    assert dallas_path == create_keep_rope_path(sue_hubunit, diff_root_dallas_rope)
-    assert elpaso_path == create_keep_rope_path(sue_hubunit, diff_root_elpaso_rope)
+    assert str(excinfo.value) == assertion_fail_str

--- a/src/a13_believer_listen_logic/test/test_listen/test_agendas_duty_vision.py
+++ b/src/a13_believer_listen_logic/test/test_listen/test_agendas_duty_vision.py
@@ -86,7 +86,7 @@ def test_listen_to_agenda_duty_vision_agenda_AddsChoresTovision_Believer(
     yao_dakota_hubunit = hubunit_shop(env_dir(), a23_str, yao_str, get_dakota_rope())
     yao_dakota_hubunit.save_vision_believer(zia_vision)
 
-    # zia_file_path = create_path(visions_dir, zia_str}.json")
+    # zia_file_path = create_path(visions_path, zia_str}.json")
     # print(f"{os_path_exists(zia_file_path)=}")
     new_yao_vision = create_listen_basis(yao_duty)
     assert len(new_yao_vision.get_agenda_dict()) == 0

--- a/src/a15_belief_logic/test/test_belief_/test_belief_.py
+++ b/src/a15_belief_logic/test/test_belief_/test_belief_.py
@@ -490,12 +490,12 @@ def test_BeliefUnit__set_all_healer_dutys_CorrectlySetsdutys(
     yao_filename = get_json_filename(yao_str)
     sue_dallas_hubunit = hubunit_shop(x_belief_mstr_dir, a23_str, sue_str, dallas_rope)
     yao_dallas_hubunit = hubunit_shop(x_belief_mstr_dir, a23_str, yao_str, dallas_rope)
-    sue_dutys_dir = sue_dallas_hubunit.dutys_dir()
-    yao_dutys_dir = yao_dallas_hubunit.dutys_dir()
-    sue_dallas_sue_duty_file_path = create_path(sue_dutys_dir, sue_filename)
-    sue_dallas_yao_duty_file_path = create_path(sue_dutys_dir, yao_filename)
-    yao_dallas_sue_duty_file_path = create_path(yao_dutys_dir, sue_filename)
-    yao_dallas_yao_duty_file_path = create_path(yao_dutys_dir, yao_filename)
+    sue_dutys_path = sue_dallas_hubunit.dutys_path()
+    yao_dutys_path = yao_dallas_hubunit.dutys_path()
+    sue_dallas_sue_duty_file_path = create_path(sue_dutys_path, sue_filename)
+    sue_dallas_yao_duty_file_path = create_path(sue_dutys_path, yao_filename)
+    yao_dallas_sue_duty_file_path = create_path(yao_dutys_path, sue_filename)
+    yao_dallas_yao_duty_file_path = create_path(yao_dutys_path, yao_filename)
     assert os_path_exists(sue_dallas_sue_duty_file_path) is False
     assert os_path_exists(sue_dallas_yao_duty_file_path) is False
     assert os_path_exists(yao_dallas_sue_duty_file_path) is False

--- a/src/a17_idea_logic/idea.py
+++ b/src/a17_idea_logic/idea.py
@@ -2,13 +2,11 @@ from csv import reader as csv_reader
 from dataclasses import dataclass
 from pandas import DataFrame
 from src.a00_data_toolbox.dict_toolbox import (
-    add_headers_to_csv,
     create_l2nested_csv_dict,
     extract_csv_headers,
     get_csv_column1_column2_metrics,
     get_positional_dict,
 )
-from src.a00_data_toolbox.file_toolbox import open_file
 from src.a01_term_logic.term import BeliefLabel, BelieverName
 from src.a06_believer_logic.believer import BelieverUnit
 from src.a07_timeline_logic.timeline import timelineunit_shop
@@ -18,9 +16,6 @@ from src.a09_pack_logic.delta import (
     believerdelta_shop,
     get_dimens_cruds_believerdelta,
 )
-from src.a09_pack_logic.pack import packunit_shop
-from src.a12_hub_toolbox.hub_tool import open_gut_file, save_gut_file
-from src.a12_hub_toolbox.hubunit import hubunit_shop
 from src.a15_belief_logic.belief import BeliefUnit, beliefunit_shop
 from src.a17_idea_logic.idea_config import (
     get_idea_format_headers,
@@ -199,36 +194,6 @@ def make_believerdelta(x_csv: str) -> BelieverDelta:
         for x_believeratom in x_atomrow.get_believeratoms():
             x_believerdelta.set_believeratom(x_believeratom)
     return x_believerdelta
-
-
-def _load_individual_idea_csv(
-    complete_csv: str,
-    belief_mstr_dir: str,
-    x_belief_label: BeliefLabel,
-    x_believer_name: BelieverName,
-):
-    x_hubunit = hubunit_shop(belief_mstr_dir, x_belief_label, x_believer_name)
-    x_hubunit.initialize_pack_gut_files()
-    x_believerdelta = make_believerdelta(complete_csv)
-    # x_believerdelta = get_minimal_believerdelta(x_believerdelta, x_gut)
-    x_packunit = packunit_shop(x_believer_name, x_belief_label)
-    x_packunit.set_believerdelta(x_believerdelta)
-    x_hubunit.save_pack_file(x_packunit)
-    x_hubunit._create_gut_from_packs()
-
-
-def load_idea_csv(belief_mstr_dir: str, x_dir: str, x_filename: str):
-    x_csv = open_file(x_dir, x_filename)
-    headers_list, headerless_csv = extract_csv_headers(x_csv)
-    nested_csv = belief_label_believer_name_nested_csv_dict(
-        headerless_csv, delimiter=","
-    )
-    for x_belief_label, belief_dict in nested_csv.items():
-        for x_believer_name, believer_csv in belief_dict.items():
-            complete_csv = add_headers_to_csv(headers_list, believer_csv)
-            _load_individual_idea_csv(
-                complete_csv, belief_mstr_dir, x_belief_label, x_believer_name
-            )
 
 
 def get_csv_belief_label_believer_name_metrics(

--- a/src/a17_idea_logic/idea_csv_tool.py
+++ b/src/a17_idea_logic/idea_csv_tool.py
@@ -1,10 +1,8 @@
-from sqlite3 import Cursor as sqlite3_Cursor
 from src.a00_data_toolbox.dict_toolbox import get_empty_str_if_None as if_none_str
 from src.a01_term_logic.term import BeliefLabel, FaceName
 from src.a06_believer_logic.believer import BelieverUnit
 from src.a09_pack_logic.pack import PackUnit
 from src.a15_belief_logic.belief import BeliefUnit
-from src.a16_pidgin_logic.pidgin import PidginUnit
 from src.a17_idea_logic.idea_config import (
     get_idea_format_filename,
     get_idea_format_headers,

--- a/src/a17_idea_logic/test/test_idea_/test_idea_format_import.py
+++ b/src/a17_idea_logic/test/test_idea_/test_idea_format_import.py
@@ -1,4 +1,3 @@
-from src.a00_data_toolbox.file_toolbox import create_path
 from src.a06_believer_logic.believer import believerunit_shop
 from src.a06_believer_logic.test._util.a06_str import (
     belief_label_str,
@@ -7,13 +6,8 @@ from src.a06_believer_logic.test._util.a06_str import (
     person_debt_points_str,
     person_name_str,
 )
-from src.a12_hub_toolbox.hub_tool import gut_file_exists, open_gut_file
-from src.a17_idea_logic.idea import get_idearef_obj, load_idea_csv, save_idea_csv
-from src.a17_idea_logic.idea_config import (
-    idea_format_00012_membership_v0_0_0,
-    idea_format_00013_planunit_v0_0_0,
-    idea_format_00021_believer_personunit_v0_0_0,
-)
+from src.a17_idea_logic.idea import get_idearef_obj, save_idea_csv
+from src.a17_idea_logic.idea_config import idea_format_00021_believer_personunit_v0_0_0
 from src.a17_idea_logic.idea_db_tool import open_csv
 from src.a17_idea_logic.test._util.a17_env import (
     env_dir_setup_cleanup,
@@ -91,118 +85,3 @@ def test_open_csv_ReturnsObjWhenNoFileExists(env_dir_setup_cleanup):
 
     # THEN
     assert person_dataframe is None
-
-
-def test_load_idea_csv_Arg_idea_format_00021_believer_personunit_v0_0_0_csvTo_job(
-    env_dir_setup_cleanup,
-):
-    # ESTABLISH
-    sue_str = "Sue"
-    bob_str = "Bob"
-    yao_str = "Yao"
-    sue_person_cred_points = 11
-    bob_person_cred_points = 13
-    yao_person_cred_points = 41
-    sue_person_debt_points = 23
-    bob_person_debt_points = 29
-    yao_person_debt_points = 37
-    amy_belief_label = "amy56"
-    sue_believerunit = believerunit_shop(sue_str, amy_belief_label)
-    sue_believerunit.add_personunit(
-        sue_str, sue_person_cred_points, sue_person_debt_points
-    )
-    sue_believerunit.add_personunit(
-        bob_str, bob_person_cred_points, bob_person_debt_points
-    )
-    sue_believerunit.add_personunit(
-        yao_str, yao_person_cred_points, yao_person_debt_points
-    )
-    j1_ideaname = idea_format_00021_believer_personunit_v0_0_0()
-    name_filename = f"{sue_str}_person_example_02.csv"
-    belief_mstr_dir = get_module_temp_dir()
-    csv_example_path = create_path(belief_mstr_dir, name_filename)
-    print(f"{csv_example_path}")
-    save_idea_csv(j1_ideaname, sue_believerunit, belief_mstr_dir, name_filename)
-    # Popen BeliefUnit and confirm gut BelieverUnit does not exist
-    assert not gut_file_exists(belief_mstr_dir, amy_belief_label, sue_str)
-
-    # WHEN
-    load_idea_csv(belief_mstr_dir, get_module_temp_dir(), name_filename)
-
-    # THEN
-    # assert gut Believerunit now exists
-    assert gut_file_exists(get_module_temp_dir(), amy_belief_label, sue_str)
-    # assert gut Believerunit personunit now exists
-    sue_gut = open_gut_file(get_module_temp_dir(), amy_belief_label, sue_str)
-
-    assert sue_gut.person_exists(sue_str)
-    assert sue_gut.person_exists(bob_str)
-    assert sue_gut.person_exists(yao_str)
-    # assert gut Believerunit personunit.person_cred_points is correct
-    sue_personunit = sue_gut.get_person(sue_str)
-    bob_personunit = sue_gut.get_person(bob_str)
-    yao_personunit = sue_gut.get_person(yao_str)
-    # assert gut Believerunit personunit.person_cred_points is correct
-    assert sue_personunit.person_cred_points == sue_person_cred_points
-    assert bob_personunit.person_cred_points == bob_person_cred_points
-    assert yao_personunit.person_cred_points == yao_person_cred_points
-    assert sue_personunit.person_debt_points == sue_person_debt_points
-    assert bob_personunit.person_debt_points == bob_person_debt_points
-    assert yao_personunit.person_debt_points == yao_person_debt_points
-
-
-def test_load_idea_csv_csvTo_job(
-    env_dir_setup_cleanup,
-):
-    # ESTABLISH
-    sue_str = "Sue"
-    bob_str = "Bob"
-    yao_str = "Yao"
-    sue_person_cred_points = 11
-    bob_person_cred_points = 13
-    yao_person_cred_points = 41
-    sue_person_debt_points = 23
-    bob_person_debt_points = 29
-    yao_person_debt_points = 37
-    amy_belief_label = "amy56"
-    sue_believerunit = believerunit_shop(sue_str, amy_belief_label)
-    sue_believerunit.add_personunit(
-        sue_str, sue_person_cred_points, sue_person_debt_points
-    )
-    sue_believerunit.add_personunit(
-        bob_str, bob_person_cred_points, bob_person_debt_points
-    )
-    sue_believerunit.add_personunit(
-        yao_str, yao_person_cred_points, yao_person_debt_points
-    )
-    j1_ideaname = idea_format_00021_believer_personunit_v0_0_0()
-    name_filename = f"{sue_str}_person_example_02.csv"
-    csv_example_path = create_path(get_module_temp_dir(), name_filename)
-    print(f"{csv_example_path}")
-    save_idea_csv(j1_ideaname, sue_believerunit, get_module_temp_dir(), name_filename)
-    belief_mstr_dir = get_module_temp_dir()
-    # Popen BeliefUnit and confirm gut BelieverUnit does not exist
-    assert not gut_file_exists(belief_mstr_dir, amy_belief_label, sue_str)
-
-    # WHEN
-    load_idea_csv(belief_mstr_dir, get_module_temp_dir(), name_filename)
-
-    # THEN
-    # assert gut Believerunit now exists
-    assert gut_file_exists(get_module_temp_dir(), amy_belief_label, sue_str)
-    # assert gut Believerunit personunit now exists
-    sue_gut = open_gut_file(get_module_temp_dir(), amy_belief_label, sue_str)
-    assert sue_gut.person_exists(sue_str)
-    assert sue_gut.person_exists(bob_str)
-    assert sue_gut.person_exists(yao_str)
-    # assert gut Believerunit personunit.person_cred_points is correct
-    sue_personunit = sue_gut.get_person(sue_str)
-    bob_personunit = sue_gut.get_person(bob_str)
-    yao_personunit = sue_gut.get_person(yao_str)
-    # assert gut Believerunit personunit.person_cred_points is correct
-    assert sue_personunit.person_cred_points == sue_person_cred_points
-    assert bob_personunit.person_cred_points == bob_person_cred_points
-    assert yao_personunit.person_cred_points == yao_person_cred_points
-    assert sue_personunit.person_debt_points == sue_person_debt_points
-    assert bob_personunit.person_debt_points == bob_person_debt_points
-    assert yao_personunit.person_debt_points == yao_person_debt_points

--- a/src/a17_idea_logic/test/test_idea_db_tool/test_pandas_tool_db.py
+++ b/src/a17_idea_logic/test/test_idea_db_tool/test_pandas_tool_db.py
@@ -80,7 +80,7 @@ def test_create_idea_table_from_csv_ChangesDBState(
     # WHEN
     create_idea_table_from_csv(test_csv_filepath, conn, new_table)
 
-    # THEN Verify the table was created correctly
+    # THEN Verify the table was created
     cursor = conn.cursor()
     cursor.execute(f"PRAGMA table_info({new_table})")
     columns = cursor.fetchall()
@@ -124,7 +124,7 @@ def test_insert_idea_csv_ChangesDBState_add_to_empty_table(
     insert_idea_csv(test_csv_filepath, conn, br_tablename)
 
     # THEN
-    # Verify the data was inserted correctly
+    # Verify the data was inserted
     cursor.execute(f"SELECT * FROM {br_tablename}")
     rows = cursor.fetchall()
     expected_data = [

--- a/src/a20_world_logic/test/test_etl_pipeline/test_stance_to_clarity.py
+++ b/src/a20_world_logic/test/test_etl_pipeline/test_stance_to_clarity.py
@@ -217,6 +217,7 @@ def test_WorldUnit_stance_sheets_to_clarity_mstr_Scenario1_DatabaseFileExists(
         assert get_max_brick_agg_event_int(cursor1) == event5 + 1
         select_sqlstr = f"SELECT * FROM {events_brick_agg_str()}"
         cursor1.execute(select_sqlstr)
-        print(cursor1.fetchall())
+        rows = cursor1.fetchall()
+        assert len(rows) == 2
     db_conn1.close()
     assert not os_path_exists(input_file_path)

--- a/src/a20_world_logic/world.py
+++ b/src/a20_world_logic/world.py
@@ -1,10 +1,6 @@
 from dataclasses import dataclass
 from os.path import exists as os_path_exists
-from sqlite3 import (
-    Connection as sqlite3_Connection,
-    Cursor as sqlite3_Cursor,
-    connect as sqlite3_connect,
-)
+from sqlite3 import Cursor as sqlite3_Cursor, connect as sqlite3_connect
 from src.a00_data_toolbox.dict_toolbox import get_0_if_None, get_empty_set_if_None
 from src.a00_data_toolbox.file_toolbox import create_path, delete_dir, set_dir
 from src.a01_term_logic.term import BeliefLabel, EventInt, FaceName

--- a/src/a99_module_logic/test/test_module_dirs.py
+++ b/src/a99_module_logic/test/test_module_dirs.py
@@ -397,7 +397,6 @@ def test_Modules_path_FunctionStructureAndFormat():
         "create_path",
         "create_directory_path",
         "ropeterm_valid_dir_path",
-        "create_keep_rope_path",
     }
     for module_desc, module_dir in get_module_descs().items():
         filenames_set = get_dir_filenames(module_dir, include_extensions={"py"})

--- a/src/a99_module_logic/test/test_module_dirs.py
+++ b/src/a99_module_logic/test/test_module_dirs.py
@@ -426,12 +426,12 @@ def test_Modules_path_FunctionStructureAndFormat():
     print(f"Total path functions found: {len(path_functions)}")
     for function_name, file_path in path_functions.items():
         func_docstring = get_docstring(file_path, function_name)
-        # if not func_docstring:
-        #     print(f"docstring for {function_name} is None")
-        # else:
-        #     print(
-        #         f"docstring for {function_name}: \t{func_docstring.replace("\n", "")}"
-        #     )
+        if not func_docstring:
+            print(f"docstring for {function_name} is None")
+        else:
+            print(
+                f"docstring for {function_name}: \t{func_docstring.replace("\n", "")}"
+            )
         assert func_docstring is not None, function_name
 
     # print(f"Path functions: {path_functions.keys()=}")


### PR DESCRIPTION
## Summary by Sourcery

Unify and refactor path management by moving keep-rope path creation into a12_path utilities, updating HubUnit methods to use consistent *_path interfaces, removing deprecated helpers and load_idea_csv logic, and strengthening test coverage accordingly.

New Features:
- Add create_keep_rope_path and get_keep_*_path utilities in a12_path to generate hierarchical keep directories

Bug Fixes:
- Adjust test in stance_to_clarity to assert row count instead of printing output

Enhancements:
- Refactor HubUnit to use *_path methods instead of *_dir and update keep_path signature
- Consolidate and remove legacy get_keep_*_dir and create_keep_rope_path implementations in hubunit.py
- Remove obsolete load_idea_csv logic from idea modules

Tests:
- Add comprehensive tests for create_keep_rope_path and get_keep_*_path including docstring validation
- Update existing tests to use renamed HubUnit methods and path utilities
- Rename and clean up numerous test functions for consistency and accuracy