### PR TITLE
fix: attempt again3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,31 +32,15 @@ jobs:
           ls -la
           echo "complete Show current directory and files"
 
-      - name: Run version extractor
-        run: |
-          echo "start Run version extractor"
-          python -c "
-          import os, re
-          path = '__init__.py'
-          print('Working dir:', os.getcwd())
-          print('Absolute path:', os.path.abspath(path))
-          print('File exists:', os.path.isfile(path))
-          with open(path) as f:
-              content = f.read()
-          match = re.search(r'__version__ *= *[\"\\']([^\"\\']+)', content)
-          print(match.group(1) if match else 'No version found')
-          "
-          echo "complete Run version extractor"
-
-      - name: Set Git remote to use PAT
+      - name: Create initial tag if missing
+        shell: bash
         env:
           GH_TOKEN: ${{ secrets.PAT_jaar }}
         run: |
+          echo "Setting git remote to use PAT token"
           git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/jschalk/jaar.git
+          git remote -v
 
-      - name: Create initial tag if missing
-        shell: bash
-        run: |
           echo "Checking for existing tags..."
           if ! git describe --tags --abbrev=0 > /dev/null 2>&1; then
             echo "No tags found. Creating initial tag from __version__..."


### PR DESCRIPTION
## Summary by Sourcery

Streamline the GitHub Actions release workflow by removing the redundant Python version extractor and consolidating the PAT-based remote setup with the initial tag creation into a single step

Enhancements:
- Remove the Python version extractor step to simplify the release job
- Merge the Git PAT remote configuration and initial tag creation into one bash step

CI:
- Update release.yml to drop the version extraction and combine remote setup with tagging