### PR TITLE
fix: new pip install file ref issue concerning idea_config

### DIFF
--- a/src/ch00_py/test/dict/test__file_.py
+++ b/src/ch00_py/test/dict/test__file_.py
@@ -51,7 +51,7 @@ def test_create_path_UsesFallback_WhenSrcPathDoesNotExist():
     with mock_patch("ch00_py.file_toolbox.os_path_exists", return_value=False):
 
         # WHEN create_path is called with a src/ path
-        result = create_path("src", os_path_join("sh17_fizz"))
+        result = create_path("src", "sh17_fizz")
 
     # THEN it returns a path relative to the caller's module, not src/
     src_sh17_fizz_path = os_path_join("src", "sh17_fizz")
@@ -75,7 +75,7 @@ def test_create_path_FallbackPathExists_WhenSrcUnavailable():
     with mock_patch("ch00_py.file_toolbox.os_path_exists", return_value=False):
 
         # WHEN create_path is called with this test file's own name
-        result = create_path("src", os_path_join(this_filename))
+        result = create_path("src", this_filename)
 
     # THEN the fallback path must point to an existing file
     assert pathlib_Path(result).exists(), (

--- a/src/ch07_person_logic/test/test_person/test__person_config.py
+++ b/src/ch07_person_logic/test/test_person/test__person_config.py
@@ -22,7 +22,7 @@ def test_max_tree_traverse_default_ReturnsObj() -> str:
 
 def test_get_person_config_dict_Exists():
     # ESTABLISH
-    expected_dir = create_path("src", os_path_join("ch07_person_logic"))
+    expected_dir = create_path("src", "ch07_person_logic")
 
     # WHEN
     config_path = person_config_path()

--- a/src/ch08_person_atom/atom_config.py
+++ b/src/ch08_person_atom/atom_config.py
@@ -6,7 +6,7 @@ from os.path import join as os_path_join
 
 def atom_config_path() -> str:
     "Returns Path: ch08_person_atom/atom_config.json"
-    return create_path("src", os_path_join("ch08_person_atom", "atom_config.json"))
+    return create_path("src", "ch08_person_atom", "atom_config.json")
 
 
 def get_atom_config_dict() -> dict:

--- a/src/ch13_time/epoch_main.py
+++ b/src/ch13_time/epoch_main.py
@@ -170,9 +170,7 @@ def get_epoch_length(epoch_config: dict) -> int:
 
 def epoch_config_path() -> str:
     "Returns path: src/ch13_time/epoch_configs/default_epoch_config.json"
-    return create_path(
-        "src", os_path_join("ch13_time", "epoch_configs", "default_epoch_config.json")
-    )
+    return create_path("src", "ch13_time", "epoch_configs", "default_epoch_config.json")
 
 
 def get_default_epoch_config_dict() -> dict:

--- a/src/ch14_moment/moment_config.py
+++ b/src/ch14_moment/moment_config.py
@@ -5,7 +5,7 @@ from os.path import join as os_path_join
 
 def moment_config_path() -> str:
     "Returns Path: a15_moment_logic/moment_config.json"
-    return create_path("src", os_path_join("ch14_moment", "moment_config.json"))
+    return create_path("src", "ch14_moment", "moment_config.json")
 
 
 def get_moment_config_dict() -> dict:

--- a/src/ch15_nabu/nabu_config.py
+++ b/src/ch15_nabu/nabu_config.py
@@ -4,7 +4,7 @@ from os.path import join as os_path_join
 
 def nabu_config_path():
     "Returns path: c15_nabu/nabu_config.json"
-    return create_path("src", os_path_join("ch15_nabu", "nabu_config.json"))
+    return create_path("src", "ch15_nabu", "nabu_config.json")
 
 
 def get_nabu_config_dict():

--- a/src/ch15_nabu/test/test_nabu_config.py
+++ b/src/ch15_nabu/test/test_nabu_config.py
@@ -15,7 +15,7 @@ from os.path import join as os_path_join
 
 def test_nabu_config_path_ReturnsObj_Nabu() -> str:
     # ESTABLISH / WHEN / THEN
-    chapter_dir = create_path("src", os_path_join("ch15_nabu"))
+    chapter_dir = create_path("src", "ch15_nabu")
     assert nabu_config_path() == create_path(chapter_dir, "nabu_config.json")
 
 

--- a/src/ch16_translate/test/test__translate_config/test_translate_config_.py
+++ b/src/ch16_translate/test/test__translate_config/test_translate_config_.py
@@ -20,7 +20,7 @@ def test_get_translate_filename_ReturnsObj():
 
 def test_translate_config_path_ReturnsObj_Translate() -> str:
     # ESTABLISH / WHEN / THEN
-    chapter_dir = create_path("src", os_path_join("ch16_translate"))
+    chapter_dir = create_path("src", "ch16_translate")
     assert translate_config_path() == create_path(chapter_dir, "translate_config.json")
 
 

--- a/src/ch16_translate/translate_config.py
+++ b/src/ch16_translate/translate_config.py
@@ -6,7 +6,7 @@ from os.path import join as os_path_join
 
 def translate_config_path() -> str:
     "Returns path: c16_translate/translate_config.json"
-    return create_path("src", os_path_join("ch16_translate", "translate_config.json"))
+    return create_path("src", "ch16_translate", "translate_config.json")
 
 
 def get_translate_filename() -> str:

--- a/src/ch17_brick/brick_config.py
+++ b/src/ch17_brick/brick_config.py
@@ -8,7 +8,7 @@ from pathlib import Path as pathlib_Path
 
 def brick_config_path() -> str:
     """Returns src\\ch17_brick\\brick_config.json"""
-    return create_path("src", os_path_join("ch17_brick", "brick_config.json"))
+    return create_path("src", "ch17_brick", "brick_config.json")
 
 
 def get_brick_config_dict(brick_categorys: set[str] = None) -> dict:
@@ -40,7 +40,7 @@ def get_allowed_curds() -> set[str]:
 
 def get_brick_formats_dir() -> str:
     """src/ch17_brick/brick_formats"""
-    result = create_path("src", os_path_join("ch17_brick", "brick_formats"))
+    result = create_path("src", "ch17_brick", "brick_formats")
     print(f"\nbrick_formats_dir: {result}")
     print(f"brick_formats_dir exists: {os_path_exists(result)}")
     return result

--- a/src/ch18_etl_config/etl_config.py
+++ b/src/ch18_etl_config/etl_config.py
@@ -173,9 +173,7 @@ def create_prime_tablename(
 
 def etl_stage_types_config_path() -> str:
     "Returns path: ch18_etl_config/etl_stage_types_config.json"
-    return create_path(
-        "src", os_path_join("ch18_etl_config", "etl_stage_types_config.json")
-    )
+    return create_path("src", "ch18_etl_config", "etl_stage_types_config.json")
 
 
 def get_etl_stage_types_config_dict() -> dict:
@@ -194,9 +192,7 @@ def get_ordered_stage_types() -> list[str]:
 
 def etl_brick_category_config_path() -> str:
     "Returns path: ch18_etl_config/etl_brick_category_config.json"
-    return create_path(
-        "src", os_path_join("ch18_etl_config", "etl_brick_category_config.json")
-    )
+    return create_path("src", "ch18_etl_config", "etl_brick_category_config.json")
 
 
 def etl_brick_category_config_dict() -> dict:

--- a/src/ch18_etl_config/test/etl_sqlstrs/test__etl_table.py
+++ b/src/ch18_etl_config/test/etl_sqlstrs/test__etl_table.py
@@ -204,9 +204,7 @@ def test_get_all_dimen_columns_set_ReturnsObj_Scenario1_translate_core_Dimens():
 
 def test_etl_stage_types_config_path_ReturnsObj():
     # ESTABLISH
-    expected_path = create_path(
-        "src", os_path_join("ch18_etl_config", "etl_stage_types_config.json")
-    )
+    expected_path = create_path("src", "ch18_etl_config", "etl_stage_types_config.json")
     # WHEN / THEN
     assert etl_stage_types_config_path() == expected_path
 
@@ -298,7 +296,7 @@ def test_get_ordered_stage_types_ReturnsObj():
 def test_etl_brick_category_config_path_ReturnsObj():
     # ESTABLISH / WHEN / THEN
     expected_path = create_path(
-        "src", os_path_join("ch18_etl_config", "etl_brick_category_config.json")
+        "src", "ch18_etl_config", "etl_brick_category_config.json"
     )
     assert etl_brick_category_config_path() == expected_path
 

--- a/src/ch19_idea_src/idea_config.py
+++ b/src/ch19_idea_src/idea_config.py
@@ -1,29 +1,9 @@
 from ch00_py.file_toolbox import create_path, open_json
-from contextlib import suppress as contextlib_suppress
-from importlib.resources import as_file, files
-from os.path import exists as os_path_exists, join as os_path_join
-from pathlib import Path
 
 
 def idea_config_path() -> str:
     "Returns path: ch19_idea_src/idea_config.json"
-    cwd_path = create_path("src", os_path_join("ch19_idea_src", "idea_config.json"))
-    if os_path_exists(cwd_path):
-        return cwd_path
-
-    module_dir = Path(__file__).resolve().parent
-    candidate_path = module_dir / "idea_config.json"
-    if candidate_path.exists():
-        return str(candidate_path)
-
-    with contextlib_suppress(Exception):
-        resource = files(__package__) / "idea_config.json"
-        with as_file(resource) as resource_path:
-            if resource_path.exists():
-                return str(resource_path)
-    raise FileNotFoundError(
-        f"Missing idea_config.json from cwd, package resources, or module path: {candidate_path}"
-    )
+    return create_path("src", "ch19_idea_src", "idea_config.json")
 
 
 def get_idea_config_dict() -> dict:

--- a/src/ch98_linter/ch_move.py
+++ b/src/ch98_linter/ch_move.py
@@ -27,7 +27,7 @@ def ch_move_main():
     print(f"Goal is to move {src_chxx_prefix} to {dst_chxx_prefix}")
 
     # Sanity checks
-    dst_chxx_dir_prefix = create_path("src", os_path_join(dst_chxx_prefix))
+    dst_chxx_dir_prefix = create_path("src", dst_chxx_prefix)
     x_prefix_dir = ""
     for prefix_dir in first_level_dirs_with_prefix(dst_chxx_dir_prefix):
         print(f"Try to delete {prefix_dir}")


### PR DESCRIPTION
## Summary by Sourcery

Standardize configuration file path resolution across modules to rely on create_path with explicit path segments, and simplify idea_config_path to always use the src-based path.

Bug Fixes:
- Fix idea_config_path to correctly locate idea_config.json in environments such as pip-installed packages by using a consistent src-based path.

Enhancements:
- Align various config helpers and tests to pass path components directly to create_path instead of pre-joining them with os.path.join for more consistent path handling.