### PR TITLE
fix: attempt8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repo
+      - name: Checkout repo with PAT
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required for tags
+          token: ${{ secrets.PAT_RELEASE }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -26,22 +29,16 @@ jobs:
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
 
-      - name: Set Git remote to use PAT token
-        env:
-          GH_TOKEN: ${{ secrets.PAT_RELEASE }}
-        run: |
-          echo "GH_TOKEN length: ${#GH_TOKEN}"
-          git remote set-url origin https://${{ github.actor }}:${GH_TOKEN}@github.com/jschalk/jaar.git
-          git remote -v
+      - name: Debug Git remote
+        run: git config --get remote.origin.url
 
       - name: Create initial tag if missing
         shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.PAT_RELEASE }}
         run: |
           echo "Checking for existing tags..."
           if ! git describe --tags --abbrev=0 > /dev/null 2>&1; then
             echo "No tags found. Creating initial tag from __version__..."
+
             VERSION=$(python -c "
           import re
           with open('__init__.py') as f:
@@ -52,6 +49,7 @@ jobs:
           else:
               raise ValueError('Version not found')
           ")
+
             echo "Tagging as v$VERSION"
             git tag "v$VERSION"
             git push origin "v$VERSION"


### PR DESCRIPTION
## Summary by Sourcery

Update release workflow to authenticate checkout with a PAT, fetch full history for tags, and simplify remote setup

CI:
- Use Personal Access Token and fetch-depth: 0 in checkout step to allow tag operations
- Replace manual remote URL override with a debug step to inspect origin URL
- Remove redundant GH_TOKEN environment variables from tagging step