### PR TITLE
fix: updated github token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,5 +67,5 @@ jobs:
 
       - name: Run python-semantic-release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT_jaar }}
         run: semantic-release publish


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Use PAT_jaar instead of default GITHUB_TOKEN for the GH_TOKEN environment variable in the release workflow