### PR TITLE
fix: epoch config file path ref error #1228

### DIFF
--- a/src/ch05_reason/test/test__caseactivefinder.py
+++ b/src/ch05_reason/test/test__caseactivefinder.py
@@ -1,4 +1,5 @@
 from ch00_py.csv_toolbox import open_csv_with_types
+from ch00_py.file_toolbox import create_path
 from ch00_py.plotly_toolbox import conditional_fig_show
 from ch05_reason.reason_main import CaseActiveFinder, caseactivefinder_shop
 from ch99_glossary.ch_keyword import Ch05Keywords as kw, ExampleStrs as exx
@@ -409,7 +410,9 @@ def check_show_caseactivefinder_scenarios(graphics_bool: bool):
     pd = 1  # reason_divisor
     fig = get_fig(pd, graphics_bool)
     linel = 0
-    test_cases_csv_path = "src/ch05_reason/test/caseactivefinder_test_cases.csv"
+    test_cases_csv_path = create_path(
+        "src", "ch05_reason", "test", "caseactivefinder_test_cases.csv"
+    )
     test_cases_types = {
         "case_desc": "TEXT",
         kw.reason_lower: "REAL",

--- a/src/ch07_person_logic/test/_util/ch07_examples.py
+++ b/src/ch07_person_logic/test/_util/ch07_examples.py
@@ -1,4 +1,4 @@
-from ch00_py.file_toolbox import open_json
+from ch00_py.file_toolbox import create_path, open_json
 from ch03_workforce.workforce import workforceunit_shop
 from ch04_rope.rope import RopeTerm, create_rope
 from ch05_reason.reason_main import factunit_shop, reasonunit_shop
@@ -16,7 +16,9 @@ from enum import Enum
 
 
 def personunit_v001() -> PersonUnit:
-    person1_path = "src/ch07_person_logic/test/_util/example_person1.json"
+    person1_path = create_path(
+        "src", "ch07_person_logic", "test", "_util", "example_person1.json"
+    )
     return get_personunit_from_dict(open_json(person1_path))
 
 
@@ -48,7 +50,9 @@ def personunit_v001_with_large_agenda() -> PersonUnit:
 
 
 def personunit_v002() -> PersonUnit:
-    person2_path = "src/ch07_person_logic/test/_util/example_person2.json"
+    person2_path = create_path(
+        "src", "ch07_person_logic", "test", "_util", "example_person2.json"
+    )
     return get_personunit_from_dict(open_json(person2_path))
 
 

--- a/src/ch13_time/epoch_config.py
+++ b/src/ch13_time/epoch_config.py
@@ -1,11 +1,11 @@
-from ch00_py.file_toolbox import open_json
+from ch00_py.file_toolbox import create_path, open_json
 from ch13_time._ref.ch13_semantic_types import LabelTerm
 
 
 def get_custom_epoch_config(epoch_label: LabelTerm) -> dict:
-    x_dir = "src/ch13_time/epoch_configs/"
     x_filename = f"epoch_config_{epoch_label}.json"
-    return open_json(x_dir, x_filename)
+    file_path = create_path("src", "ch13_time", "epoch_configs", x_filename)
+    return open_json(file_path)
 
 
 def get_five_config() -> dict:

--- a/src/ch13_time/epoch_main.py
+++ b/src/ch13_time/epoch_main.py
@@ -36,7 +36,7 @@ class C400Constants:
 
 
 def get_c400_constants() -> C400Constants:
-    c400_constants_path = create_path("src/ch13_time", "c400_constants.json")
+    c400_constants_path = create_path("src", "ch13_time", "c400_constants.json")
     c400_dict = open_json(c400_constants_path)
     return C400Constants(
         day_length=c400_dict.get("day_length"),

--- a/src/ch32_world/test/test_world_examples/test_world_examples.py
+++ b/src/ch32_world/test/test_world_examples/test_world_examples.py
@@ -18,7 +18,7 @@ def test_brick_sheets_to_lego_mstr_Examples(temp3_fs, run_big_tests):
 
     if not run_big_tests:
         return
-    examples_dir = "src/ch32_world/test/test_world_examples"
+    examples_dir = create_path("src", "ch32_world", "test", "test_world_examples")
     example_names = set(get_level1_dirs(examples_dir))
     if "__pycache__" in example_names:
         example_names.remove("__pycache__")  # Remove __pycache__ if it exists

--- a/src/ch98_linter/create_notebook.py
+++ b/src/ch98_linter/create_notebook.py
@@ -1,7 +1,7 @@
 # test_file_path = "src\ch18_etl_config\test\z_heard\test_heard_agg_update_reasonnum_columns.py"
 # test_name = "test_get_update_prncase_inx_epoch_diff_sqlstr_SetsColumnValues"
 
-# dest_dir = "src/ch19_etl_steps/test/z_notebooks"
+# dest_dir = create_path"src", "ch19_etl_steps", "test", "z_notebooks"
 # dest_filename = "reasonnum_update_test.py"
 # from ch00_py.file_toolbox import create_path
 
@@ -25,7 +25,7 @@ def create_notebook_main():
     test_name = input("test_name: ").strip()
     dest_dir = input("dest_dir (default ch18): ").strip()
     if dest_dir in {None, ""}:
-        dest_dir = "src/ch19_idea_src/test/z_notebooks"
+        dest_dir = create_path("src", "ch19_idea_src", "test", "z_notebooks")
     dest_filename = input("dest_filename (default test_name): ").strip()
     if dest_filename in {None, ""}:
         dest_filename = f"{test_name[5:]}.py"

--- a/src/ch98_linter/test/apply_linter/test_chapter_dirs.py
+++ b/src/ch98_linter/test/apply_linter/test_chapter_dirs.py
@@ -146,10 +146,10 @@ def test_Chapters_ChapterReferenceDir_ref_ExistsForEveryChapter_Scenario0():
 def test_Chapters_DoNotHaveEmptyDirectories():
     # sourcery skip: no-loop-in-tests, no-conditionals-in-tests
     # ESTABLISH
-    excluded_dirs = {
-        "src/ch32_world/test/test_world_examples/worlds",
-        "src/ch19_idea_src/test/z_notebooks",
-    }
+    twe = "test_world_examples"
+    x_worlds_dir = create_path("src", "ch32_world", "test", twe, "worlds")
+    z_nootbooks_dir = create_path("src", "ch19_idea_src", "test", "z_notebooks")
+    excluded_dirs = {x_worlds_dir, z_nootbooks_dir}
 
     # WHEN / THEN
     for chapter_desc, chapter_dir in get_chapter_descs().items():


### PR DESCRIPTION
## Summary by Sourcery

Standardize file path construction across time, world, reason, and linter modules and fix incorrect epoch configuration file resolution.

Bug Fixes:
- Correct epoch configuration file loading by constructing the full path with the shared path utility instead of relying on an incorrect directory argument.

Enhancements:
- Replace hard-coded filesystem paths in tests and utilities with the shared create_path helper for more robust, portable path handling.