### PR TITLE
fix: more attempt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,15 +50,15 @@ jobs:
           if ! git describe --tags --abbrev=0 > /dev/null 2>&1; then
             echo "No tags found. Creating initial tag from __version__..."
             VERSION=$(python -c "
-              import re
-              with open('__init__.py') as f:
-                  content = f.read()
-              match = re.search(r'__version__ *= *[\"\\']([^\"\\']+)', content)
-              if match:
-                  print(match.group(1))
-              else:
-                  raise ValueError('Version not found')
-              ")
+          import re
+          with open('__init__.py') as f:
+              content = f.read()
+          match = re.search(r'__version__ *= *[\"\\']([^\"\\']+)', content)
+          if match:
+              print(match.group(1))
+          else:
+              raise ValueError('Version not found')
+          ")
             git tag "v$VERSION"
             git push origin "v$VERSION"
           else


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Adjust indentation of the multi-line Python command in .github/workflows/release.yml for version tagging