### PR TITLE
1079 build relative timezone tools2

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ The internal data model is built around the following object hierarchy:
 ### Development
 
 keg was built using Test-Driven Development. Every feature has a corresponding test. This is mostly a one-man project — Femi has significantly helped.
+# TODO remove this once it's fixed.
 pip deployment has been a challenge. Hopefully __init__.py file creation gets rid of failed file reference errors. 
 ---
 

--- a/src/ch00_py/test/dict/test__file_.py
+++ b/src/ch00_py/test/dict/test__file_.py
@@ -51,7 +51,7 @@ def test_create_path_UsesFallback_WhenSrcPathDoesNotExist():
     with mock_patch("ch00_py.file_toolbox.os_path_exists", return_value=False):
 
         # WHEN create_path is called with a src/ path
-        result = create_path("src", "sh17_fizz")
+        result = create_path("src", os_path_join("sh17_fizz"))
 
     # THEN it returns a path relative to the caller's module, not src/
     src_sh17_fizz_path = os_path_join("src", "sh17_fizz")
@@ -75,7 +75,7 @@ def test_create_path_FallbackPathExists_WhenSrcUnavailable():
     with mock_patch("ch00_py.file_toolbox.os_path_exists", return_value=False):
 
         # WHEN create_path is called with this test file's own name
-        result = create_path("src", this_filename)
+        result = create_path("src", os_path_join(this_filename))
 
     # THEN the fallback path must point to an existing file
     assert pathlib_Path(result).exists(), (

--- a/src/ch07_person_logic/person_config.py
+++ b/src/ch07_person_logic/person_config.py
@@ -1,4 +1,5 @@
 from ch00_py.file_toolbox import create_path, open_json
+from os.path import join as os_path_join
 
 
 def max_tree_traverse_default() -> int:
@@ -8,7 +9,7 @@ def max_tree_traverse_default() -> int:
 def person_config_path() -> str:
     """src/ch07_person_logic/person_config.json"""
     chapter_dir = create_path("src", "ch07_person_logic")
-    return create_path(chapter_dir, "person_config.json")
+    return create_path(chapter_dir, os_path_join("person_config.json"))
 
 
 def get_person_config_dict() -> dict[str, dict]:

--- a/src/ch07_person_logic/test/test_person/test__person_config.py
+++ b/src/ch07_person_logic/test/test_person/test__person_config.py
@@ -12,7 +12,7 @@ from ch07_person_logic.person_config import (
 )
 from ch07_person_logic.person_main import ContactUnit, PersonUnit
 from ch99_glossary.ch_keyword import Ch07Keywords as kw
-from os.path import exists as os_path_exists
+from os.path import exists as os_path_exists, join as os_path_join
 
 
 def test_max_tree_traverse_default_ReturnsObj() -> str:
@@ -22,7 +22,7 @@ def test_max_tree_traverse_default_ReturnsObj() -> str:
 
 def test_get_person_config_dict_Exists():
     # ESTABLISH
-    expected_dir = create_path("src", "ch07_person_logic")
+    expected_dir = create_path("src", os_path_join("ch07_person_logic"))
 
     # WHEN
     config_path = person_config_path()

--- a/src/ch08_person_atom/atom_config.py
+++ b/src/ch08_person_atom/atom_config.py
@@ -1,12 +1,12 @@
 from ch00_py.dict_toolbox import get_from_nested_dict
 from ch00_py.file_toolbox import create_path, open_json, save_json
 from ch08_person_atom._ref.ch08_semantic_types import CRUD_command
+from os.path import join as os_path_join
 
 
 def atom_config_path() -> str:
     "Returns Path: ch08_person_atom/atom_config.json"
-    chapter_dir = create_path("src", "ch08_person_atom")
-    return create_path(chapter_dir, "atom_config.json")
+    return create_path("src", os_path_join("ch08_person_atom", "atom_config.json"))
 
 
 def get_atom_config_dict() -> dict:

--- a/src/ch13_time/epoch_main.py
+++ b/src/ch13_time/epoch_main.py
@@ -16,7 +16,8 @@ from ch13_time._ref.ch13_semantic_types import (
     TimeNum,
 )
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime
+from os.path import join as os_path_join
 from re import search as re_search
 from typing import Tuple
 
@@ -169,9 +170,9 @@ def get_epoch_length(epoch_config: dict) -> int:
 
 def epoch_config_path() -> str:
     "Returns path: src/ch13_time/epoch_configs/default_epoch_config.json"
-    chapter_dir = create_path("src", "ch13_time")
-    epoch_configs_dir = create_path(chapter_dir, "epoch_configs")
-    return create_path(epoch_configs_dir, "default_epoch_config.json")
+    return create_path(
+        "src", os_path_join("ch13_time", "epoch_configs", "default_epoch_config.json")
+    )
 
 
 def get_default_epoch_config_dict() -> dict:

--- a/src/ch14_moment/moment_config.py
+++ b/src/ch14_moment/moment_config.py
@@ -1,11 +1,11 @@
 from ch00_py.dict_toolbox import get_from_nested_dict
 from ch00_py.file_toolbox import create_path, open_json
+from os.path import join as os_path_join
 
 
 def moment_config_path() -> str:
     "Returns Path: a15_moment_logic/moment_config.json"
-    chapter_dir = create_path("src", "ch14_moment")
-    return create_path(chapter_dir, "moment_config.json")
+    return create_path("src", os_path_join("ch14_moment", "moment_config.json"))
 
 
 def get_moment_config_dict() -> dict:

--- a/src/ch15_nabu/nabu_config.py
+++ b/src/ch15_nabu/nabu_config.py
@@ -1,11 +1,10 @@
-from ch00_py.dict_toolbox import get_from_nested_dict
 from ch00_py.file_toolbox import create_path, open_json
+from os.path import join as os_path_join
 
 
 def nabu_config_path():
     "Returns path: c15_nabu/nabu_config.json"
-    chapter_dir = create_path("src", "ch15_nabu")
-    return create_path(chapter_dir, "nabu_config.json")
+    return create_path("src", os_path_join("ch15_nabu", "nabu_config.json"))
 
 
 def get_nabu_config_dict():

--- a/src/ch15_nabu/test/test_nabu_config.py
+++ b/src/ch15_nabu/test/test_nabu_config.py
@@ -10,11 +10,12 @@ from ch15_nabu.nabu_config import (
     set_nabuable_otx_inx_args,
 )
 from ch99_glossary.ch_keyword import Ch15Keywords as kw
+from os.path import join as os_path_join
 
 
 def test_nabu_config_path_ReturnsObj_Nabu() -> str:
     # ESTABLISH / WHEN / THEN
-    chapter_dir = create_path("src", "ch15_nabu")
+    chapter_dir = create_path("src", os_path_join("ch15_nabu"))
     assert nabu_config_path() == create_path(chapter_dir, "nabu_config.json")
 
 

--- a/src/ch16_translate/test/test__translate_config/test_translate_config_.py
+++ b/src/ch16_translate/test/test__translate_config/test_translate_config_.py
@@ -10,6 +10,7 @@ from ch16_translate.translate_config import (
     translate_config_path,
 )
 from ch99_glossary.ch_keyword import Ch16Keywords as kw
+from os.path import join as os_path_join
 
 
 def test_get_translate_filename_ReturnsObj():
@@ -19,7 +20,7 @@ def test_get_translate_filename_ReturnsObj():
 
 def test_translate_config_path_ReturnsObj_Translate() -> str:
     # ESTABLISH / WHEN / THEN
-    chapter_dir = create_path("src", "ch16_translate")
+    chapter_dir = create_path("src", os_path_join("ch16_translate"))
     assert translate_config_path() == create_path(chapter_dir, "translate_config.json")
 
 

--- a/src/ch16_translate/translate_config.py
+++ b/src/ch16_translate/translate_config.py
@@ -1,12 +1,12 @@
 from ch00_py.dict_toolbox import get_from_nested_dict
 from ch00_py.file_toolbox import create_path, open_json
 from ch08_person_atom.atom_config import get_all_person_dimen_delete_keys
+from os.path import join as os_path_join
 
 
 def translate_config_path() -> str:
     "Returns path: c16_translate/translate_config.json"
-    chapter_dir = create_path("src", "ch16_translate")
-    return create_path(chapter_dir, "translate_config.json")
+    return create_path("src", os_path_join("ch16_translate", "translate_config.json"))
 
 
 def get_translate_filename() -> str:

--- a/src/ch17_brick/brick_config.py
+++ b/src/ch17_brick/brick_config.py
@@ -8,7 +8,7 @@ from pathlib import Path as pathlib_Path
 
 def brick_config_path() -> str:
     """Returns src\\ch17_brick\\brick_config.json"""
-    return create_path(create_path("src", "ch17_brick"), "brick_config.json")
+    return create_path("src", os_path_join("ch17_brick", "brick_config.json"))
 
 
 def get_brick_config_dict(brick_categorys: set[str] = None) -> dict:

--- a/src/ch18_etl_config/etl_config.py
+++ b/src/ch18_etl_config/etl_config.py
@@ -10,6 +10,7 @@ from ch17_brick.brick_config import (
     get_default_sorted_list,
 )
 from copy import copy as copy_copy
+from os.path import join as os_path_join
 
 ALL_DIMEN_ABBV7 = {
     "MMTPAYY",
@@ -172,8 +173,9 @@ def create_prime_tablename(
 
 def etl_stage_types_config_path() -> str:
     "Returns path: ch18_etl_config/etl_stage_types_config.json"
-    chapter_dir = create_path("src", "ch18_etl_config")
-    return create_path(chapter_dir, "etl_stage_types_config.json")
+    return create_path(
+        "src", os_path_join("ch18_etl_config", "etl_stage_types_config.json")
+    )
 
 
 def get_etl_stage_types_config_dict() -> dict:
@@ -192,8 +194,9 @@ def get_ordered_stage_types() -> list[str]:
 
 def etl_brick_category_config_path() -> str:
     "Returns path: ch18_etl_config/etl_brick_category_config.json"
-    chapter_dir = create_path("src", "ch18_etl_config")
-    return create_path(chapter_dir, "etl_brick_category_config.json")
+    return create_path(
+        "src", os_path_join("ch18_etl_config", "etl_brick_category_config.json")
+    )
 
 
 def etl_brick_category_config_dict() -> dict:

--- a/src/ch18_etl_config/test/etl_sqlstrs/test__etl_table.py
+++ b/src/ch18_etl_config/test/etl_sqlstrs/test__etl_table.py
@@ -23,6 +23,7 @@ from ch18_etl_config.etl_config import (
     remove_staging_columns,
 )
 from ch99_glossary.ch_keyword import Ch18Keywords as kw
+from os.path import join as os_path_join
 
 
 def test_remove_otx_columns_ReturnsObj():
@@ -203,11 +204,11 @@ def test_get_all_dimen_columns_set_ReturnsObj_Scenario1_translate_core_Dimens():
 
 def test_etl_stage_types_config_path_ReturnsObj():
     # ESTABLISH
-    chapter_dir = create_path("src", "ch18_etl_config")
-    # WHEN / THEN
-    assert etl_stage_types_config_path() == create_path(
-        chapter_dir, "etl_stage_types_config.json"
+    expected_path = create_path(
+        "src", os_path_join("ch18_etl_config", "etl_stage_types_config.json")
     )
+    # WHEN / THEN
+    assert etl_stage_types_config_path() == expected_path
 
 
 def test_get_etl_stage_types_config_dict_ReturnsObj_Scenario0_IsFullyPopulated():
@@ -296,10 +297,10 @@ def test_get_ordered_stage_types_ReturnsObj():
 
 def test_etl_brick_category_config_path_ReturnsObj():
     # ESTABLISH / WHEN / THEN
-    chapter_dir = create_path("src", "ch18_etl_config")
-    assert etl_brick_category_config_path() == create_path(
-        chapter_dir, "etl_brick_category_config.json"
+    expected_path = create_path(
+        "src", os_path_join("ch18_etl_config", "etl_brick_category_config.json")
     )
+    assert etl_brick_category_config_path() == expected_path
 
 
 def test_get_etl_brick_category_config_dict_ReturnsObj_Scenario0_IsFullyPopulated():

--- a/src/ch19_idea_src/idea_config.py
+++ b/src/ch19_idea_src/idea_config.py
@@ -1,12 +1,13 @@
 from ch00_py.file_toolbox import create_path, open_json
+from contextlib import suppress as contextlib_suppress
 from importlib.resources import as_file, files
-from os.path import exists as os_path_exists
+from os.path import exists as os_path_exists, join as os_path_join
 from pathlib import Path
 
 
 def idea_config_path() -> str:
     "Returns path: ch19_idea_src/idea_config.json"
-    cwd_path = create_path(create_path("src", "ch19_idea_src"), "idea_config.json")
+    cwd_path = create_path("src", os_path_join("ch19_idea_src", "idea_config.json"))
     if os_path_exists(cwd_path):
         return cwd_path
 
@@ -15,14 +16,11 @@ def idea_config_path() -> str:
     if candidate_path.exists():
         return str(candidate_path)
 
-    try:
+    with contextlib_suppress(Exception):
         resource = files(__package__) / "idea_config.json"
         with as_file(resource) as resource_path:
             if resource_path.exists():
                 return str(resource_path)
-    except Exception:
-        pass
-
     raise FileNotFoundError(
         f"Missing idea_config.json from cwd, package resources, or module path: {candidate_path}"
     )

--- a/src/ch98_linter/ch_move.py
+++ b/src/ch98_linter/ch_move.py
@@ -8,7 +8,7 @@ from ch98_linter.chapter_move_tool import (
     string_exists_in_filepaths,
 )
 from os import getcwd as os_getcwd
-from os.path import isdir as os_path_isdir
+from os.path import isdir as os_path_isdir, join as os_path_join
 
 # HOW TO USE:
 # Open up CMD, change directory to repo
@@ -27,7 +27,7 @@ def ch_move_main():
     print(f"Goal is to move {src_chxx_prefix} to {dst_chxx_prefix}")
 
     # Sanity checks
-    dst_chxx_dir_prefix = create_path("src", dst_chxx_prefix)
+    dst_chxx_dir_prefix = create_path("src", os_path_join(dst_chxx_prefix))
     x_prefix_dir = ""
     for prefix_dir in first_level_dirs_with_prefix(dst_chxx_dir_prefix):
         print(f"Try to delete {prefix_dir}")

--- a/src/ch98_linter/test/apply_linter/test_chapter_dirs.py
+++ b/src/ch98_linter/test/apply_linter/test_chapter_dirs.py
@@ -37,6 +37,7 @@ def test_Chapters_test_TestsAreInCorrectDirStructure():
                 assert level1_dir == test_str
 
 
+# TODO remove brick_config.py from list
 def test_Chapters_NonTestFilesDoNotHavePrintStatments():
     # sourcery skip: no-loop-in-tests, no-conditionals-in-tests
     # ESTABLISH


### PR DESCRIPTION
## Summary by Sourcery

Standardize configuration file path construction across chapters and tighten related tests and docs annotations.

Enhancements:
- Refactor multiple config path helpers to build paths using os.path.join for chapter subdirectories and JSON filenames.
- Simplify idea_config_path resource lookup by using contextlib.suppress instead of manual try/except, keeping the error semantics unchanged.
- Align tests with the new path construction pattern to better reflect the intended directory structure and fallback behavior.
- Annotate known linter issues in README and chapter linter tests with TODO comments for future cleanup.

Tests:
- Update configuration path tests to expect paths built with joined chapter subdirectories and filenames, including fallback path behavior tests.