### PR TITLE
fix: try to fix release failures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,9 @@ repos:
     rev: v4.8.3
     hooks:
       - id: commitizen
+
+  - repo: https://github.com/pappasam/toml-sort
+    rev: v0.20.0
+    hooks:
+      - id: toml-sort
+  

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,11 @@ test = [
 branch = "main"
 build_command = ""
 changelog_file = "CHANGELOG.md"
+plugins = [
+  "semantic_release.hooks.commit_parser",
+  "semantic_release.hooks.tag_formatter",
+]
+tag_format = "v{version}"
 upload_to_pypi = false
 version_variable = "jaar/__init__.py:__version__"
 


### PR DESCRIPTION
## Summary by Sourcery

Configure pre-commit and semantic-release settings to address release failures by adding toml sorting and enabling necessary release hooks.

Enhancements:
- Add toml-sort hook to pre-commit configuration
- Enable semantic_release commit parser and tag formatter plugins
- Set semantic-release tag format to "v{version}"