### PR TITLE
closes #976 fixed incorrect drop if exists

### DIFF
--- a/src/ch19_kpi_toolbox/kpi_mstr.py
+++ b/src/ch19_kpi_toolbox/kpi_mstr.py
@@ -22,7 +22,7 @@ def create_populate_kpi001_table(cursor: sqlite3_Cursor):
 
 
 def create_populate_kpi002_table(cursor: sqlite3_Cursor):
-    cursor.execute("DROP TABLE IF EXISTS moment_kpi001_voice_nets")
+    cursor.execute("DROP TABLE IF EXISTS moment_kpi002_belief_pledges")
     cursor.execute(get_create_kpi002_sqlstr())
 
 

--- a/src/ch19_kpi_toolbox/test/test_z_bundles.py
+++ b/src/ch19_kpi_toolbox/test/test_z_bundles.py
@@ -25,83 +25,82 @@ from src.ch19_kpi_toolbox._ref.ch19_keywords import (
 )
 from src.ch19_kpi_toolbox.kpi_mstr import populate_kpi_bundle
 
-# #TODO figure out why this test sometimes randomly fails. Is the sqlite db not catching the table creation?
-# def test_populate_kpi_bundle_PopulatesTable_Scenario0_WithDefaultBundleID():
-#     # ESTABLISH
-#     a23_str = "amy23"
-#     yao_str = "Yao"
-#     bob_str = "Bob"
-#     yao_voice_net = -55
-#     bob_voice_net = 600
 
-#     with sqlite3_connect(":memory:") as db_conn:
-#         cursor = db_conn.cursor()
-#         cursor.execute(CREATE_JOB_BLRPLAN_SQLSTR)
-#         cursor.execute(CREATE_MOMENT_VOICE_NETS_SQLSTR)
-#         moment_voice_nets_tablename = moment_voice_nets_str()
-#         insert_sqlstr = f"""INSERT INTO {moment_voice_nets_tablename} ({moment_label_str()}, {belief_name_str()}, {belief_net_amount_str()})
-# VALUES
-#   ('{a23_str}', '{bob_str}', {bob_voice_net})
-# , ('{a23_str}', '{yao_str}', {yao_voice_net})
-# """
-#         cursor.execute(insert_sqlstr)
-#         assert get_row_count(cursor, moment_voice_nets_tablename) == 2
-#         moment_kpi001_tablename = moment_kpi001_voice_nets_str()
-#         moment_kpi002_tablename = moment_kpi002_belief_pledges_str()
-#         assert not db_table_exists(cursor, moment_kpi001_tablename)
-#         assert not db_table_exists(cursor, moment_kpi002_tablename)
+def test_populate_kpi_bundle_PopulatesTable_Scenario0_WithDefaultBundleID():
+    # ESTABLISH
+    a23_str = "amy23"
+    yao_str = "Yao"
+    bob_str = "Bob"
+    yao_voice_net = -55
+    bob_voice_net = 600
 
-#         # WHEN
-#         populate_kpi_bundle(cursor, default_kpi_bundle_str())
+    with sqlite3_connect(":memory:") as db_conn:
+        cursor = db_conn.cursor()
+        cursor.execute(CREATE_JOB_BLRPLAN_SQLSTR)
+        cursor.execute(CREATE_MOMENT_VOICE_NETS_SQLSTR)
+        moment_voice_nets_tablename = moment_voice_nets_str()
+        blrplan_job_tablename = create_prime_tablename("BLRPLAN", "job", None)
+        insert_sqlstr = f"""INSERT INTO {moment_voice_nets_tablename} ({moment_label_str()}, {belief_name_str()}, {belief_net_amount_str()})
+VALUES
+  ('{a23_str}', '{bob_str}', {bob_voice_net})
+, ('{a23_str}', '{yao_str}', {yao_voice_net})
+"""
+        cursor.execute(insert_sqlstr)
+        assert db_table_exists(cursor, blrplan_job_tablename)
+        assert get_row_count(cursor, moment_voice_nets_tablename) == 2
+        moment_kpi001_tablename = moment_kpi001_voice_nets_str()
+        moment_kpi002_tablename = moment_kpi002_belief_pledges_str()
+        assert not db_table_exists(cursor, moment_kpi001_tablename)
+        assert not db_table_exists(cursor, moment_kpi002_tablename)
 
-#         # THEN
-#         assert db_table_exists(cursor, moment_kpi001_tablename)
-#         assert db_table_exists(cursor, moment_kpi002_tablename)
-#         assert get_row_count(cursor, moment_kpi001_tablename) == 2
-#         assert get_row_count(cursor, moment_kpi002_tablename) == 0
-#         blrplan_job_tablename = create_prime_tablename("BLRPLAN", "job", None)
-#         assert set(get_db_tables(db_conn).keys()) == {
-#             moment_kpi001_voice_nets_str(),
-#             moment_kpi002_belief_pledges_str(),
-#             moment_voice_nets_tablename,
-#             blrplan_job_tablename,
-#         }
+        # WHEN
+        populate_kpi_bundle(cursor, default_kpi_bundle_str())
+
+        # THEN
+        assert db_table_exists(cursor, moment_kpi001_tablename)
+        assert db_table_exists(cursor, moment_kpi002_tablename)
+        assert get_row_count(cursor, moment_kpi001_tablename) == 2
+        assert get_row_count(cursor, moment_kpi002_tablename) == 0
+        assert set(get_db_tables(db_conn).keys()) == {
+            moment_kpi001_voice_nets_str(),
+            moment_kpi002_belief_pledges_str(),
+            moment_voice_nets_tablename,
+            blrplan_job_tablename,
+        }
 
 
-# #TODO figure out why this test sometimes randomly fails. Is the sqlite db not catching the table creation?
-# only started happening when second kpi table was added.
-# def test_populate_kpi_bundle_PopulatesTable_Scenario1_WithNoBundleID():
-#     # ESTABLISH
-#     a23_str = "amy23"
-#     yao_str = "Yao"
-#     bob_str = "Bob"
-#     yao_voice_net = -55
-#     bob_voice_net = 600
+def test_populate_kpi_bundle_PopulatesTable_Scenario1_WithNoBundleID():
+    # ESTABLISH
+    a23_str = "amy23"
+    yao_str = "Yao"
+    bob_str = "Bob"
+    yao_voice_net = -55
+    bob_voice_net = 600
 
-#     with sqlite3_connect(":memory:") as db_conn:
-#         cursor = db_conn.cursor()
-#         cursor.execute(CREATE_JOB_BLRPLAN_SQLSTR)
-#         cursor.execute(CREATE_MOMENT_VOICE_NETS_SQLSTR)
-#         moment_voice_nets_tablename = moment_voice_nets_str()
-#         insert_sqlstr = f"""INSERT INTO {moment_voice_nets_tablename} ({moment_label_str()}, {belief_name_str()}, {belief_net_amount_str()})
-# VALUES
-#   ('{a23_str}', '{bob_str}', {bob_voice_net})
-# , ('{a23_str}', '{yao_str}', {yao_voice_net})
-# """
-#         cursor.execute(insert_sqlstr)
-#         assert get_row_count(cursor, moment_voice_nets_tablename) == 2
-#         moment_kpi001_voice_nets_tablename = moment_kpi001_voice_nets_str()
-#         assert not db_table_exists(cursor, moment_kpi001_voice_nets_tablename)
+    with sqlite3_connect(":memory:") as db_conn:
+        cursor = db_conn.cursor()
+        cursor.execute(CREATE_JOB_BLRPLAN_SQLSTR)
+        cursor.execute(CREATE_MOMENT_VOICE_NETS_SQLSTR)
+        moment_voice_nets_tablename = moment_voice_nets_str()
+        insert_sqlstr = f"""INSERT INTO {moment_voice_nets_tablename} ({moment_label_str()}, {belief_name_str()}, {belief_net_amount_str()})
+VALUES
+  ('{a23_str}', '{bob_str}', {bob_voice_net})
+, ('{a23_str}', '{yao_str}', {yao_voice_net})
+"""
+        cursor.execute(insert_sqlstr)
+        assert get_row_count(cursor, moment_voice_nets_tablename) == 2
+        moment_kpi001_voice_nets_tablename = moment_kpi001_voice_nets_str()
+        assert not db_table_exists(cursor, moment_kpi001_voice_nets_tablename)
 
-#         # WHEN
-#         populate_kpi_bundle(cursor)
+        # WHEN
+        populate_kpi_bundle(cursor)
 
-#         # THEN
-#         assert get_row_count(cursor, moment_kpi001_voice_nets_tablename) == 2
-#         blrplan_job_tablename = create_prime_tablename("BLRPLAN", "job", None)
-#         assert set(get_db_tables(db_conn).keys()) == {
-#             moment_kpi001_voice_nets_str(),
-#             moment_kpi002_belief_pledges_str(),
-#             moment_voice_nets_tablename,
-#             blrplan_job_tablename,
-#         }
+        # THEN
+        assert get_row_count(cursor, moment_kpi001_voice_nets_tablename) == 2
+        blrplan_job_tablename = create_prime_tablename("BLRPLAN", "job", None)
+        assert set(get_db_tables(db_conn).keys()) == {
+            moment_kpi001_voice_nets_str(),
+            moment_kpi002_belief_pledges_str(),
+            moment_voice_nets_tablename,
+            blrplan_job_tablename,
+        }

--- a/src/ch98_docs_builder/test/test_z_rebuild_docs.py
+++ b/src/ch98_docs_builder/test/test_z_rebuild_docs.py
@@ -30,12 +30,12 @@ def test_SpecialTestThatBuildsDocs():
     save_ropeterm_explanation_md(destination_dir)
     save_str_funcs_md(destination_dir)  # docs\str_funcs.md
 
-    # resave json files so that they are ordered alphabetically
-    for chapter_dir in get_chapter_descs().values():
-        json_file_tuples = get_dir_filenames(chapter_dir, {"json"})
-        for x_dir, x_filename in json_file_tuples:
-            json_filepath = create_path(x_dir, x_filename)
-            print(f"{json_filepath=}")
-            print(f"{x_dir} {x_filename=}")
-            json_dir = create_path(chapter_dir, x_dir)
-            save_json(json_dir, x_filename, open_json(json_dir, x_filename))
+    # # resave json files so that they are ordered alphabetically
+    # for chapter_dir in get_chapter_descs().values():
+    #     json_file_tuples = get_dir_filenames(chapter_dir, {"json"})
+    #     for x_dir, x_filename in json_file_tuples:
+    #         json_filepath = create_path(x_dir, x_filename)
+    #         print(f"{json_filepath=}")
+    #         print(f"{x_dir} {x_filename=}")
+    #         json_dir = create_path(chapter_dir, x_dir)
+    #         save_json(json_dir, x_filename, open_json(json_dir, x_filename))


### PR DESCRIPTION
## Summary by Sourcery

Re-enable KPI bundle population tests, fix the DROP TABLE statement for KPI002, and clean up redundant JSON resaving in docs builder test.

Bug Fixes:
- Correct the table name in the DROP TABLE IF EXISTS statement in create_populate_kpi002_table from moment_kpi001_voice_nets to moment_kpi002_belief_pledges

Tests:
- Uncomment and refine tests for populate_kpi_bundle scenarios with and without a default bundle ID, adding assertions for the BLRPLAN job table
- Comment out redundant JSON resaving logic in test_z_rebuild_docs