### PR TITLE
fix: attempt to display #880

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: pip install python-semantic-release
@@ -26,12 +26,13 @@ jobs:
           pwd
           ls -la
           ls -la jaar
+          echo "complete Show current directory and files"
 
       - name: Run version extractor
         run: |
           python -c "
           import os, re
-          path = 'jaar/__init__.py'
+          path = '__init__.py'
           print('Working dir:', os.getcwd())
           print('Absolute path:', os.path.abspath(path))
           print('File exists:', os.path.isfile(path))
@@ -40,6 +41,7 @@ jobs:
           match = re.search(r'__version__ *= *[\"\\']([^\"\\']+)', content)
           print(match.group(1) if match else 'No version found')
           "
+          echo "complete Run version extractor"
 
       - name: Create initial tag if missing
         shell: bash


### PR DESCRIPTION
## Summary by Sourcery

Improve the release GitHub Actions workflow by bumping the Python version, fixing the path for version extraction, and adding logging echoes for clarity

Bug Fixes:
- Correct the path for the version extractor script to use '__init__.py'

Enhancements:
- Add echo statements to the release workflow for better visibility of directory listing and version extraction progress

CI:
- Upgrade Python version from 3.10 to 3.12 in the release GitHub Actions workflow