### PR TITLE
fix: attempt to display workign directory info

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,26 @@ jobs:
           ls -la
           ls -la jaar
 
+      - name: Run version extractor
+        run: |
+          python -c "
+          import os, re
+          path = 'jaar/__init__.py'
+          print('Working dir:', os.getcwd())
+          print('Absolute path:', os.path.abspath(path))
+          print('File exists:', os.path.isfile(path))
+          with open(path) as f:
+              content = f.read()
+          match = re.search(r'__version__ *= *[\"\\']([^\"\\']+)', content)
+          print(match.group(1) if match else 'No version found')
+          "
+
       - name: Create initial tag if missing
         shell: bash
         run: |
           if ! git describe --tags --abbrev=0 > /dev/null 2>&1; then
             echo "No tags found. Creating initial tag from __version__..."
-            VERSION=$(python -c "import re; f=open('jaar\__init__.py'); print(re.search(r'__version__ *= *[\"\\\']([^\"\\\']+)', f.read()).group(1))")
+            VERSION=$(python -c "import re; f=open('__init__.py'); print(re.search(r'__version__ *= *[\"\\\']([^\"\\\']+)', f.read()).group(1))")
             git tag "v$VERSION"
             git push origin "v$VERSION"
           else


### PR DESCRIPTION
## Summary by Sourcery

Add debugging step in the release workflow to display working directory and version extraction details, and correct the file path when creating the initial git tag from the package version.

New Features:
- Add a GitHub Actions step to print the current working directory, absolute file path, existence check, and extracted version from __init__.py

Bug Fixes:
- Fix the path used to open __init__.py when creating the initial git tag