### PR TITLE
1079 build relative timezone tools2

### DIFF
--- a/src/ch05_rope/rope.py
+++ b/src/ch05_rope/rope.py
@@ -221,6 +221,11 @@ def validate_labelterm(
 
 def rope_is_valid_dir_path(x_rope: RopeTerm, knot: KnotTerm) -> bool:
     """Returns path built from RopeTerm if it is a valid directory path."""
+    if not x_rope:
+        return False
+
+    if x_rope[:1] != knot or not x_rope.endswith(knot):
+        return False
     x_rope_labels = get_all_rope_labels(x_rope, knot)
     slash_str = "/"
     x_rope_os_path = create_rope_from_labels(x_rope_labels, knot=slash_str)

--- a/src/ch05_rope/test/test_rope_core.py
+++ b/src/ch05_rope/test/test_rope_core.py
@@ -596,7 +596,6 @@ def test_validate_labelterm_Scenario1_RaisesErrorWhenLabelTerm():
     assert str(excinfo.value) == assertion_failure_str
 
 
-@pytest_mark.skip_on_linux
 def test_rope_is_valid_dir_path_ReturnsObj_Scenario0_simple_knot():
     # ESTABLISH
     comma_str = ","
@@ -606,7 +605,6 @@ def test_rope_is_valid_dir_path_ReturnsObj_Scenario0_simple_knot():
     assert not rope_is_valid_dir_path("run,sport?,", comma_str)
 
 
-@pytest_mark.skip_on_linux
 def test_rope_is_valid_dir_path_ReturnsObj_Scenario1_complicated_knot():
     # ESTABLISH
     colon_str = ":"

--- a/src/ch05_rope/test/test_rope_core.py
+++ b/src/ch05_rope/test/test_rope_core.py
@@ -600,9 +600,12 @@ def test_rope_is_valid_dir_path_ReturnsObj_Scenario0_simple_knot():
     # ESTABLISH
     comma_str = ","
     # WHEN / THEN
+    assert not rope_is_valid_dir_path("", knot=comma_str)
+    assert not rope_is_valid_dir_path(None, knot=comma_str)
     assert rope_is_valid_dir_path(",run,", knot=comma_str)
     assert rope_is_valid_dir_path(",run,sport,", knot=comma_str)
-    assert not rope_is_valid_dir_path("run,sport?,", comma_str)
+    assert not rope_is_valid_dir_path("run,sport,", comma_str)
+    assert not rope_is_valid_dir_path(",run,sport", comma_str)
 
 
 def test_rope_is_valid_dir_path_ReturnsObj_Scenario1_complicated_knot():

--- a/src/ch10_person_lesson/test/_util/test_ch10_path.py
+++ b/src/ch10_person_lesson/test/_util/test_ch10_path.py
@@ -140,6 +140,7 @@ def test_create_gut_path_ReturnsObj(temp3_dir):
     assert gen_a23_e3_person_path == expected_a23_bob_gut_json_path
 
 
+@pytest_mark.skip_on_linux
 def test_create_moments_dir_path_HasDocString():
     # ESTABLISH
     doc_str = create_moments_dir_path("moment_mstr_dir")
@@ -148,6 +149,7 @@ def test_create_moments_dir_path_HasDocString():
     assert inspect_getdoc(create_moments_dir_path) == doc_str
 
 
+@pytest_mark.skip_on_linux
 def test_create_moment_dir_path_HasDocString():
     # ESTABLISH
     x_moment_lasso = lassounit_shop(create_rope(kw.moment_rope))

--- a/src/ch10_person_lesson/test/_util/test_ch10_path.py
+++ b/src/ch10_person_lesson/test/_util/test_ch10_path.py
@@ -140,7 +140,6 @@ def test_create_gut_path_ReturnsObj(temp3_dir):
     assert gen_a23_e3_person_path == expected_a23_bob_gut_json_path
 
 
-@pytest_mark.skip_on_linux
 def test_create_moments_dir_path_HasDocString():
     # ESTABLISH
     doc_str = create_moments_dir_path("moment_mstr_dir")
@@ -149,7 +148,6 @@ def test_create_moments_dir_path_HasDocString():
     assert inspect_getdoc(create_moments_dir_path) == doc_str
 
 
-@pytest_mark.skip_on_linux
 def test_create_moment_dir_path_HasDocString():
     # ESTABLISH
     x_moment_lasso = lassounit_shop(create_rope(kw.moment_rope))


### PR DESCRIPTION
## Summary by Sourcery

Enforce stricter validation for rope directory path strings and expand test coverage accordingly.

Bug Fixes:
- Reject empty or None rope directory path inputs.
- Require directory path strings to start and end with the knot delimiter and add tests for additional invalid path shapes.