### PR TITLE
fix: small cleanup

### DIFF
--- a/src/a09_pack_logic/test/test_delta/test_delta_get_belief_difference.py
+++ b/src/a09_pack_logic/test/test_delta/test_delta_get_belief_difference.py
@@ -233,6 +233,7 @@ def test_BeliefDelta_add_all_different_beliefatoms_Creates_BeliefAtom_BeliefUnit
 
 
 def test_BeliefDelta_add_all_different_beliefatoms_Creates_BeliefAtom_voice_membership_insert():
+    # sourcery skip: extract-duplicate-method
     # ESTABLISH
     sue_str = "Sue"
     before_sue_belief = beliefunit_shop(sue_str)

--- a/src/a13_belief_listen_logic/test/_util/example_listen_beliefs.py
+++ b/src/a13_belief_listen_logic/test/_util/example_listen_beliefs.py
@@ -143,6 +143,7 @@ def get_fund_breakdown_belief() -> BeliefUnit:
 
 
 def get_beliefunit_irrational_example() -> BeliefUnit:
+    # sourcery skip: extract-duplicate-method
     # this belief has no definitive agenda because 2 task plans are in contradiction
     # "egg first" is true when "chicken first" is false
     # "chicken first" is true when "egg first" is true

--- a/src/a18_etl_toolbox/test/test_tran/test_brick_raw_tables_to_brick_agg_tables.py
+++ b/src/a18_etl_toolbox/test/test_tran/test_brick_raw_tables_to_brick_agg_tables.py
@@ -304,6 +304,7 @@ VALUES
 
 
 def test_get_max_brick_events_event_int_ReturnsObj_Scenario2_MultipleTable():
+    # sourcery skip: extract-duplicate-method, extract-method
     # ESTABLISH
     event1 = 1
     event3 = 3

--- a/src/a99_module_linter/linter.py
+++ b/src/a99_module_linter/linter.py
@@ -203,7 +203,7 @@ def check_if_module_str_funcs_is_sorted(module_str_funcs: list[str]):
                     f"{module_str_funcs[x]} should be {sorted_module_str_funcs[x]}"
                 )
 
-        print(f"{first_wrong_index=}")
+        # print(f"{first_wrong_index=}")
         # print(f"Bad Order     {module_str_funcs}")
         # print(f"Correct order {sorted(module_str_funcs)}")
     assert module_str_funcs == sorted(module_str_funcs)


### PR DESCRIPTION
## Summary by Sourcery

Remove stray debug print and suppress Sourcery refactoring suggestions in test code

Enhancements:
- Comment out leftover debug print in module linter
- Add Sourcery skip directives to suppress duplicate-method and extract-method refactoring hints in multiple test files