### PR TITLE
closes #982, closes #980

### DIFF
--- a/docs/ropeterm_explanation.md
+++ b/docs/ropeterm_explanation.md
@@ -40,7 +40,7 @@ vacuum_rope = ";amy;casa;clean;vacuum;"
 dirty_rope = ";amy;casa;appearance;dirty;"
 usa_texas_rope = ";UN;USA;Texas;"
 un_texas_rope = ";UN;Texas;"
-- **CentralLabel**: The first label in a RopeTerm. Example "UN" in ";UN;USA;Texas;"
+- **NexusLabel**: The first label in a RopeTerm. Example "UN" in ";UN;USA;Texas;"
 
 # Moments
 Consider these 3 ropes: 
@@ -48,9 +48,9 @@ Consider these 3 ropes:
 2. ;USA;Texas;
 3. ;USA;The South;Texas;
 
-Each rope arrives at the concept of Texas in a different way and connotes something different. Now consider these UN central :
+Each rope arrives at the concept of Texas in a different way and connotes something different. Now consider these UN nexus :
 
-"UN" has the central moment
+"UN" has the nexus moment
 1. ;UN;France;Paris;
 2. ;UN;Germany;Berlin;
 3. ;UN;USA;Texas;Dallas;
@@ -58,7 +58,7 @@ Each rope arrives at the concept of Texas in a different way and connotes someth
 
 vs 
 
-"USA" has the central moment
+"USA" has the nexus moment
 1. ;USA;UN;France;Paris;
 2. ;USA;UN;Germany;Berlin;
 3. ;USA;Texas;Dallas;

--- a/docs/str_funcs.md
+++ b/docs/str_funcs.md
@@ -3,7 +3,7 @@
 ## Str Functions by Chapter
 - ch00_purpose: 
 - ch01_data_toolbox: INSERT, UPDATE, sqlite_datatype
-- ch02_rope_logic: CentralLabel, KnotTerm, LabelTerm, MomentLabel, NameTerm, RopeTerm, TitleTerm, knot, parent_rope
+- ch02_rope_logic: KnotTerm, LabelTerm, MomentLabel, NameTerm, NexusLabel, RopeTerm, TitleTerm, knot, parent_rope
 - ch03_finance_logic: BitNum, FundIota, FundNum, GrainFloat, MoneyUnit, PennyNum, RespectNum, fund_iota, fund_pool, magnitude, penny
 - ch04_group_logic: GroupTitle, HealerName, VoiceName, awardee_title, awardunits, belief_name, credor_pool, debtor_pool, fund_agenda_give, fund_agenda_ratio_give, fund_agenda_ratio_take, fund_agenda_take, fund_give, fund_take, give_force, group_cred_points, group_debt_points, group_title, groupunits, inallocable_voice_debt_points, irrational_voice_debt_points, laborheir, laborunit, memberships, parent_solo, party_title, rational, respect_bit, solo, take_force, voice_cred_points, voice_debt_points, voice_name
 - ch05_reason_logic: active, cases, fact_context, fact_lower, fact_state, fact_upper, factheirs, factunits, reason_active_requisite, reason_context, reason_divisor, reason_lower, reason_state, reason_upper, reasonunits, status, task

--- a/src/ch02_rope_logic/_ref/ch02_keywords.py
+++ b/src/ch02_rope_logic/_ref/ch02_keywords.py
@@ -1,10 +1,6 @@
 from src.ch01_data_toolbox._ref.ch01_keywords import *
 
 
-def NexusLabel_str() -> str:
-    return "NexusLabel"
-
-
 def KnotTerm_str() -> str:
     return "KnotTerm"
 
@@ -19,6 +15,10 @@ def MomentLabel_str() -> str:
 
 def NameTerm_str() -> str:
     return "NameTerm"
+
+
+def NexusLabel_str() -> str:
+    return "NexusLabel"
 
 
 def RopeTerm_str() -> str:


### PR DESCRIPTION
## Summary by Sourcery

Rename CentralLabel to NexusLabel throughout documentation and code.

Enhancements:
- Replace CentralLabel references with NexusLabel in rope term documentation and examples
- Update the string functions index to remove CentralLabel and add NexusLabel
- Relocate and ensure the NexusLabel_str keyword function is defined and returns "NexusLabel"