### PR TITLE
874 create gui for calendarto do creation

### DIFF
--- a/src/a17_idea_logic/_ref/a17_doc_builder.py
+++ b/src/a17_idea_logic/_ref/a17_doc_builder.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+from src.a00_data_toolbox.file_toolbox import open_json
+from src.a17_idea_logic.idea_config import get_default_sorted_list, get_idea_formats_dir
+
+
+def get_idea_brick_md(idea_brick_config) -> str:
+    # Create per-idea Markdown file
+    idea = idea_brick_config["idea_number"]
+    attr_names = list(idea_brick_config["attributes"].keys())
+    dimens = list(idea_brick_config["dimens"])
+    sorted_attrs = get_default_sorted_list(attr_names)
+
+    idea_md_lines = [
+        f"# Idea `{idea}`\n",
+        f"## Dimens `{dimens}`\n",
+        "## Attributes",
+        *(f"- `{attr}`" for attr in sorted_attrs),
+    ]
+    return "\n".join(idea_md_lines) + "\n"
+
+
+def get_idea_brick_mds(idea_brick_format_dir: str = None) -> dict[str,]:
+    if not idea_brick_format_dir:
+        idea_brick_format_dir = get_idea_formats_dir()
+
+    idea_formats_dir = Path(idea_brick_format_dir)
+    idea_brick_mds = {}
+    for json_path in sorted(idea_formats_dir.glob("*.json")):
+        idea_brick_format = open_json(json_path)
+        idea_number = idea_brick_format["idea_number"]
+        idea_brick_mds[idea_number] = get_idea_brick_md(idea_brick_format)
+
+    return idea_brick_mds
+
+
+def get_brick_formats_md():
+    idea_formats_dir = Path(get_idea_formats_dir())
+
+    manifest_lines = []
+    for json_path in sorted(idea_formats_dir.glob("*.json")):
+        data = open_json(json_path)
+
+        idea = data["idea_number"]
+        attr_names = list(data["attributes"].keys())
+        sorted_attrs = get_default_sorted_list(attr_names)
+        manifest_line = f"- [`{idea}`](ideas/{idea}.md): " + ", ".join(sorted_attrs)
+        manifest_lines.append(manifest_line)
+
+    # Where the Markdown manifest will be written
+    return "# Idea Manifest\n\n" + "\n".join(manifest_lines)

--- a/src/a17_idea_logic/test/test_idea_/test_idea_format_builder.py
+++ b/src/a17_idea_logic/test/test_idea_/test_idea_format_builder.py
@@ -1,21 +1,43 @@
 from json import loads as json_loads
 from pathlib import Path
-from src.a00_data_toolbox.file_toolbox import count_files, save_json
+from src.a00_data_toolbox.file_toolbox import count_files, open_file, save_json
 from src.a08_belief_atom_logic.atom_config import get_atom_config_args
+from src.a17_idea_logic._ref.a17_doc_builder import (
+    get_brick_formats_md,
+    get_idea_brick_md,
+    get_idea_brick_mds,
+)
 from src.a17_idea_logic._ref.a17_terms import (
     attributes_str,
     belief_name_str,
     belief_planunit_str,
+    c400_number_str,
     dimens_str,
+    event_int_str,
+    face_name_str,
+    fund_iota_str,
     gogo_want_str,
+    idea_number_str,
+    job_listen_rotations_str,
+    knot_str,
     moment_label_str,
+    monthday_distortion_str,
+    otx_key_str,
+    penny_str,
     plan_rope_str,
+    respect_bit_str,
+    timeline_label_str,
+    yr1_jan1_offset_str,
 )
 from src.a17_idea_logic.idea_config import (
     get_default_sorted_list,
     get_idea_config_dict,
     get_idea_formats_dir,
     get_idea_numbers,
+)
+from src.a17_idea_logic.test._util.a17_env import (
+    env_dir_setup_cleanup,
+    get_module_temp_dir,
 )
 
 
@@ -62,51 +84,107 @@ def rebuild_format_jsons(x_rebuild_format_jsons: bool):
             save_json(get_idea_formats_dir(), x_filename, idea_format)
 
 
-def test_idea_brick_formats_MarkdownFileExists():
+def test_get_idea_brick_md_ReturnsObj():
     # ESTABLISH
-    # Gather lines here
-    doc_main_dir = "docs"
-    doc_ideas_dir = Path(f"{doc_main_dir}/a17_idea_brick_formats")
-    doc_ideas_dir.mkdir(parents=True, exist_ok=True)
-
-    manifest_lines = []
-    idea_formats_dir = Path(get_idea_formats_dir())
+    idea_brick_config = {
+        "attributes": {
+            knot_str(): {otx_key_str(): False},
+            c400_number_str(): {otx_key_str(): False},
+            event_int_str(): {otx_key_str(): True},
+            face_name_str(): {otx_key_str(): True},
+            moment_label_str(): {otx_key_str(): True},
+            fund_iota_str(): {otx_key_str(): False},
+            job_listen_rotations_str(): {otx_key_str(): False},
+            monthday_distortion_str(): {otx_key_str(): False},
+            penny_str(): {otx_key_str(): False},
+            respect_bit_str(): {otx_key_str(): False},
+            timeline_label_str(): {otx_key_str(): False},
+            yr1_jan1_offset_str(): {otx_key_str(): False},
+        },
+        idea_number_str(): "br00000",
+        dimens_str(): ["momentunit"],
+    }
 
     # WHEN
-    for json_path in sorted(idea_formats_dir.glob("*.json")):
-        data = json_loads(json_path.read_text())
-        # print(f"{data=}")
-
-        # Basic validation
-        assert "idea_number" in data, f"{json_path.name} missing 'idea_number'"
-        assert "attributes" in data, f"{json_path.name} missing 'attributes'"
-        assertion_fail_str = f"{json_path.name} has malformed 'attributes'"
-        assert isinstance(data["attributes"], dict), assertion_fail_str
-
-        idea = data["idea_number"]
-        attr_names = list(data["attributes"].keys())
-        dimens = list(data["dimens"])
-        sorted_attrs = get_default_sorted_list(attr_names)
-        manifest_line = f"- [`{idea}`](ideas/{idea}.md): " + ", ".join(sorted_attrs)
-        manifest_lines.append(manifest_line)
-
-        # Create per-idea Markdown file
-        idea_md_path = doc_ideas_dir / f"{idea}.md"
-        idea_md_lines = [
-            f"# Idea `{idea}`\n",
-            f"## Dimens `{dimens}`\n",
-            "## Attributes",
-            *(f"- `{attr}`" for attr in sorted_attrs),
-        ]
-        idea_md_path.write_text("\n".join(idea_md_lines) + "\n")
-
-    # Where the Markdown manifest will be written
-    dst_path = Path(f"{doc_main_dir}/idea_brick_formats.md")
-    dst_path.parent.mkdir(parents=True, exist_ok=True)
-    dst_path.write_text("# Idea Manifest\n\n" + "\n".join(manifest_lines))
+    idea_brick_md = get_idea_brick_md(idea_brick_config)
 
     # THEN
-    assert dst_path.exists(), f"Failed to write manifest to {dst_path}"
+    print(idea_brick_md)
+    expected_idea_brick_md = f"""# Idea `br00000`
 
-    assertion_fail_str = f"Expected {len(get_idea_numbers())} idea files, found {count_files(doc_ideas_dir)}"
-    assert count_files(doc_ideas_dir) == len(get_idea_numbers()), assertion_fail_str
+## Dimens `['momentunit']`
+
+## Attributes
+- `{event_int_str()}`
+- `{face_name_str()}`
+- `{moment_label_str()}`
+- `{timeline_label_str()}`
+- `{c400_number_str()}`
+- `{yr1_jan1_offset_str()}`
+- `{monthday_distortion_str()}`
+- `{fund_iota_str()}`
+- `{penny_str()}`
+- `{respect_bit_str()}`
+- `{knot_str()}`
+- `{job_listen_rotations_str()}`
+"""
+    assert (idea_brick_md) == expected_idea_brick_md
+
+
+def test_get_idea_brick_mds_ReturnsObj(env_dir_setup_cleanup):
+    # ESTABLISH
+    temp_dir = get_module_temp_dir()
+    br00000_str = "br00000"
+    idea_brick_config = {
+        "attributes": {
+            knot_str(): {otx_key_str(): False},
+            c400_number_str(): {otx_key_str(): False},
+            event_int_str(): {otx_key_str(): True},
+            face_name_str(): {otx_key_str(): True},
+            moment_label_str(): {otx_key_str(): True},
+            fund_iota_str(): {otx_key_str(): False},
+            job_listen_rotations_str(): {otx_key_str(): False},
+            monthday_distortion_str(): {otx_key_str(): False},
+            penny_str(): {otx_key_str(): False},
+            respect_bit_str(): {otx_key_str(): False},
+            timeline_label_str(): {otx_key_str(): False},
+            yr1_jan1_offset_str(): {otx_key_str(): False},
+        },
+        idea_number_str(): br00000_str,
+        dimens_str(): ["momentunit"],
+    }
+    save_json(temp_dir, f"{br00000_str}.json", idea_brick_config)
+
+    # WHEN
+    idea_brick_mds = get_idea_brick_mds(temp_dir)
+
+    # THEN
+    expected_idea_brick_md = f"""# Idea `br00000`
+
+## Dimens `['momentunit']`
+
+## Attributes
+- `{event_int_str()}`
+- `{face_name_str()}`
+- `{moment_label_str()}`
+- `{timeline_label_str()}`
+- `{c400_number_str()}`
+- `{yr1_jan1_offset_str()}`
+- `{monthday_distortion_str()}`
+- `{fund_iota_str()}`
+- `{penny_str()}`
+- `{respect_bit_str()}`
+- `{knot_str()}`
+- `{job_listen_rotations_str()}`
+"""
+    assert set(idea_brick_mds.keys()) == {br00000_str}
+    assert idea_brick_mds == {br00000_str: expected_idea_brick_md}
+
+
+def test_get_brick_formats_md_ReturnsObj():
+    # ESTABLISH / WHEN
+    idea_brick_formats_md = get_brick_formats_md()
+
+    # THEN
+    assert idea_brick_formats_md
+    assert idea_brick_formats_md.find("br00004") > 0

--- a/src/a98_docs_builder/doc_builder.py
+++ b/src/a98_docs_builder/doc_builder.py
@@ -5,6 +5,7 @@ from src.a00_data_toolbox.file_toolbox import (
     open_json,
     save_file,
 )
+from src.a01_rope_logic._ref.a01_doc_builder import get_ropepointer_explanation_md
 
 
 def get_module_descs() -> dict[str, str]:
@@ -70,3 +71,7 @@ def get_module_blurbs_md() -> str:
 
 def save_module_blurbs_md(x_dir: str):
     save_file(x_dir, "module_blurbs.md", get_module_blurbs_md())
+
+
+def save_ropepointer_explanation_md(x_dir: str):
+    save_file(x_dir, "ropepointer_explanation.md", get_ropepointer_explanation_md())

--- a/src/a98_docs_builder/doc_builder.py
+++ b/src/a98_docs_builder/doc_builder.py
@@ -1,4 +1,5 @@
 from ast import FunctionDef as ast_FunctionDef, parse as ast_parse, walk as ast_walk
+from pathlib import Path
 from src.a00_data_toolbox.file_toolbox import (
     create_path,
     get_level1_dirs,
@@ -6,6 +7,10 @@ from src.a00_data_toolbox.file_toolbox import (
     save_file,
 )
 from src.a01_rope_logic._ref.a01_doc_builder import get_ropepointer_explanation_md
+from src.a17_idea_logic._ref.a17_doc_builder import (
+    get_brick_formats_md,
+    get_idea_brick_mds,
+)
 
 
 def get_module_descs() -> dict[str, str]:
@@ -75,3 +80,16 @@ def save_module_blurbs_md(x_dir: str):
 
 def save_ropepointer_explanation_md(x_dir: str):
     save_file(x_dir, "ropepointer_explanation.md", get_ropepointer_explanation_md())
+
+
+def save_idea_brick_mds(dest_dir: str):
+    idea_brick_mds = get_idea_brick_mds()
+    dest_dir = create_path(dest_dir, "a17_idea_brick_formats")
+
+    for idea_number, idea_brick_md in idea_brick_mds.items():
+        save_file(dest_dir, f"{idea_number}.md", idea_brick_md)
+
+
+def save_brick_formats_md(dest_dir: str):
+    brick_formats_md = get_brick_formats_md()
+    save_file(dest_dir, "idea_brick_formats.md", brick_formats_md)

--- a/src/a98_docs_builder/test/test_blurbs_md.py
+++ b/src/a98_docs_builder/test/test_blurbs_md.py
@@ -1,6 +1,11 @@
 from os.path import exists as os_path_exists
 from src.a00_data_toolbox.file_toolbox import create_path, open_file
-from src.a98_docs_builder.doc_builder import get_module_blurbs_md, save_module_blurbs_md
+from src.a01_rope_logic._ref.a01_doc_builder import get_ropepointer_explanation_md
+from src.a98_docs_builder.doc_builder import (
+    get_module_blurbs_md,
+    save_module_blurbs_md,
+    save_ropepointer_explanation_md,
+)
 from src.a98_docs_builder.test._util.a98_env import (
     env_dir_setup_cleanup,
     get_module_temp_dir,
@@ -16,7 +21,7 @@ def test_get_module_blurbs_md_ReturnsObj():
     assert module_blurbs_md.find("a03") > 0
 
 
-def test_save_module_blurbs_md_ReturnsObj(env_dir_setup_cleanup):
+def test_save_module_blurbs_md_CreatesFile(env_dir_setup_cleanup):
     # ESTABLISH
     temp_dir = get_module_temp_dir()
     module_blurbs_path = create_path(temp_dir, "module_blurbs.md")
@@ -29,3 +34,17 @@ def test_save_module_blurbs_md_ReturnsObj(env_dir_setup_cleanup):
     assert os_path_exists(module_blurbs_path)
     expected_module_blurbs_md = get_module_blurbs_md()
     assert open_file(module_blurbs_path) == expected_module_blurbs_md
+
+
+def test_save_ropepointer_explanation_md_CreatesFile(env_dir_setup_cleanup):
+    # ESTABLISH
+    temp_dir = get_module_temp_dir()
+    file_path = create_path(temp_dir, "ropepointer_explanation.md")
+    assert not os_path_exists(file_path)
+
+    # WHEN
+    save_ropepointer_explanation_md(temp_dir)
+
+    # THEN
+    assert os_path_exists(file_path)
+    assert open_file(file_path) == get_ropepointer_explanation_md()

--- a/src/a98_docs_builder/test/test_files_md.py
+++ b/src/a98_docs_builder/test/test_files_md.py
@@ -1,8 +1,10 @@
 from os.path import exists as os_path_exists
-from src.a00_data_toolbox.file_toolbox import create_path, open_file
+from src.a00_data_toolbox.file_toolbox import count_dirs_files, create_path, open_file
 from src.a01_rope_logic._ref.a01_doc_builder import get_ropepointer_explanation_md
 from src.a98_docs_builder.doc_builder import (
     get_module_blurbs_md,
+    save_brick_formats_md,
+    save_idea_brick_mds,
     save_module_blurbs_md,
     save_ropepointer_explanation_md,
 )
@@ -48,3 +50,30 @@ def test_save_ropepointer_explanation_md_CreatesFile(env_dir_setup_cleanup):
     # THEN
     assert os_path_exists(file_path)
     assert open_file(file_path) == get_ropepointer_explanation_md()
+
+
+def test_save_idea_brick_mds_CreatesFiles(env_dir_setup_cleanup):
+    # ESTABLISH
+    temp_dir = get_module_temp_dir()
+    assert count_dirs_files(temp_dir) == 0
+
+    # WHEN
+    save_idea_brick_mds(temp_dir)
+
+    # THEN
+    assert count_dirs_files(temp_dir) == 41
+
+
+def test_save_idea_brick_formats_CreatesFile(env_dir_setup_cleanup):
+    # ESTABLISH
+    doc_main_dir = get_module_temp_dir()
+    idea_brick_formats_path = create_path(doc_main_dir, "idea_brick_formats.md")
+    assert not os_path_exists(idea_brick_formats_path)
+
+    # WHEN
+    save_brick_formats_md(doc_main_dir)
+
+    # THEN
+    assert os_path_exists(idea_brick_formats_path)
+    idea_brick_formats_md = open_file(idea_brick_formats_path)
+    assert idea_brick_formats_md.find("br00004") > 0

--- a/src/a98_docs_builder/test/test_z_rebuild_docs.py
+++ b/src/a98_docs_builder/test/test_z_rebuild_docs.py
@@ -1,4 +1,10 @@
-from src.a98_docs_builder.doc_builder import save_module_blurbs_md, save_str_funcs_md
+from src.a98_docs_builder.doc_builder import (
+    save_brick_formats_md,
+    save_idea_brick_mds,
+    save_module_blurbs_md,
+    save_ropepointer_explanation_md,
+    save_str_funcs_md,
+)
 
 
 def test_SpecialTestThatBuildsDocs():
@@ -6,8 +12,8 @@ def test_SpecialTestThatBuildsDocs():
     destination_dir = "docs"
     # This is a special test in that instead of asserting anything it just writes
     # documentation to production when Pytest is run
-    # docs\a17_idea_brick_formats\ (#TODO build from test_idea_brick_formats_MarkdownFileExists)
-    # docs\idea_brick_formats.md (#TODO build from test_idea_brick_formats_MarkdownFileExists)
+    save_idea_brick_mds(destination_dir)
+    save_brick_formats_md(destination_dir)
     save_module_blurbs_md(destination_dir)
-    # docs\ropeterm_explanation.md (Probably leave as is)
+    save_ropepointer_explanation_md(destination_dir)
     save_str_funcs_md(destination_dir)  # docs\str_funcs.md


### PR DESCRIPTION
## Summary by Sourcery

Provide automated generation and saving of idea brick documentation and manifests alongside existing module blurbs and ropepointer explanations, and update tests to validate the new documentation builder functionality

New Features:
- Generate per-idea Markdown definitions and a consolidated manifest from idea format JSON files via get_idea_brick_md, get_idea_brick_mds, and get_brick_formats_md
- Expose new save_* functions in the documentation builder to write ropepointer explanations, idea brick files, and the idea manifest to the docs directory

Enhancements:
- Refactor existing tests to use the new API instead of manual file and directory handling
- Integrate ropepointer explanation generation into the docs build

Tests:
- Add unit tests for get_idea_brick_md, get_idea_brick_mds, and get_brick_formats_md functions
- Add integration tests for save_idea_brick_mds, save_brick_formats_md, save_ropepointer_explanation_md, and save_module_blurbs_md in isolated environments